### PR TITLE
Update lint requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   static-code-analysis:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     working_directory: ~/code
     steps:
       - checkout

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,10 +1,9 @@
 appdirs==1.4.4
-black==20.8b1
+attrs==20.2.0
+black==19.10b0
 click==7.1.2
 isort==5.4.2
-mypy-extensions==0.4.3
 pathspec==0.8.0
 regex==2020.9.27
 toml==0.10.1
 typed-ast==1.4.1
-typing-extensions==3.7.4.3

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,7 +1,10 @@
-black==19.10b0
+appdirs==1.4.4
+black==20.8b1
 click==7.1.2
 isort==5.4.2
+mypy-extensions==0.4.3
 pathspec==0.8.0
-regex==2020.7.14
+regex==2020.9.27
 toml==0.10.1
 typed-ast==1.4.1
+typing-extensions==3.7.4.3


### PR DESCRIPTION
Ran `pip freeze` on a fresh venv with just `black==19.10b0`.

```
appdirs==1.4.4
attrs==20.2.0
black==19.10b0
click==7.1.2
pathspec==0.8.0
regex==2020.9.27
toml==0.10.1
typed-ast==1.4.1
```


`black==20.8b1` still has some issues and has fewer dependencies in Python 3.7, therefore I also bumped the Python version of the image (even though it shouldn't make a difference here)