### PR TITLE
Filter out issues reported to Rollbar with given threshold

### DIFF
--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -363,7 +363,9 @@ class SyncbackService(gevent.Greenlet):
             if account_id is None:
                 account_id = namespace.account.id
             else:
-                assert account_id is namespace.account.id
+                assert (
+                    account_id is namespace.account.id
+                ), "account_id and namespace.account.id do not match"
 
             if namespace.account.sync_state in ("invalid", "stopped"):
                 sync_state = namespace.account.sync_state


### PR DESCRIPTION
This provides a way for a user to filter out issues reported to Rollbar by specifying an environment variable `ROLLBAR_MESSAGE_FILTERS`. This environment carries a JSON string in form

```json
[
	{"regex": "error regex 1", "threshold": 0.4},
	{"regex": "error regex 2", "threshold": 0.00001},
	...
]
```

Thresholds are probabilities of error matching given regex being reported. E.g. 0.5 means report 50% of times, 0 means never and greater or equal to 1 means always.