### PR TITLE
Bump AuthAlligator client version

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -5,7 +5,7 @@ arrow==0.5.4
 asn1crypto==0.24.0
 astroid==1.6.1
 attrs==20.2.0
-git+https://github.com/closeio/authalligator-client.git@58310ba34c639f4504dff8d9c64c0247d27100f8#egg=authalligator_client
+git+https://github.com/closeio/authalligator-client.git@fe93c9d2333d2949e44c48a2dd0a9a266734e026#egg=authalligator_client
 backports.functools-lru-cache==1.4
 backports.ssl==0.0.9
 boto==2.10.0


### PR DESCRIPTION
The latest version fixes a py2/3 compatibility error with a `super(..)` call.

cc @thomasst 