### PR TITLE
Check for "all" in foldernames before accessing it

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -226,7 +226,10 @@ class GmailFolderSyncEngine(FolderSyncEngine):
 
     def is_all_mail(self, crispin_client):
         if not hasattr(self, "_is_all_mail"):
-            self._is_all_mail = self.folder_name in crispin_client.folder_names()["all"]
+            folder_names = crispin_client.folder_names()
+            self._is_all_mail = (
+                "all" in folder_names and self.folder_name in folder_names["all"]
+            )
         return self._is_all_mail
 
     def should_idle(self, crispin_client):


### PR DESCRIPTION
In production we've seen this error come up before:
```
Traceback (most recent call last):
 File "sync-engine/inbox/util/concurrency.py", line 73, in wrapped
 return func(*args, **kwargs)
 File "sync-engine/inbox/mailsync/backends/imap/monitor.py", line 174, in sync
 self.start_new_folder_sync_engines()
 File "sync-engine/inbox/mailsync/backends/imap/monitor.py", line 128, in start_new_folder_sync_engines
 for folder_name in self.prepare_sync():
 File "sync-engine/inbox/util/concurrency.py", line 73, in wrapped
 return func(*args, **kwargs)
 File "sync-engine/inbox/mailsync/backends/imap/monitor.py", line 52, in prepare_sync
 sync_folders = crispin_client.sync_folders()
 File "sync-engine/inbox/crispin.py", line 995, in sync_folders
 to_sync.append(present_folders[folder][0])
IndexError: list index out of range
```

The index error happens on the result of a call to [`folder_names()`](https://github.com/closeio/sync-engine/blob/7c36f45078c70efb772e73acf902f36bbacbf5d2/inbox/crispin.py#L1071-L1099). `folder_names()` populates, caches, and returns a `defaultdict(list)`. Pretty much everywhere guards access with `"name" in folder_names()` and doesn't actually treat it like a `defaultdict` that could potentially have empty entries in it.

So the only way I can think that this error could happen is by doing an unguarded access of the cached `defaultdict` (i.e. `folder_names()["all"]`), which would make `"all" in folder_names()` pass but not actually add any values to it.

The only place I could find which does that is the line in the diff, which I've changed to be a guarded check instead.
