### PR TITLE
Provide a possibility of running arbitrary startup hook 

### DIFF
--- a/bin/backfix-duplicate-categories.py
+++ b/bin/backfix-duplicate-categories.py
@@ -185,7 +185,7 @@ def backfix_shard(shard_id, dry_run):
 @click.option("--dry-run", is_flag=True)
 def main(shard_id, dry_run):
     hook.maybe_run_startup()
-    
+
     if shard_id is not None:
         backfix_shard(shard_id, dry_run)
     else:

--- a/bin/backfix-duplicate-categories.py
+++ b/bin/backfix-duplicate-categories.py
@@ -14,6 +14,7 @@ from sqlalchemy.sql import and_, exists
 from inbox.ignition import engine_manager
 from inbox.models import Category, MessageCategory
 from inbox.models.session import session_scope_by_shard_id
+from inbox.util import hook
 
 configure_logging()
 log = get_logger(purpose="duplicate-category-backfill")
@@ -183,6 +184,8 @@ def backfix_shard(shard_id, dry_run):
 @click.option("--shard-id", type=int, default=None)
 @click.option("--dry-run", is_flag=True)
 def main(shard_id, dry_run):
+    hook.maybe_run_startup()
+    
     if shard_id is not None:
         backfix_shard(shard_id, dry_run)
     else:

--- a/bin/backfix-generic-imap-separators.py
+++ b/bin/backfix-generic-imap-separators.py
@@ -11,6 +11,7 @@ from inbox.models.session import (
     session_scope,
     session_scope_by_shard_id,
 )
+from inbox.util import hook
 
 configure_logging()
 log = get_logger(purpose="separator-backfix")
@@ -21,6 +22,8 @@ log = get_logger(purpose="separator-backfix")
 @click.option("--max-id", type=int, default=None)
 @click.option("--shard-id", type=int, default=None)
 def main(min_id, max_id, shard_id):
+    hook.maybe_run_startup()
+    
     generic_accounts = []
     failed = []
 

--- a/bin/backfix-generic-imap-separators.py
+++ b/bin/backfix-generic-imap-separators.py
@@ -23,7 +23,7 @@ log = get_logger(purpose="separator-backfix")
 @click.option("--shard-id", type=int, default=None)
 def main(min_id, max_id, shard_id):
     hook.maybe_run_startup()
-    
+
     generic_accounts = []
     failed = []
 

--- a/bin/balance-fleet
+++ b/bin/balance-fleet
@@ -19,7 +19,7 @@ from inbox.scheduling.deferred_migration import (
     DeferredAccountMigration,
     DeferredAccountMigrationExecutor,
 )
-from inbox.util import fleet
+from inbox.util import fleet, hook
 
 configure_logging()
 log = get_logger()
@@ -188,6 +188,8 @@ def balance_zone(zone, normal_hosts, debug_hosts, account_loads, timespan, minim
 @click.option('--minimize-migrations/--no-minimize-migrations', default=True)
 @click.argument('account-loads')
 def main(dry_run, level, timespan, minimize_migrations, account_loads):
+    hook.maybe_run_startup()
+    
     zones = {h.get('ZONE') for h in config['DATABASE_HOSTS']}
     load_per_account = {}
     with open(account_loads) as f:

--- a/bin/check-attachments
+++ b/bin/check-attachments
@@ -24,6 +24,7 @@ from inbox.models.session import (
 )
 from inbox.s3.base import get_raw_from_provider
 from inbox.s3.exc import EmailFetchException, TemporaryEmailFetchException
+from inbox.util import hook
 
 configure_logging()
 log = get_logger(purpose='separator-backfix')
@@ -71,6 +72,8 @@ def process_account(account_id):
 @click.command()
 @click.option('--num-accounts', type=int, default=1500)
 def main(num_accounts):
+    hook.maybe_run_startup()
+    
     with global_session_scope() as db_session:
         accounts = db_session.query(Account).filter(
             Account.sync_should_run == True).order_by(func.rand()).limit(

--- a/bin/clear-all-heartbeats
+++ b/bin/clear-all-heartbeats
@@ -12,6 +12,7 @@ from inbox.heartbeat.config import (
     WAIT_TIMEOUT,
     get_redis_client,
 )
+from inbox.util import hook
 
 
 @click.command()
@@ -19,6 +20,8 @@ from inbox.heartbeat.config import (
 @click.option('--port', '-p', type=int, default=6379)
 @click.option('--database', '-d', type=int, default=STATUS_DATABASE)
 def main(host, port, database):
+    hook.maybe_run_startup()
+    
     connection_pool = BlockingConnectionPool(
         host=host, port=port, db=database,
         max_connections=MAX_CONNECTIONS, timeout=WAIT_TIMEOUT,

--- a/bin/clear-db
+++ b/bin/clear-db
@@ -2,10 +2,13 @@
 import argparse
 import sys
 
+from inbox.util import hook
 from inbox.util.db import drop_everything
 
 
 def main():
+    hook.maybe_run_startup()
+    
     parser = argparse.ArgumentParser()
     parser.add_argument('-u', '--with-users', action='store_true',
                         dest='with_users', default=False)

--- a/bin/clear-heartbeat-status
+++ b/bin/clear-heartbeat-status
@@ -7,6 +7,7 @@ from nylas.logging import configure_logging, get_logger
 
 from inbox.config import config
 from inbox.heartbeat.status import clear_heartbeat_status
+from inbox.util import hook
 
 configure_logging(config.get('LOGLEVEL'))
 log = get_logger()
@@ -19,6 +20,8 @@ log = get_logger()
 @click.option('--folder-id', '-f', type=int)
 @click.option('--device-id', '-d', type=int)
 def main(host, port, account_id, folder_id, device_id):
+    hook.maybe_run_startup()
+    
     print 'Clearing heartbeat status...'
     n = clear_heartbeat_status(account_id, folder_id, device_id, host, port)
     print '{} folders cleared.'.format(n)

--- a/bin/clear-kv
+++ b/bin/clear-kv
@@ -10,12 +10,15 @@ from inbox.heartbeat.config import (
     _get_redis_client,
     get_redis_client,
 )
+from inbox.util import hook
 
 
 @click.command()
 @click.option('--host', '-h', type=str)
 @click.option('--port', '-p', type=int, default=6379)
 def main(host, port):
+    hook.maybe_run_startup()
+    
     if host:
         status_client = _get_redis_client(host, port, STATUS_DATABASE)
         report_client = _get_redis_client(host, port, REPORT_DATABASE)

--- a/bin/contact-search-backfill
+++ b/bin/contact-search-backfill
@@ -11,6 +11,7 @@ import click
 from nylas.logging import configure_logging, get_logger
 
 from inbox.contacts.search import index_namespace
+from inbox.util import hook
 
 configure_logging()
 log = get_logger()
@@ -23,6 +24,8 @@ def main(namespace_ids):
     Idempotently index the given namespace_ids.
 
     """
+    hook.maybe_run_startup()
+    
     for namespace_id in namespace_ids:
         log.info("indexing namespace {namespace_id}".format(
                  namespace_id=namespace_id))

--- a/bin/contact-search-delete-index
+++ b/bin/contact-search-delete-index
@@ -3,6 +3,7 @@ import click
 from nylas.logging import configure_logging, get_logger
 
 from inbox.contacts.search import delete_namespace_indexes as delete_indexes
+from inbox.util import hook
 
 configure_logging()
 log = get_logger()
@@ -15,6 +16,8 @@ def delete_namespace_indexes(namespace_ids):
     Delete the CloudSearch indexes for a list of namespaces, specified by id.
 
     """
+    hook.maybe_run_startup()
+    
     delete_indexes(namespace_ids)
 
 

--- a/bin/contact-search-service
+++ b/bin/contact-search-service
@@ -15,6 +15,7 @@ from nylas.logging import configure_logging
 from setproctitle import setproctitle
 
 from inbox.config import config as inbox_config
+from inbox.util import hook
 from inbox.util.startup import preflight
 
 setproctitle("nylas-contact-search-index-service")
@@ -28,6 +29,8 @@ setproctitle("nylas-contact-search-index-service")
               help='Path to JSON configuration file.')
 def main(prod, config):
     """ Launch the contact search index service. """
+    hook.maybe_run_startup()
+    
     level = os.environ.get('LOGLEVEL', inbox_config.get('LOGLEVEL'))
     configure_logging(log_level=level)
 

--- a/bin/correct-autoincrements
+++ b/bin/correct-autoincrements
@@ -4,11 +4,14 @@ import click
 
 from inbox.config import config
 from inbox.ignition import EngineManager, reset_invalid_autoincrements
+from inbox.util import hook
 
 
 @click.command()
 @click.option('--dry-run', is_flag=True)
 def reset_db(dry_run):
+    hook.maybe_run_startup()
+    
     database_hosts = config.get_required('DATABASE_HOSTS')
     database_users = config.get_required('DATABASE_USERS')
     # Do not include disabled shards since application services do not use them.

--- a/bin/create-db
+++ b/bin/create-db
@@ -9,6 +9,7 @@ import sqlalchemy
 from inbox.config import config
 from inbox.ignition import EngineManager, build_uri, init_db, verify_db
 from inbox.sqlalchemy_ext.util import ForceStrictMode
+from inbox.util import hook
 
 
 @click.command()
@@ -17,6 +18,8 @@ from inbox.sqlalchemy_ext.util import ForceStrictMode
                    'set of shards')
 @click.option('--host-ip', default=None)
 def main(target_hostname, host_ip):
+    hook.maybe_run_startup()
+    
     database_hosts = config.get_required('DATABASE_HOSTS')
     database_users = config.get_required('DATABASE_USERS')
     engine_manager = EngineManager(database_hosts, database_users,

--- a/bin/create-encryption-keys
+++ b/bin/create-encryption-keys
@@ -5,8 +5,12 @@ import nacl.secret
 import nacl.utils
 import yaml
 
+from inbox.util import hook
+
 
 def main():
+    hook.maybe_run_startup()
+    
     from inbox.config import config, secrets_path
 
     # If the config contains encryption keys, don't override.

--- a/bin/create-event-contact-associations.py
+++ b/bin/create-event-contact-associations.py
@@ -14,6 +14,7 @@ from inbox.ignition import engine_manager
 from inbox.models import Event
 from inbox.models.session import session_scope_by_shard_id
 from inbox.models.util import limitlion
+from inbox.util import hook
 
 configure_logging()
 log = get_logger(purpose="create-event-contact-associations")
@@ -91,6 +92,8 @@ def process_shard(shard_id, dry_run, id_start=0):
 @click.option("--id-start", type=int, default=0)
 @click.option("--dry-run", is_flag=True)
 def main(shard_id, id_start, dry_run):
+    hook.maybe_run_startup()
+    
     if shard_id is not None:
         process_shard(shard_id, dry_run, id_start)
     else:

--- a/bin/create-event-contact-associations.py
+++ b/bin/create-event-contact-associations.py
@@ -93,7 +93,7 @@ def process_shard(shard_id, dry_run, id_start=0):
 @click.option("--dry-run", is_flag=True)
 def main(shard_id, id_start, dry_run):
     hook.maybe_run_startup()
-    
+
     if shard_id is not None:
         process_shard(shard_id, dry_run, id_start)
     else:

--- a/bin/deferred-migration-service
+++ b/bin/deferred-migration-service
@@ -9,11 +9,14 @@ from nylas.logging import configure_logging
 from setproctitle import setproctitle
 
 from inbox.scheduling.deferred_migration import DeferredAccountMigrationExecutor
+from inbox.util import hook
 
 configure_logging()
 
 
 def main():
+    hook.maybe_run_startup()
+    
     setproctitle('deferred-migration-service')
     print "Starting DeferredAccountMigrationExecutor..."
     dame = DeferredAccountMigrationExecutor()

--- a/bin/delete-account-data
+++ b/bin/delete-account-data
@@ -25,6 +25,7 @@ from inbox.heartbeat.status import clear_heartbeat_status
 from inbox.models import Account
 from inbox.models.session import session_scope
 from inbox.models.util import delete_namespace
+from inbox.util import hook
 
 
 @click.command()
@@ -33,6 +34,8 @@ from inbox.models.util import delete_namespace
 @click.option('--yes', is_flag=True)
 @click.option('--throttle', is_flag=True)
 def delete_account_data(account_id, dry_run, yes, throttle):
+    hook.maybe_run_startup()
+    
     with session_scope(account_id) as db_session:
         account = db_session.query(Account).get(account_id)
 

--- a/bin/delete-marked-accounts
+++ b/bin/delete-marked-accounts
@@ -19,6 +19,7 @@ import gevent
 from nylas.logging import configure_logging, get_logger
 
 from inbox.config import config
+from inbox.util import hook
 from inbox.models.util import batch_delete_namespaces, get_accounts_to_delete
 
 configure_logging(logging.INFO)
@@ -29,6 +30,8 @@ log = get_logger()
 @click.option('--throttle', is_flag=True)
 @click.option('--dry-run', is_flag=True)
 def run(throttle, dry_run):
+    hook.run_startup()
+    
     pool = []
 
     for host in config['DATABASE_HOSTS']:

--- a/bin/delete-marked-accounts
+++ b/bin/delete-marked-accounts
@@ -19,8 +19,8 @@ import gevent
 from nylas.logging import configure_logging, get_logger
 
 from inbox.config import config
-from inbox.util import hook
 from inbox.models.util import batch_delete_namespaces, get_accounts_to_delete
+from inbox.util import hook
 
 configure_logging(logging.INFO)
 log = get_logger()

--- a/bin/delete-marked-accounts
+++ b/bin/delete-marked-accounts
@@ -30,7 +30,7 @@ log = get_logger()
 @click.option('--throttle', is_flag=True)
 @click.option('--dry-run', is_flag=True)
 def run(throttle, dry_run):
-    hook.run_startup()
+    hook.maybe_run_startup()
     
     pool = []
 

--- a/bin/detect-missing-sync-host
+++ b/bin/detect-missing-sync-host
@@ -5,6 +5,7 @@ from sqlalchemy.orm import load_only
 
 from inbox.models.account import Account
 from inbox.models.session import global_session_scope
+from inbox.util import hook
 
 
 @click.command()
@@ -16,6 +17,8 @@ def main():
     host.)
 
     """
+    hook.maybe_run_startup()
+    
     with global_session_scope() as db_session:
         for acc in db_session.query(Account).options(
                 load_only('sync_state', 'sync_should_run', 'sync_host', 'desired_sync_host'))\

--- a/bin/get-account-loads
+++ b/bin/get-account-loads
@@ -13,7 +13,7 @@ from inbox.ignition import engine_manager
 from inbox.mailsync.service import MAX_ACCOUNTS_PER_PROCESS
 from inbox.models.account import Account
 from inbox.models.session import session_scope_by_shard_id
-from inbox.util import fleet
+from inbox.util import fleet, hook
 
 NUM_PROCESSES_PER_HOST = 16
 
@@ -84,6 +84,8 @@ def get_account_loads(zone, hosts):
 @click.command()
 @click.option('--level', default='staging')
 def main(level):
+    hook.maybe_run_startup()
+    
     zones = {h.get('ZONE') for h in config['DATABASE_HOSTS']}
     zone_map = {}
     for zone in zones:

--- a/bin/get-accounts-for-host
+++ b/bin/get-accounts-for-host
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from inbox.util import hook
 import click
 
 from inbox.models.account import Account
@@ -9,6 +10,8 @@ from inbox.models.session import global_session_scope
 @click.command()
 @click.argument('hostname')
 def main(hostname):
+    hook.maybe_run_startup()
+    
     with global_session_scope() as db_session:
         account_ids = db_session.query(Account.id).filter(Account.sync_host == hostname)
 

--- a/bin/get-accounts-for-host
+++ b/bin/get-accounts-for-host
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-from inbox.util import hook
 import click
 
 from inbox.models.account import Account
 from inbox.models.session import global_session_scope
+from inbox.util import hook
 
 
 @click.command()

--- a/bin/get-id
+++ b/bin/get-id
@@ -17,6 +17,7 @@ from inbox.models import (
     Transaction,
 )
 from inbox.models.session import global_session_scope
+from inbox.util import hook
 
 cls_for_type = dict(
     account=Account,
@@ -35,6 +36,8 @@ cls_for_type = dict(
 @click.option('--id', type=str, default=None)
 @click.option('--public-id', type=str, default=None)
 def main(type, id, public_id):
+    hook.maybe_run_startup()
+    
     type = type.lower()
 
     if type not in cls_for_type:

--- a/bin/get-object
+++ b/bin/get-object
@@ -22,6 +22,7 @@ from inbox.models import (
     Transaction,
 )
 from inbox.models.session import global_session_scope, session_scope
+from inbox.util import hook
 
 cls_for_type = dict(
     account=Account,
@@ -49,6 +50,8 @@ except ImportError:
 @click.option('--namespace-id', type=str, default=None)
 @click.option('--readwrite', is_flag=True, default=False)
 def main(type, id, public_id, account_id, namespace_id, readwrite):
+    hook.maybe_run_startup()
+    
     type = type.lower()
 
     if type not in cls_for_type:

--- a/bin/inbox-api
+++ b/bin/inbox-api
@@ -34,6 +34,7 @@ from nylas.api.wsgi import NylasWSGIHandler
 from nylas.logging import configure_logging, get_logger
 
 from inbox.mailsync.frontend import SyncbackHTTPFrontend
+from inbox.util import hook
 from inbox.util.startup import load_overrides, preflight
 
 syncback = None
@@ -57,6 +58,8 @@ def main(prod, start_syncback, enable_tracer, config, port, enable_profiler):
     """ Launch the Nylas API service. """
     level = os.environ.get('LOGLEVEL', inbox_config.get('LOGLEVEL'))
     configure_logging(log_level=level)
+
+    hook.maybe_run_startup()
 
     if config is not None:
         config_path = os.path.abspath(config)

--- a/bin/inbox-auth
+++ b/bin/inbox-auth
@@ -21,6 +21,7 @@ from inbox.basicauth import NotSupportedError
 from inbox.config import config
 from inbox.models import Account
 from inbox.models.session import session_scope
+from inbox.util import hook
 from inbox.util.startup import preflight
 from inbox.util.url import provider_from_address
 
@@ -37,6 +38,8 @@ configure_logging(config.get('LOGLEVEL'))
               help='Manually specify the provider instead of trying to detect it')
 def main(email_address, reauth, target, provider):
     """ Auth an email account. """
+    hook.maybe_run_startup()
+
     preflight()
 
     shard_id = target << 48

--- a/bin/inbox-console
+++ b/bin/inbox-console
@@ -15,6 +15,7 @@ from nylas.logging import get_logger
 log = get_logger()
 
 from inbox.console import start_client_console, start_console
+from inbox.util import hook
 
 
 @click.command()
@@ -24,6 +25,8 @@ from inbox.console import start_client_console, start_console
               help='Start a repl with an APIClient')
 def console(email_address, client):
     """ REPL for Nylas. """
+    hook.maybe_run_startup()
+    
     if client:
         start_client_console(email_address)
     else:

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -29,8 +29,8 @@ except ImportError:
 from nylas.logging import configure_logging, get_logger
 
 from inbox.mailsync.frontend import SyncHTTPFrontend
-from inbox.util import hook
 from inbox.mailsync.service import SyncService
+from inbox.util import hook
 from inbox.util.logging_helper import reconfigure_logging
 from inbox.util.startup import preflight
 

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -29,6 +29,7 @@ except ImportError:
 from nylas.logging import configure_logging, get_logger
 
 from inbox.mailsync.frontend import SyncHTTPFrontend
+from inbox.util import hook
 from inbox.mailsync.service import SyncService
 from inbox.util.logging_helper import reconfigure_logging
 from inbox.util.startup import preflight
@@ -63,6 +64,8 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
     level = os.environ.get('LOGLEVEL', inbox_config.get('LOGLEVEL'))
     configure_logging(log_level=level)
     reconfigure_logging()
+
+    hook.run_startup()
 
     os.environ["SENTRY_DSN"] = inbox_config.get("SENTRY_DSN", "")
 

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -65,7 +65,7 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
     configure_logging(log_level=level)
     reconfigure_logging()
 
-    hook.run_startup()
+    hook.maybe_run_startup()
 
     os.environ["SENTRY_DSN"] = inbox_config.get("SENTRY_DSN", "")
 

--- a/bin/migrate-db
+++ b/bin/migrate-db
@@ -6,9 +6,12 @@ import alembic.config
 import alembic.util
 
 from inbox.config import config
+from inbox.util import hook
 
 
 def main():
+    hook.maybe_run_startup()
+    
     alembic_ini_filename = os.environ.get('ALEMBIC_INI_PATH', 'alembic.ini')
     assert os.path.isfile(alembic_ini_filename), \
         'Missing alembic.ini file at {}'.format(alembic_ini_filename)

--- a/bin/mysql-prompt
+++ b/bin/mysql-prompt
@@ -7,11 +7,14 @@ import click
 from setproctitle import setproctitle
 
 from inbox.config import config
+from inbox.util import hook
 
 
 @click.command()
 @click.option('--shard-num', type=int)
 def main(shard_num):
+    hook.maybe_run_startup()
+    
     users = config.get_required('DATABASE_USERS')
 
     creds = dict(hostname=None, username=None,

--- a/bin/populate-sync-queue
+++ b/bin/populate-sync-queue
@@ -15,11 +15,14 @@ from setproctitle import setproctitle
 
 from inbox.config import config
 from inbox.scheduling.queue import QueuePopulator
+from inbox.util import hook
 
 configure_logging()
 
 
 def main():
+    hook.maybe_run_startup()
+    
     setproctitle('scheduler')
     zones = {h.get('ZONE') for h in config['DATABASE_HOSTS']}
     threads = []

--- a/bin/purge-transaction-log
+++ b/bin/purge-transaction-log
@@ -28,7 +28,7 @@ log = get_logger()
 @click.option('--throttle', is_flag=True)
 @click.option('--dry-run', is_flag=True)
 def run(days_ago, limit, throttle, dry_run):
-    hook.run_startup()
+    hook.maybe_run_startup()
 
     pool = []
 

--- a/bin/purge-transaction-log
+++ b/bin/purge-transaction-log
@@ -14,6 +14,7 @@ import click
 import gevent
 from nylas.logging import configure_logging, get_logger
 
+from inbox.util import hook
 from inbox.config import config
 from inbox.models.util import purge_transactions
 
@@ -27,6 +28,8 @@ log = get_logger()
 @click.option('--throttle', is_flag=True)
 @click.option('--dry-run', is_flag=True)
 def run(days_ago, limit, throttle, dry_run):
+    hook.run_startup()
+
     pool = []
 
     for host in config['DATABASE_HOSTS']:

--- a/bin/purge-transaction-log
+++ b/bin/purge-transaction-log
@@ -14,9 +14,9 @@ import click
 import gevent
 from nylas.logging import configure_logging, get_logger
 
-from inbox.util import hook
 from inbox.config import config
 from inbox.models.util import purge_transactions
+from inbox.util import hook
 
 configure_logging(logging.INFO)
 log = get_logger()

--- a/bin/restart-forgotten-accounts
+++ b/bin/restart-forgotten-accounts
@@ -8,6 +8,7 @@ gevent.monkey.patch_all()
 from nylas.logging import configure_logging, get_logger
 
 from inbox.ignition import engine_manager
+from inbox.util import hook
 from inbox.mailsync.service import shared_sync_event_queue_for_zone
 from inbox.models.account import Account
 from inbox.models.session import global_session_scope
@@ -20,6 +21,8 @@ accounts_without_sync_host = set()
 
 
 def check_accounts():
+    hook.maybe_run_startup()
+    
     global accounts_without_sync_host
     poll_interval = 30
 

--- a/bin/restart-forgotten-accounts
+++ b/bin/restart-forgotten-accounts
@@ -8,10 +8,10 @@ gevent.monkey.patch_all()
 from nylas.logging import configure_logging, get_logger
 
 from inbox.ignition import engine_manager
-from inbox.util import hook
 from inbox.mailsync.service import shared_sync_event_queue_for_zone
 from inbox.models.account import Account
 from inbox.models.session import global_session_scope
+from inbox.util import hook
 from inbox.util.concurrency import retry_with_logging
 
 configure_logging()

--- a/bin/set-desired-host
+++ b/bin/set-desired-host
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
-from inbox.util import hook
 import click
 
 from inbox.models.account import Account
 from inbox.models.session import global_session_scope
+from inbox.util import hook
 
 
 @click.command()

--- a/bin/set-desired-host
+++ b/bin/set-desired-host
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from inbox.util import hook
 import click
 
 from inbox.models.account import Account
@@ -12,6 +13,8 @@ from inbox.models.session import global_session_scope
 @click.option('--dry-run', is_flag=True)
 @click.option('--toggle-sync', is_flag=True)
 def main(account_id, desired_host, dry_run, toggle_sync):
+    hook.maybe_run_startup()
+    
     with global_session_scope() as db_session:
         account = db_session.query(Account).get(int(account_id))
 

--- a/bin/set-throttled
+++ b/bin/set-throttled
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # throttle or unthrottle an account
+from inbox.util import hook
 import optparse
 import sys
 import time
@@ -36,6 +37,8 @@ def throttle(options):
 
 
 def main():
+    hook.maybe_run_startup()
+    
     parser = optparse.OptionParser()
     parser.add_option('--throttled', action="store_true", default=False)
     parser.add_option('--unthrottled', action="store_true", default=False)

--- a/bin/set-throttled
+++ b/bin/set-throttled
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # throttle or unthrottle an account
-from inbox.util import hook
 import optparse
 import sys
 import time
 
 from inbox.models.account import Account
 from inbox.models.session import session_scope
+from inbox.util import hook
 
 
 def print_usage():

--- a/bin/stamp-db
+++ b/bin/stamp-db
@@ -7,9 +7,12 @@ import alembic.config
 import alembic.util
 
 from inbox.config import config
+from inbox.util import hook
 
 
 def main(revision_id):
+    hook.maybe_run_startup()
+    
     alembic_ini_filename = os.environ.get('ALEMBIC_INI_PATH', 'alembic.ini')
     assert os.path.isfile(alembic_ini_filename), \
         'Missing alembic.ini file at {}'.format(alembic_ini_filename)

--- a/bin/syncback-service
+++ b/bin/syncback-service
@@ -24,6 +24,7 @@ from inbox.mailsync.frontend import SyncbackHTTPFrontend
 from inbox.transactions.actions import SyncbackService
 from inbox.util.logging_helper import reconfigure_logging
 from inbox.util.startup import load_overrides, preflight
+from inbox.util import hook
 
 
 @click.command()
@@ -53,6 +54,8 @@ def main(prod, config, process_num, syncback_id, enable_tracer,
     level = os.environ.get('LOGLEVEL', inbox_config.get('LOGLEVEL'))
     configure_logging(log_level=level)
     reconfigure_logging()
+
+    hook.run_startup()
 
     os.environ["SENTRY_DSN"] = inbox_config.get("SENTRY_DSN", "")
 

--- a/bin/syncback-service
+++ b/bin/syncback-service
@@ -22,9 +22,9 @@ from setproctitle import setproctitle
 from inbox.config import config as inbox_config
 from inbox.mailsync.frontend import SyncbackHTTPFrontend
 from inbox.transactions.actions import SyncbackService
+from inbox.util import hook
 from inbox.util.logging_helper import reconfigure_logging
 from inbox.util.startup import load_overrides, preflight
-from inbox.util import hook
 
 
 @click.command()

--- a/bin/syncback-service
+++ b/bin/syncback-service
@@ -55,7 +55,7 @@ def main(prod, config, process_num, syncback_id, enable_tracer,
     configure_logging(log_level=level)
     reconfigure_logging()
 
-    hook.run_startup()
+    hook.maybe_run_startup()
 
     os.environ["SENTRY_DSN"] = inbox_config.get("SENTRY_DSN", "")
 

--- a/bin/syncback-stats
+++ b/bin/syncback-stats
@@ -10,6 +10,7 @@ from inbox.ignition import engine_manager
 from inbox.models import Account, Namespace
 from inbox.models.action_log import ActionLog
 from inbox.models.session import session_scope_by_shard_id
+from inbox.util import hook
 
 
 @click.command()
@@ -18,6 +19,8 @@ def main():
     lengths.
 
     """
+    hook.maybe_run_startup()
+    
     for key in engine_manager.engines:
         with session_scope_by_shard_id(key) as db_session:
             total_pending_actions = 0

--- a/bin/unschedule-account-syncs
+++ b/bin/unschedule-account-syncs
@@ -3,6 +3,7 @@ import click
 
 from inbox.models.account import Account
 from inbox.models.session import global_session_scope, session_scope
+from inbox.util import hook
 
 
 @click.command()
@@ -17,6 +18,8 @@ def main(dry_run, number, hostname, process):
     manually unloading an overloaded sync instance.
 
     """
+    hook.maybe_run_startup()
+    
     if not number:
         message = 'You have not provided a --number option. This will '\
                   'unschedule ALL syncs on the host. Proceed? [Y/n] '

--- a/bin/update-categories
+++ b/bin/update-categories
@@ -3,11 +3,14 @@
 import click
 
 from inbox.ignition import engine_manager
+from inbox.util import hook
 
 
 @click.command()
 @click.option('--shard_id', type=int)
 def main(shard_id):
+    hook.maybe_run_startup()
+    
     if shard_id is not None:
         update_categories_for_shard(shard_id)
         update_folders_and_labels_for_shard(shard_id)

--- a/bin/verify-db
+++ b/bin/verify-db
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 from inbox.config import config
 from inbox.ignition import EngineManager, verify_db
+from inbox.util import hook
 
 
 def main():
+    hook.maybe_run_startup()
+    
     database_hosts = config.get_required('DATABASE_HOSTS')
     database_users = config.get_required('DATABASE_USERS')
     # Do not include disabled shards since application services do not use them.

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -830,5 +830,6 @@ class SyncbackWorker(gevent.Greenlet):
                     exc_info=True,
                     account_id=task.account_id,
                 )
+                log_uncaught_errors()
             finally:
                 self.parent_service().notify_worker_finished(task.action_log_ids)

--- a/inbox/util/hook.py
+++ b/inbox/util/hook.py
@@ -11,9 +11,7 @@ _already_run = set()
 
 
 def run_once(hookspec):
-    if not hookspec:
-        return
-
+    """Execute given hookspec once per process"""
     with _lock:
         if hookspec in _already_run:
             log.info("Not running hook {}, it was already run".format(hookspec))
@@ -30,5 +28,10 @@ def run_once(hookspec):
         _already_run.add(hookspec)
 
 
-def run_startup():
-    return run_once(os.environ.get("SYNC_ENGINE_STARTUP_HOOK"))
+def maybe_run_startup():
+    """Check if startup hook env var is set and run it"""
+    startup_hook = os.environ.get("SYNC_ENGINE_STARTUP_HOOK")
+    if not startup_hook:
+        return
+
+    return run_once(startup_hook)

--- a/inbox/util/hook.py
+++ b/inbox/util/hook.py
@@ -1,0 +1,26 @@
+import importlib
+
+import gevent.threading
+from nylas.logging import get_logger
+
+log = get_logger()
+
+_lock = gevent.threading.Lock()
+_already_run = set()
+
+
+def run_once(hookspec):
+    with _lock:
+        if hookspec in _already_run:
+            log.info("Not running hook {}, it was already run".format(hookspec))
+            return
+
+        module_name, function_name = hookspec.rsplit('.', 1)
+        module = importlib.import_module(module_name)
+        function = getattr(module, function_name)
+
+        log.info("Running hook {}".format(hookspec))
+
+        function()
+
+        _already_run.add(hookspec)

--- a/inbox/util/hook.py
+++ b/inbox/util/hook.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 
 import gevent.threading
 from nylas.logging import get_logger
@@ -10,12 +11,15 @@ _already_run = set()
 
 
 def run_once(hookspec):
+    if not hookspec:
+        return
+
     with _lock:
         if hookspec in _already_run:
             log.info("Not running hook {}, it was already run".format(hookspec))
             return
 
-        module_name, function_name = hookspec.rsplit('.', 1)
+        module_name, function_name = hookspec.rsplit(".", 1)
         module = importlib.import_module(module_name)
         function = getattr(module, function_name)
 
@@ -24,3 +28,7 @@ def run_once(hookspec):
         function()
 
         _already_run.add(hookspec)
+
+
+def run_startup():
+    return run_once(os.environ.get("SYNC_ENGINE_STARTUP_HOOK"))

--- a/tests/util/test_hook.py
+++ b/tests/util/test_hook.py
@@ -1,0 +1,31 @@
+import mock
+
+from inbox.util.hook import run_once
+
+def hook():
+    pass
+
+
+def another_hook():
+    pass
+
+
+def test_run_once():
+    with mock.patch("inbox.util.hook.log") as log_mock:
+        run_once("tests.util.test_hook.hook")
+
+    assert log_mock.info.call_count == 1
+    assert log_mock.info.call_args == (('Running hook tests.util.test_hook.hook',),)
+
+    with mock.patch("inbox.util.hook.log") as log_mock:
+        run_once("tests.util.test_hook.hook")
+
+    assert log_mock.info.call_count == 1
+    assert log_mock.info.call_args == (('Not running hook tests.util.test_hook.hook, it was already run',),)
+
+    with mock.patch("inbox.util.hook.log") as log_mock:
+        run_once("tests.util.test_hook.another_hook")
+
+    assert log_mock.info.call_count == 1
+    assert log_mock.info.call_args == (('Running hook tests.util.test_hook.another_hook',),)
+

--- a/tests/util/test_hook.py
+++ b/tests/util/test_hook.py
@@ -11,14 +11,6 @@ def another_hook():
     pass
 
 
-def test_empty():
-    with mock.patch("inbox.util.hook.log") as log_mock:
-        run_once("")
-        run_once(None)
-
-    assert log_mock.info.call_count == 0
-
-
 def test_run_once():
     with mock.patch("inbox.util.hook.log") as log_mock:
         run_once("tests.util.test_hook.hook")

--- a/tests/util/test_hook.py
+++ b/tests/util/test_hook.py
@@ -2,6 +2,7 @@ import mock
 
 from inbox.util.hook import run_once
 
+
 def hook():
     pass
 
@@ -10,22 +11,33 @@ def another_hook():
     pass
 
 
+def test_empty():
+    with mock.patch("inbox.util.hook.log") as log_mock:
+        run_once("")
+        run_once(None)
+
+    assert log_mock.info.call_count == 0
+
+
 def test_run_once():
     with mock.patch("inbox.util.hook.log") as log_mock:
         run_once("tests.util.test_hook.hook")
 
     assert log_mock.info.call_count == 1
-    assert log_mock.info.call_args == (('Running hook tests.util.test_hook.hook',),)
+    assert log_mock.info.call_args == (("Running hook tests.util.test_hook.hook",),)
 
     with mock.patch("inbox.util.hook.log") as log_mock:
         run_once("tests.util.test_hook.hook")
 
     assert log_mock.info.call_count == 1
-    assert log_mock.info.call_args == (('Not running hook tests.util.test_hook.hook, it was already run',),)
+    assert log_mock.info.call_args == (
+        ("Not running hook tests.util.test_hook.hook, it was already run",),
+    )
 
     with mock.patch("inbox.util.hook.log") as log_mock:
         run_once("tests.util.test_hook.another_hook")
 
     assert log_mock.info.call_count == 1
-    assert log_mock.info.call_args == (('Running hook tests.util.test_hook.another_hook',),)
-
+    assert log_mock.info.call_args == (
+        ("Running hook tests.util.test_hook.another_hook",),
+    )


### PR DESCRIPTION
A third party can set `SYNC_ENGINE_STARTUP_HOOK` environment variable to `module.submodule.callable`. This will be executed once per process as part of the startup and can serve as a way to customize the process behavior.