### PR TITLE
Explicit `return None` + optimize the case of self-sending

### DIFF
--- a/inbox/util/threading.py
+++ b/inbox/util/threading.py
@@ -10,8 +10,11 @@ MAX_MESSAGES_SCANNED = 20000
 
 
 def fetch_corresponding_thread(db_session, namespace_id, message):
-    """fetch a thread matching the corresponding message. Returns None if
-       there's no matching thread."""
+    """
+    Fetch a thread matching the corresponding message.
+
+    Returns None if there's no matching thread.
+    """
     # FIXME: for performance reasons, we make the assumption that a reply
     # to a message always has a similar subject. This is only
     # right 95% of the time.
@@ -74,5 +77,3 @@ def fetch_corresponding_thread(db_session, namespace_id, message):
                     break
                 else:
                     return match.thread
-
-    return


### PR DESCRIPTION
This started off as a PR removing an unnecessary `return` at the end of the function and then turned into something else entirely (see the commit messages for the play-by-play history).

@alecrosenbaum said:
> Personally I prefer an explicit `return None` because it's less likely that
> I'll miss it when reading through a function.

I cannot personally relate to it, but if there's anyone who benefits from `return None`, then I'm happy to oblige.

While making this change, I also noticed that one of the `return` statements within the thread-match loop only looked at the `message` param and didn't need any additional data (also, none of the `return` statements above it could've matched if the `message` didn't have a `from_addr` and a `to_addr`). Because of that, we can move that check all the way up and hence, in case of self-sent emails, we don't even need to fetch anything from the database.