### PR TITLE
Fix catastrophic backtracking when finding event emails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get dist-upgrade -y 
 WORKDIR /src
 COPY ./ ./
 RUN pip install setuptools==44.0.0
-RUN pip install --upgrade pip
+RUN pip install pip==20.3.4
 RUN pip install -r requirements_frozen.txt -e .
 
 ENV \

--- a/inbox/util/addr.py
+++ b/inbox/util/addr.py
@@ -8,7 +8,7 @@ from flanker.mime.message.headers.parsing import normalize
 # Note that technically `'` is also allowed in the local part, but nobody
 # uses it in practice, so we'd rather extract <a href='email@example.com'>
 # from HTML.
-EMAIL_FIND_RE = re.compile(r"[\w.!#$%&*+-/=?^_`{|}~]+@[\w.-]+\w", re.UNICODE)
+EMAIL_FIND_RE = re.compile(r"[\w.!#$%&*+-/=?^_`{|}~]{1,64}@[\w.-]{1,254}\w", re.UNICODE)
 
 
 def valid_email(email_address):


### PR DESCRIPTION
When parsing long event descriptions (e.g. with a long base64 string), email detection can take a long time due to catastrophic backtracking (http://www.regular-expressions.info/catastrophic.html). We can speed this up without compromising on accuracy by limiting how much it backtracks. The email user part can be up to 64 chars and hostname part 255 chars.