### PR TITLE
Bring back Flake8 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,25 @@ jobs:
           when: always
           command: isort -c .
 
+  static-code-analysis-flake8:
+    docker:
+      - image: circleci/python:2.7
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    working_directory: ~/code
+    steps:
+      - checkout
+
+      - run:
+          name: Prepare Environment
+          command: |
+            sudo -E pip install flake8==3.9.2
+
+      - run:
+          name: flake8
+          command: flake8
+
   build:
     machine:
       image: ubuntu-1604:201903-01 
@@ -66,4 +85,5 @@ workflows:
   workflow:
     jobs:
       - static-code-analysis
+      - static-code-analysis-flake8
       - build

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,13 @@
+[flake8]
+ignore=
+    # do not use bare 'except'
+    E722
+    # Module level import not at top of file
+    E402,
+    # This is not PEP8-compliant and conflicts with black.
+    E501,
+    E231,
+    E203,
+    W503,
+    W504
+exclude=migrations/versions

--- a/bin/check-attachments
+++ b/bin/check-attachments
@@ -5,26 +5,18 @@ from gevent import monkey
 monkey.patch_all()
 
 import datetime
-import traceback
 from collections import defaultdict
 
 import click
-import gevent
+import gevent  # noqa
 from gevent.pool import Pool
 from nylas.logging import configure_logging, get_logger
 from sqlalchemy.sql.expression import func
 
-from inbox.crispin import connection_pool
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.models import Account, Block
-from inbox.models.backends.generic import GenericAccount
-from inbox.models.session import (
-    global_session_scope,
-    session_scope,
-    session_scope_by_shard_id,
-)
+from inbox.models.session import global_session_scope, session_scope
 from inbox.s3.base import get_raw_from_provider
-from inbox.s3.exc import EmailFetchException, TemporaryEmailFetchException
 
 configure_logging()
 log = get_logger(purpose='separator-backfix')
@@ -76,7 +68,7 @@ def main(num_accounts):
 
     with global_session_scope() as db_session:
         accounts = db_session.query(Account).filter(
-            Account.sync_should_run == True).order_by(func.rand()).limit(
+            Account.sync_should_run).order_by(func.rand()).limit(
             num_accounts).all()
 
         accounts = [acc.id for acc in accounts][:num_accounts]
@@ -94,6 +86,7 @@ def main(num_accounts):
             global_results[key] += ret[key]
 
     print global_results
+
 
 if __name__ == '__main__':
     main()

--- a/bin/clear-all-heartbeats
+++ b/bin/clear-all-heartbeats
@@ -11,7 +11,6 @@ from inbox.heartbeat.config import (
     SOCKET_TIMEOUT,
     STATUS_DATABASE,
     WAIT_TIMEOUT,
-    get_redis_client,
 )
 
 
@@ -21,7 +20,7 @@ from inbox.heartbeat.config import (
 @click.option('--database', '-d', type=int, default=STATUS_DATABASE)
 def main(host, port, database):
     maybe_enable_rollbar()
-    
+
     connection_pool = BlockingConnectionPool(
         host=host, port=port, db=database,
         max_connections=MAX_CONNECTIONS, timeout=WAIT_TIMEOUT,

--- a/bin/clear-db
+++ b/bin/clear-db
@@ -36,5 +36,6 @@ def main():
     init_db(engine)
     sys.exit(0)
 
+
 if __name__ == '__main__':
     main()

--- a/bin/contact-search-backfill
+++ b/bin/contact-search-backfill
@@ -31,5 +31,6 @@ def main(namespace_ids):
                  namespace_id=namespace_id))
         index_namespace(namespace_id)
 
+
 if __name__ == '__main__':
     main()

--- a/bin/contact-search-service
+++ b/bin/contact-search-service
@@ -54,5 +54,6 @@ def main(prod, config):
     contact_search_indexer.start()
     contact_search_indexer.join()
 
+
 if __name__ == '__main__':
     main()

--- a/bin/get-id
+++ b/bin/get-id
@@ -59,5 +59,6 @@ def main(type, id, public_id):
             obj = db_session.query(cls).filter(cls.id == id).one()
             print obj.public_id
 
+
 if __name__ == '__main__':
     main()

--- a/bin/get-object
+++ b/bin/get-object
@@ -9,20 +9,16 @@ import IPython
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.models import (
     Account,
-    ActionLog,
     Block,
     Calendar,
-    Category,
     Event,
-    Folder,
-    Label,
     Message,
     Namespace,
     Part,
     Thread,
     Transaction,
 )
-from inbox.models.session import global_session_scope, session_scope
+from inbox.models.session import global_session_scope
 
 cls_for_type = dict(
     account=Account,
@@ -78,7 +74,7 @@ def main(type, id, public_id, account_id, namespace_id, readwrite):
             elif namespace_id:
                 qu = qu.filter(cls.namespace_id == namespace_id)
 
-            obj = qu.one()
+            qu.one()
 
             banner = """The object you queried is accessible as `obj`.
 Note that the db session is read-only, unless if you start this script with --readwrite"""

--- a/bin/inbox-api
+++ b/bin/inbox-api
@@ -103,5 +103,6 @@ def start(port, start_syncback, enable_tracer, enable_profiler):
     if start_syncback:
         syncback.join()
 
+
 if __name__ == '__main__':
     main()

--- a/bin/inbox-auth
+++ b/bin/inbox-auth
@@ -75,5 +75,6 @@ def main(email_address, reauth, target, provider):
 
     print 'OK. Authenticated account for {}'.format(email_address)
 
+
 if __name__ == '__main__':
     main()

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -118,8 +118,8 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
         exit_after_min, exit_after_max = None, None
 
     sync_service = SyncService(process_identifier, process_num,
-				               exit_after_min=exit_after_min,
-				               exit_after_max=exit_after_max)
+                               exit_after_min=exit_after_min,
+                               exit_after_max=exit_after_max)
     signal.signal(signal.SIGTERM, sync_service.stop)
     signal.signal(signal.SIGINT, sync_service.stop)
     http_frontend = SyncHTTPFrontend(sync_service, port, enable_tracer,

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -39,6 +39,29 @@ SOCKET_TIMEOUT = 2 * 60
 socket.setdefaulttimeout(SOCKET_TIMEOUT)
 
 
+banner = (
+    "\033[1;95m"
+    r"""
+      _   _       _
+     | \ | |     | |
+     |  \| |_   _| | __ _ ___
+     | . ` | | | | |/ _` / __|
+     | |\  | |_| | | (_| \__ \
+     \_| \_/\__, |_|\__,_|___/
+             __/ |
+            |___/
+    """
+    "\033[0m\033[94m"
+    """
+      S Y N C   E N G I N E
+    """
+    "\033[0m"
+    """
+     Use CTRL-C to stop.
+    """
+)
+
+
 @click.command()
 @click.option('--prod/--no-prod', default=False,
               help='Disables the autoreloader and potentially other '
@@ -88,20 +111,7 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
              total_processes=total_processes,
              recursion_limit=sys.getrecursionlimit())
 
-    print >>sys.stderr, """\033[1;95m
-      _   _       _
-     | \ | |     | |
-     |  \| |_   _| | __ _ ___
-     | . ` | | | | |/ _` / __|
-     | |\  | |_| | | (_| \__ \\
-     \_| \_/\__, |_|\__,_|___/
-             __/ |
-            |___/
-\033[0m\033[94m
-      S Y N C   E N G I N E \033[0m
-
-     Use CTRL-C to stop.
-     """
+    print >>sys.stderr, banner
 
     if enable_profiler:
         inbox_config['DEBUG_PROFILING_ON'] = True

--- a/bin/mysql-prompt
+++ b/bin/mysql-prompt
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
-import os
 import subprocess
 import sys
 
 import click
-from setproctitle import setproctitle
 
 from inbox.config import config
 from inbox.error_handling import maybe_enable_rollbar
@@ -38,6 +36,7 @@ def main(shard_num):
     proc = subprocess.Popen(['mysql', '-h' + creds['hostname'], '-u' + creds['username'], '-D ' + creds['db_name'], '-p' + creds['password'],
                              '--safe-updates'])
     proc.wait()
+
 
 if __name__ == '__main__':
     main()

--- a/bin/restart-forgotten-accounts
+++ b/bin/restart-forgotten-accounts
@@ -29,7 +29,7 @@ def check_accounts():
     with global_session_scope() as db_session:
         not_syncing_accounts = set(db_session.query(Account.id).
                                    filter(Account.sync_should_run,
-                                          Account.sync_host == None))  # noqa
+                                          Account.sync_host.is_(None)))
         still_not_syncing_accounts = accounts_without_sync_host & not_syncing_accounts
 
         for account_id in still_not_syncing_accounts:

--- a/bin/unschedule-account-syncs
+++ b/bin/unschedule-account-syncs
@@ -37,8 +37,7 @@ def main(dry_run, number, hostname, process):
     with global_session_scope() as db_session:
         if process is not None:
             hostname = ':'.join([hostname, process])
-        to_unschedule = db_session.query(Account.id). \
-                filter(Account.sync_host.like('{}%'.format(hostname)))
+        to_unschedule = db_session.query(Account.id).filter(Account.sync_host.like('{}%'.format(hostname)))
         if number:
             to_unschedule = to_unschedule.limit(number)
         to_unschedule = [id_ for id_, in to_unschedule.all()]

--- a/bin/verify-db
+++ b/bin/verify-db
@@ -6,7 +6,7 @@ from inbox.ignition import EngineManager, verify_db
 
 def main():
     maybe_enable_rollbar()
-    
+
     database_hosts = config.get_required('DATABASE_HOSTS')
     database_users = config.get_required('DATABASE_USERS')
     # Do not include disabled shards since application services do not use them.

--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -68,7 +68,7 @@ def threads(
     else:
         query = db_session.query(Thread)
 
-    filters = [Thread.namespace_id == namespace_id, Thread.deleted_at == None]
+    filters = [Thread.namespace_id == namespace_id, Thread.deleted_at.is_(None)]
     if thread_public_id is not None:
         filters.append(Thread.public_id == thread_public_id)
 
@@ -290,7 +290,7 @@ def messages_or_drafts(
     query += lambda q: q.filter(
         Message.namespace_id == bindparam("namespace_id"),
         Message.is_draft == bindparam("drafts"),
-        Thread.deleted_at == None,
+        Thread.deleted_at.is_(None),
     )
 
     if subject is not None:
@@ -538,8 +538,8 @@ def filter_event_query(
 ):
 
     query = query.filter(event_cls.namespace_id == namespace_id).filter(
-        event_cls.deleted_at == None
-    )  # noqa
+        event_cls.deleted_at.is_(None)
+    )
 
     if event_public_id:
         query = query.filter(event_cls.public_id == event_public_id)
@@ -596,12 +596,12 @@ def recurring_events(
     after_criteria = []
     if starts_after:
         after_criteria.append(
-            or_(RecurringEvent.until > starts_after, RecurringEvent.until == None)
-        )  # noqa
+            or_(RecurringEvent.until > starts_after, RecurringEvent.until.is_(None))
+        )
     if ends_after:
         after_criteria.append(
-            or_(RecurringEvent.until > ends_after, RecurringEvent.until == None)
-        )  # noqa
+            or_(RecurringEvent.until > ends_after, RecurringEvent.until.is_(None))
+        )
 
     recur_query = recur_query.filter(and_(*after_criteria))
 

--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -454,8 +454,8 @@ def thread_api(public_id):
         thread = (
             g.db_session.query(Thread)
             .filter(
-                Thread.public_id == public_id,  # noqa
-                Thread.deleted_at == None,  # noqa
+                Thread.public_id == public_id,
+                Thread.deleted_at.is_(None),
                 Thread.namespace_id == g.namespace.id,
             )
             .one()
@@ -475,8 +475,8 @@ def thread_api_update(public_id):
         thread = (
             g.db_session.query(Thread)
             .filter(
-                Thread.public_id == public_id,  # noqa
-                Thread.deleted_at == None,  # noqa
+                Thread.public_id == public_id,
+                Thread.deleted_at.is_(None),
                 Thread.namespace_id == g.namespace.id,
             )
             .one()
@@ -1148,10 +1148,10 @@ def event_read_api(public_id):
             .filter(
                 Event.namespace_id == g.namespace.id,
                 Event.public_id == public_id,
-                Event.deleted_at == None,
+                Event.deleted_at.is_(None),
             )
             .one()
-        )  # noqa
+        )
     except NoResultFound:
         raise NotFoundError("Couldn't find event id {0}".format(public_id))
     return g.encoder.jsonify(event)
@@ -1170,10 +1170,10 @@ def event_update_api(public_id):
             .filter(
                 Event.public_id == public_id,
                 Event.namespace_id == g.namespace.id,
-                Event.deleted_at == None,
+                Event.deleted_at.is_(None),
             )
             .one()
-        )  # noqa
+        )
     except NoResultFound:
         raise NotFoundError("Couldn't find event {0}".format(public_id))
 
@@ -1272,10 +1272,10 @@ def event_delete_api(public_id):
             .filter(
                 Event.public_id == public_id,
                 Event.namespace_id == g.namespace.id,
-                Event.deleted_at == None,
+                Event.deleted_at.is_(None),
             )
             .one()
-        )  # noqa
+        )
     except NoResultFound:
         raise NotFoundError("Couldn't find event {0}".format(public_id))
 

--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -59,7 +59,6 @@ from inbox.api.validation import (
     strict_bool,
     strict_parse_args,
     timestamp,
-    valid_account,
     valid_category_type,
     valid_delta_object_types,
     valid_display_name,
@@ -290,7 +289,7 @@ def handle_generic_error(error):
     log_exception(sys.exc_info())
     response = flask_jsonify(
         message="An internal error occured. If this issue persists, please contact support@nylas.com and include this request_uid: {}".format(
-            request.headers.get("X-Unique-ID"), type="api_error"
+            request.headers.get("X-Unique-ID")
         )
     )
     response.status_code = 500

--- a/inbox/api/update.py
+++ b/inbox/api/update.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E266
 from datetime import datetime
 
 from nylas.logging import get_logger

--- a/inbox/api/validation.py
+++ b/inbox/api/validation.py
@@ -247,7 +247,7 @@ def get_thread(thread_public_id, namespace_id, db_session):
             db_session.query(Thread)
             .filter(
                 Thread.public_id == thread_public_id,
-                Thread.deleted_at == None,
+                Thread.deleted_at.is_(None),
                 Thread.namespace_id == namespace_id,
             )
             .one()

--- a/inbox/auth/base.py
+++ b/inbox/auth/base.py
@@ -11,8 +11,6 @@ from .utils import create_imap_connection
 
 log = get_logger()
 
-from .utils import create_imap_connection
-
 
 def handler_from_provider(provider_name):
     """

--- a/inbox/contacts/google.py
+++ b/inbox/contacts/google.py
@@ -8,10 +8,7 @@ import gdata.client
 import gdata.contacts.client
 import gevent
 from nylas.logging import get_logger
-from sqlalchemy.orm import joinedload
 
-from inbox.auth.google import GoogleAuthHandler
-from inbox.basicauth import ConnectionError, OAuthError, ValidationError
 from inbox.models import Contact
 from inbox.models.backends.gmail import GmailAccount
 from inbox.models.backends.oauth import token_manager

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -330,7 +330,7 @@ class CrispinClient(object):
         self.readonly = readonly
 
     def _fetch_folder_list(self):
-        """ NOTE: XLIST is deprecated, so we just use LIST.
+        r""" NOTE: XLIST is deprecated, so we just use LIST.
 
         An example response with some other flags:
 

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -12,7 +12,7 @@ import requests
 from nylas.logging import get_logger
 
 from inbox.auth.oauth import OAuthRequestsWrapper
-from inbox.basicauth import AccessNotEnabledError
+from inbox.basicauth import AccessNotEnabledError, OAuthError
 from inbox.config import config
 from inbox.events.util import (
     CalendarSyncResponse,

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -159,7 +159,7 @@ class GmailSyncMonitor(ImapSyncMonitor):
         old_labels = {
             label
             for label in db_session.query(Label).filter(
-                Label.account_id == self.account_id, Label.deleted_at == None
+                Label.account_id == self.account_id, Label.deleted_at.is_(None)
             )
         }  # noqa
 

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -71,7 +71,6 @@ from gevent import Greenlet
 from nylas.logging import get_logger
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import load_only
 from sqlalchemy.orm.exc import NoResultFound
 
 from inbox.basicauth import ValidationError

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -232,10 +232,10 @@ class SyncService(object):
                     or_(
                         and_(
                             Account.desired_sync_host == self.process_identifier,
-                            Account.sync_host == None,
-                        ),  # noqa
+                            Account.sync_host.is_(None),
+                        ),
                         and_(
-                            Account.desired_sync_host == None,  # noqa
+                            Account.desired_sync_host.is_(None),
                             Account.sync_host == self.process_identifier,
                         ),
                         and_(

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -1,21 +1,11 @@
-from collections import defaultdict, namedtuple
-from datetime import datetime, timedelta
-from random import shuffle
+from datetime import datetime
 
 from nylas.logging import get_logger
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, ForeignKey, String
-from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import backref, relationship
-from sqlalchemy.orm.session import object_session
+from sqlalchemy import Column, DateTime, ForeignKey, String
 
-from inbox.basicauth import ConnectionError, OAuthError
 from inbox.config import config
 from inbox.models.backends.imap import ImapAccount
 from inbox.models.backends.oauth import OAuthAccount
-from inbox.models.base import MailSyncBase
-from inbox.models.mixins import DeletedAtMixin, UpdatedAtMixin
-from inbox.models.secret import Secret
-from inbox.models.session import session_scope
 
 log = get_logger()
 

--- a/inbox/models/backends/imap.py
+++ b/inbox/models/backends/imap.py
@@ -188,7 +188,9 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
             else:
                 remote_labels.add((label, None))
 
-        local_labels = {(l.name, l.canonical_name): l for l in self.labels}
+        local_labels = {
+            (label.name, label.canonical_name): label for label in self.labels
+        }
 
         remove = set(local_labels) - remote_labels
         add = remote_labels - set(local_labels)
@@ -209,7 +211,7 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     @property
     def categories(self):
-        categories = set([l.category for l in self.labels])
+        categories = set([label.category for label in self.labels])
         categories.add(self.folder.category)
         return categories
 

--- a/inbox/models/transaction.py
+++ b/inbox/models/transaction.py
@@ -1,8 +1,7 @@
-import redis
 from sqlalchemy import BigInteger, Column, Enum, Index, String, func, inspect
 from sqlalchemy.orm import relationship
 
-from inbox.config import config
+from inbox.config import config  # noqa
 from inbox.ignition import redis_txn
 from inbox.models.base import MailSyncBase
 from inbox.models.category import EPOCH

--- a/inbox/models/util.py
+++ b/inbox/models/util.py
@@ -2,7 +2,7 @@ import math
 import time
 from collections import OrderedDict
 
-import gevent
+import gevent  # noqa
 import limitlion
 from nylas.logging import get_logger
 from nylas.logging.sentry import log_uncaught_errors

--- a/inbox/models/util.py
+++ b/inbox/models/util.py
@@ -1,11 +1,9 @@
-import datetime
 import math
 import time
 from collections import OrderedDict
 
 import gevent
 import limitlion
-import requests
 from nylas.logging import get_logger
 from nylas.logging.sentry import log_uncaught_errors
 from sqlalchemy import desc, func

--- a/inbox/s3/backends/gmail.py
+++ b/inbox/s3/backends/gmail.py
@@ -30,7 +30,7 @@ def get_gmail_raw_contents(message):
 
     hex_id = format(g_msgid, "x")
     url = "https://www.googleapis.com/gmail/v1/users/me/messages/{}?format=raw".format(
-        hex_id, "x"
+        hex_id
     )
     r = requests.get(url, auth=OAuthRequestsWrapper(auth_token))
 

--- a/inbox/search/backends/gmail.py
+++ b/inbox/search/backends/gmail.py
@@ -79,7 +79,7 @@ class GmailSearchClient(object):
             .join(Message, Message.thread_id == Thread.id)
             .filter(
                 Thread.namespace_id == self.account.namespace.id,
-                Thread.deleted_at == None,
+                Thread.deleted_at.is_(None),
                 Message.namespace_id == self.account.namespace.id,
                 Message.g_msgid.in_(g_msgids),
             )

--- a/inbox/search/backends/imap.py
+++ b/inbox/search/backends/imap.py
@@ -117,7 +117,7 @@ class IMAPSearchClient(object):
             .filter(
                 ImapUid.account_id == self.account_id,
                 ImapUid.msg_uid.in_(imap_uids),
-                Thread.deleted_at == None,
+                Thread.deleted_at.is_(None),
                 Thread.id == Message.thread_id,
             )
             .order_by(desc(Message.received_date))

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -168,7 +168,7 @@ class SyncbackService(gevent.Greenlet):
             return False
 
         log_entry = log_entries[0]
-        action_log_ids = [log_entry.id for log_entry in log_entries]
+        action_log_ids = [entry.id for entry in log_entries]
         # Check if there was a pending move action that recently completed.
         threshold = datetime.utcnow() - timedelta(seconds=90)
         actionlog = (

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -168,7 +168,7 @@ class SyncbackService(gevent.Greenlet):
             return False
 
         log_entry = log_entries[0]
-        action_log_ids = [l.id for l in log_entries]
+        action_log_ids = [log_entry.id for log_entry in log_entries]
         # Check if there was a pending move action that recently completed.
         threshold = datetime.utcnow() - timedelta(seconds=90)
         actionlog = (
@@ -212,7 +212,7 @@ class SyncbackService(gevent.Greenlet):
         account_id = namespace.account.id
         semaphore = self.account_semaphores[account_id]
 
-        actions = set([l.action for l in log_entries])
+        actions = set([label.action for label in log_entries])
         assert len(actions) == 1
         action = actions.pop()
 
@@ -243,9 +243,9 @@ class SyncbackService(gevent.Greenlet):
                 .all()
             )
 
-        record_ids = [l.record_id for l in log_entries]
+        record_ids = [log_entry.record_id for log_entry in log_entries]
 
-        log_entry_ids = [l.id for l in log_entries]
+        log_entry_ids = [log_entry.id for log_entry in log_entries]
 
         if action in ("move", "mark_unread"):
             extra_args = log_entries[-1].extra_args

--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -181,10 +181,10 @@ def cleanup_subject(subject_str):
         return ""
     # TODO consider expanding to all
     # http://en.wikipedia.org/wiki/List_of_email_subject_abbreviations
-    prefix_regexp = "(?i)^((re|fw|fwd|aw|wg|undeliverable|undelivered):\s*)+"
+    prefix_regexp = r"(?i)^((re|fw|fwd|aw|wg|undeliverable|undelivered):\s*)+"
     subject = re.sub(prefix_regexp, "", subject_str)
 
-    whitespace_regexp = "\s+"
+    whitespace_regexp = r"\s+"
     return re.sub(whitespace_regexp, " ", subject)
 
 

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -207,7 +207,7 @@ class MockIMAPClient(object):
             data.append("BODY[]")
         if isinstance(items, (int, long)):
             items = [items]
-        elif isinstance(items, basestring) and re.match("[0-9]+:\*", items):
+        elif isinstance(items, basestring) and re.match(r"[0-9]+:\*", items):
             min_uid = int(items.split(":")[0])
             items = {u for u in uid_dict if u >= min_uid} | {max(uid_dict)}
             if modifiers is not None:

--- a/inbox/util/threading.py
+++ b/inbox/util/threading.py
@@ -2,7 +2,7 @@
 from operator import attrgetter
 
 from sqlalchemy import desc
-from sqlalchemy.orm import contains_eager, load_only, outerjoin
+from sqlalchemy.orm import contains_eager, load_only
 
 from inbox.models.message import Message
 from inbox.models.thread import Thread

--- a/inbox/webhooks/gpush_notifications.py
+++ b/inbox/webhooks/gpush_notifications.py
@@ -1,6 +1,3 @@
-import random
-from datetime import datetime
-
 from flask import Blueprint, g, jsonify, make_response, request
 from nylas.logging import get_logger
 from sqlalchemy.orm.exc import NoResultFound

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -27,8 +27,6 @@ docutils==0.14
 enum34==1.0.4
 execnet==1.5.0
 faulthandler==2.3
-flake8==2.1.0
-flake8-pep3101==0.6
 git+https://github.com/closeio/flanker.git@c86e8c2599497f234988acfcef726bbc3228c787#egg=flanker
 Flask==0.10.1
 Flask-RESTful==0.3.2
@@ -62,7 +60,6 @@ lunatic-python-bugfix==1.1.1  # For Redis mocking in tests
 lxml==3.4.2
 Mako==1.0.7
 MarkupSafe==1.0
-mccabe==0.6.1
 mock==1.3.0
 mockredispy==2.9.0.10
 msgpack-python==0.4.2
@@ -72,7 +69,6 @@ ndg-httpsclient==0.4.3
 nylas==1.2.3
 nylas-production-python==0.4.2
 pbr==3.1.1
-pep8==1.4.6
 pluggy==0.3.1
 ply==3.10
 psutil==3.3.0
@@ -80,7 +76,6 @@ py==1.5.2
 pyaml==14.5.7
 pyasn1==0.2.3
 pycparser==2.18
-pyflakes==0.7.3
 pyinstrument==0.12
 pylint==1.5.1
 pymongo==2.5.2  # For json_util in bson

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,6 +1,7 @@
 appdirs==1.4.4
 attrs==20.2.0
 black==19.10b0
+flake8==3.9.2 
 click==7.1.2
 isort==5.4.2
 pathspec==0.8.0

--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,7 +1,6 @@
 appdirs==1.4.4
 attrs==20.2.0
 black==19.10b0
-flake8==3.9.2 
 click==7.1.2
 isort==5.4.2
 pathspec==0.8.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,4 @@
 # Allow out-of-tree submodules.
 from pkgutil import extend_path
 
-a = "\s"
-
 __path__ = extend_path(__path__, __name__)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,6 @@
 # Allow out-of-tree submodules.
 from pkgutil import extend_path
 
+a = "\s"
+
 __path__ = extend_path(__path__, __name__)

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -1,8 +1,6 @@
 import json
 from base64 import b64encode
 
-from pytest import fixture, yield_fixture
-
 
 def new_api_client(db, namespace):
     from inbox.api.srv import app
@@ -10,20 +8,6 @@ def new_api_client(db, namespace):
     app.config["TESTING"] = True
     with app.test_client() as c:
         return TestAPIClient(c, namespace.public_id)
-
-
-@yield_fixture
-def api_client(db, default_namespace):
-    from inbox.api.srv import app
-
-    app.config["TESTING"] = True
-    with app.test_client() as c:
-        yield TestAPIClient(c, default_namespace.public_id)
-
-
-@fixture
-def imap_api_client(db, generic_account):
-    return new_api_client(db, generic_account.namespace)
 
 
 class TestAPIClient(object):

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,8 @@
+from pytest import fixture
+
+from tests.api.base import new_api_client
+
+
+@fixture
+def imap_api_client(db, generic_account):
+    return new_api_client(db, generic_account.namespace)

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F811
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import add_fake_yahoo_account, db, generic_account, gmail_account
 
 __all__ = ["db", "api_client", "generic_account", "gmail_account"]

--- a/tests/api/test_calendars.py
+++ b/tests/api/test_calendars.py
@@ -1,9 +1,8 @@
 from inbox.models import Calendar
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_event, db, default_namespace
 
-__all__ = ["api_client", "db", "default_namespace"]
+__all__ = ["db", "default_namespace"]
 
 
 def test_get_calendar(db, default_namespace, api_client):
@@ -78,10 +77,8 @@ def test_delete_from_readonly_calendar(db, default_namespace, api_client):
         db.session,
         default_namespace.id,
         calendar=db.session.query(Calendar)
-        .filter(
-            Calendar.namespace_id == default_namespace.id, Calendar.read_only == True
-        )
-        .first(),  # noqa
+        .filter(Calendar.namespace_id == default_namespace.id, Calendar.read_only)
+        .first(),
         read_only=True,
     )
     calendar_list = api_client.get_data("/calendars")

--- a/tests/api/test_contacts.py
+++ b/tests/api/test_contacts.py
@@ -1,9 +1,8 @@
 from inbox.models import Contact
 
-from tests.api.base import api_client
 from tests.util.base import contact_sync, contacts_provider
 
-__all__ = ["contacts_provider", "contact_sync", "api_client"]
+__all__ = ["contacts_provider", "contact_sync"]
 
 
 def test_api_list(contacts_provider, contact_sync, db, api_client, default_namespace):

--- a/tests/api/test_data_processing.py
+++ b/tests/api/test_data_processing.py
@@ -4,10 +4,9 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from inbox.models import DataProcessingCache
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread, default_namespace
 
-__all__ = ["api_client", "default_namespace"]
+__all__ = ["default_namespace"]
 
 
 def test_contact_rankings(db, api_client, default_namespace):

--- a/tests/api/test_drafts.py
+++ b/tests/api/test_drafts.py
@@ -8,10 +8,7 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread
-
-__all__ = ["api_client"]
 
 
 @pytest.fixture

--- a/tests/api/test_event_participants.py
+++ b/tests/api/test_event_participants.py
@@ -2,10 +2,9 @@ import json
 
 import pytest
 
-from tests.api.base import api_client
 from tests.util.base import calendar
 
-__all__ = ["calendar", "api_client"]
+__all__ = ["calendar"]
 
 
 # TODO(emfree) WTF is all this crap anyways?

--- a/tests/api/test_event_when.py
+++ b/tests/api/test_event_when.py
@@ -3,10 +3,6 @@ import json
 import arrow
 import pytest
 
-from tests.api.base import api_client
-
-__all__ = ["api_client"]
-
 
 class CreateError(Exception):
     pass

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -4,10 +4,9 @@ from inbox.api.ns_api import API_VERSIONS
 from inbox.models import Calendar, Event
 from inbox.sqlalchemy_ext.util import generate_public_id
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_event, calendar, db
 
-__all__ = ["api_client", "calendar", "db"]
+__all__ = ["calendar", "db"]
 
 
 def test_create_event(db, api_client, calendar):

--- a/tests/api/test_events_recurring.py
+++ b/tests/api/test_events_recurring.py
@@ -6,7 +6,6 @@ import pytest
 
 from inbox.models import Calendar, Event
 
-from tests.api.base import api_client
 from tests.util.base import message
 
 __all__ = ["api_client"]

--- a/tests/api/test_files.py
+++ b/tests/api/test_files.py
@@ -10,10 +10,6 @@ import pytest
 from inbox.models import Block, Part
 from inbox.util.testutils import FILENAMES
 
-from tests.api.base import api_client
-
-__all__ = ["api_client"]
-
 
 @pytest.fixture
 def draft(db, default_account):

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -7,10 +7,9 @@ from sqlalchemy import desc
 from inbox.models import Block, Category, Message, Namespace, Thread
 from inbox.util.misc import dt_to_timestamp
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread, test_client
 
-__all__ = ["api_client", "test_client"]
+__all__ = ["test_client"]
 
 
 def test_filtering(db, api_client, default_namespace):
@@ -222,7 +221,7 @@ def test_filtering(db, api_client, default_namespace):
     assert results["count"] == 4
 
     results = api_client.get_data(
-        "/threads?view=ids&to={}&limit=3".format("inboxapptest@gmail.com", 3)
+        "/threads?view=ids&to={}&limit=3".format("inboxapptest@gmail.com")
     )
 
     assert len(results) == 3

--- a/tests/api/test_folders.py
+++ b/tests/api/test_folders.py
@@ -4,7 +4,6 @@ import mock
 
 from inbox.util.testutils import mock_imapclient  # noqa
 
-from tests.api.base import imap_api_client
 from tests.util.base import add_fake_category, add_fake_folder
 
 

--- a/tests/api/test_folders_labels.py
+++ b/tests/api/test_folders_labels.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from inbox.api.ns_api import API_VERSIONS
 from inbox.models.category import EPOCH, Category
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import (
     add_fake_message,
     add_fake_thread,

--- a/tests/api/test_invalid_account.py
+++ b/tests/api/test_invalid_account.py
@@ -5,10 +5,9 @@ import mock
 import pytest
 import requests
 
-from tests.api.base import api_client
 from tests.util.base import db
 
-__all__ = ["api_client", "db"]
+__all__ = ["db"]
 
 
 @pytest.fixture

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -7,7 +7,7 @@ import pytest
 from inbox.api.ns_api import API_VERSIONS
 from inbox.util.blockstore import get_from_blockstore
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import (
     add_fake_message,
     add_fake_thread,

--- a/tests/api/test_searching.py
+++ b/tests/api/test_searching.py
@@ -13,7 +13,6 @@ from inbox.search.backends.gmail import GmailSearchClient
 from inbox.search.backends.imap import IMAPSearchClient
 from inbox.search.base import get_search_client
 
-from tests.api.base import api_client, imap_api_client
 from tests.util.base import (
     add_fake_folder,
     add_fake_imapuid,

--- a/tests/api/test_sending.py
+++ b/tests/api/test_sending.py
@@ -16,7 +16,6 @@ from inbox.basicauth import OAuthError
 from inbox.models import Event, Message
 from inbox.sendmail.smtp.postel import _substitute_bcc
 
-from tests.api.base import api_client
 from tests.util.base import imported_event, message, thread
 
 __all__ = ["thread", "message", "api_client", "imported_event"]

--- a/tests/api/test_srv.py
+++ b/tests/api/test_srv.py
@@ -1,7 +1,5 @@
 import json
 
-from tests.api.base import api_client
-
 
 def test_create_generic_account(db, api_client):
     resp = api_client.post_data(

--- a/tests/api/test_streaming.py
+++ b/tests/api/test_streaming.py
@@ -6,13 +6,10 @@ from gevent import Greenlet
 
 from inbox.util.url import url_concat
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message
 
 GEVENT_EPSILON = 0.5  # Greenlet switching time. VMs on Macs suck :()
 LONGPOLL_EPSILON = 2 + GEVENT_EPSILON  # API implementation polls every second
-
-__all__ = ["api_client"]
 
 
 @pytest.yield_fixture

--- a/tests/api/test_threads.py
+++ b/tests/api/test_threads.py
@@ -5,10 +5,9 @@ import pytest
 
 from inbox.api.ns_api import API_VERSIONS
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread, db, default_account
 
-__all__ = ["db", "api_client", "default_account"]
+__all__ = ["db", "default_account"]
 
 
 def test_thread_received_recent_date(db, api_client, default_account):

--- a/tests/api/test_validation.py
+++ b/tests/api/test_validation.py
@@ -6,10 +6,9 @@ import pytest
 from inbox.api.validation import noop_event_update, valid_email
 from inbox.models import Namespace
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_event, calendar, db
 
-__all__ = ["api_client", "db", "calendar"]
+__all__ = ["db", "calendar"]
 
 
 # TODO(emfree): Add more comprehensive parameter-validation tests.

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -1,7 +1,7 @@
 # flake8: noqa: F811
 import pytest
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import generic_account
 
 __all__ = ["api_client", "generic_account"]

--- a/tests/auth/test_generic_auth.py
+++ b/tests/auth/test_generic_auth.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-import copy
 import socket
 
 import attr
 import pytest
 
 from inbox.auth.generic import GenericAccountData, GenericAuthHandler
-from inbox.basicauth import SettingUpdateError, ValidationError
+from inbox.basicauth import ValidationError
 from inbox.models.account import Account
 from inbox.util.url import parent_domain
 

--- a/tests/auth/test_gmail_auth.py
+++ b/tests/auth/test_gmail_auth.py
@@ -1,7 +1,4 @@
-import copy
-
 import attr
-import mock
 import pytest
 
 from inbox.auth.google import GoogleAccountData, GoogleAuthHandler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,24 @@ import gevent_openssl
 
 gevent_openssl.monkey_patch()
 
+from pytest import yield_fixture
+
 from inbox.util.testutils import files  # noqa
 from inbox.util.testutils import mock_dns_resolver  # noqa
 from inbox.util.testutils import mock_imapclient  # noqa
 from inbox.util.testutils import mock_smtp_get_connection  # noqa
-from inbox.util.testutils import uploaded_file_ids
+from inbox.util.testutils import uploaded_file_ids  # noqa
 
+from tests.api.base import TestAPIClient
 from tests.util.base import *  # noqa
 
 from inbox.util.testutils import dump_dns_queries  # noqa; noqa
+
+
+@yield_fixture
+def api_client(db, default_namespace):
+    from inbox.api.srv import app
+
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield TestAPIClient(c, default_namespace.public_id)

--- a/tests/events/test_recurrence.py
+++ b/tests/events/test_recurrence.py
@@ -619,7 +619,7 @@ def test_rrule_to_json():
     r = rrulestr(r, dtstart=None)
     j = rrule_to_json(r)
     assert j.get("until") is None
-    assert j.get("byminute") is 42
+    assert j.get("byminute") == 42
 
 
 def test_master_cancelled(db, default_account, calendar):

--- a/tests/general/test_lock.py
+++ b/tests/general/test_lock.py
@@ -26,33 +26,33 @@ def nb_lock():
     return lock(block=False)
 
 
-def grab_lock(l):
+def grab_lock(lock):
     """ Stub fn to grab lock inside a Greenlet. """
-    l.acquire()
-    print "Got the lock again", l.filename
-    l.release()
+    lock.acquire()
+    print "Got the lock again", lock.filename
+    lock.release()
 
 
 def test_nb_lock(nb_lock):
-    with nb_lock as l:
-        filename = l.filename
+    with nb_lock as lock_:
+        filename = lock_.filename
         with pytest.raises(IOError):
             with lock(block=False, filename=filename):
                 pass
     # Should be able to acquire the lock again after the scope ends (also
     # testing that the non-context-manager acquire works).
-    l.acquire()
+    lock_.acquire()
     # Should NOT be able to take the same lock from a Greenlet.
-    g = spawn(grab_lock, l)
+    g = spawn(grab_lock, lock_)
     g.join()
     assert not g.successful(), "greenlet should throw error"
-    l.release()
+    lock_.release()
 
 
 def test_b_lock(b_lock):
-    with b_lock as l:
+    with b_lock as lock:
         # A greenlet should hang forever if it tries to acquire this lock.
-        g = spawn(grab_lock, l)
+        g = spawn(grab_lock, lock)
         # Wait long enough that the greenlet ought to be able to finish if
         # it's not blocking, but not long enough to make the test suite hella
         # slow.

--- a/tests/imap/network/test_send.py
+++ b/tests/imap/network/test_send.py
@@ -3,11 +3,10 @@ from datetime import datetime
 
 import pytest
 
-from tests.api.base import api_client
 from tests.util.base import default_account
 from tests.util.crispin import crispin_client
 
-__all__ = ["default_account", "api_client"]
+__all__ = ["default_account"]
 
 
 @pytest.fixture

--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -658,7 +658,7 @@ def test_gmail_many_folders_one_role(monkeypatch, constants):
     # in both cases, only one should come out flagged.
     folders = constants["gmail_folders"]
     duplicates = [
-        (("\HasNoChildren"), "/", u"[Imap]/Trash"),
+        (("\\HasNoChildren"), "/", u"[Imap]/Trash"),
         (("\\HasNoChildren"), "/", u"[Imap]/Sent"),
     ]
     folders += duplicates
@@ -744,7 +744,7 @@ def test_imap_many_folders_one_role(monkeypatch, constants):
     """
     folders = constants["imap_folders"]
     duplicates = [
-        (("\HasNoChildren", "\\Trash"), "/", u"[Gmail]/Trash"),
+        (("\\HasNoChildren", "\\Trash"), "/", u"[Gmail]/Trash"),
         (("\\HasNoChildren"), "/", u"[Gmail]/Sent"),
     ]
     folders += duplicates

--- a/tests/imap/test_full_imap_enabled.py
+++ b/tests/imap/test_full_imap_enabled.py
@@ -1,9 +1,5 @@
-import pytest
 from imapclient import IMAPClient
 from mock import Mock
-
-from inbox.auth.generic import GenericAuthHandler
-from inbox.basicauth import UserRecoverableConfigError
 
 
 class MockIMAPClient(IMAPClient):

--- a/tests/imap/test_labels.py
+++ b/tests/imap/test_labels.py
@@ -4,7 +4,6 @@ import pytest
 
 from inbox.mailsync.backends.imap.common import update_message_metadata
 
-from tests.api.base import api_client
 from tests.util.base import (
     add_fake_folder,
     add_fake_imapuid,
@@ -13,7 +12,7 @@ from tests.util.base import (
     default_account,
 )
 
-__all__ = ["default_account", "api_client"]
+__all__ = ["default_account"]
 
 
 def add_fake_label(db_session, default_account, display_name, name):

--- a/tests/imap/test_labels.py
+++ b/tests/imap/test_labels.py
@@ -156,14 +156,17 @@ def test_adding_trash_or_spam_removes_inbox(
     resp_data = api_client.get_data("/messages/{}".format(message.public_id))
     labels = resp_data["labels"]
     assert len(labels) == 2
-    assert set([l["name"] for l in labels]) == set(["all", "inbox"])
+    assert set([label_["name"] for label_ in labels]) == set(["all", "inbox"])
 
     # Adding 'trash'/ 'spam' removes 'inbox' (and 'all'),
     # irrespective of whether it's provided in the request or not.
     label_to_add = folder_map[label]
     response = api_client.put_data(
         "/messages/{}".format(message.public_id),
-        {"label_ids": [label_to_add.category.public_id] + [l["id"] for l in labels]},
+        {
+            "label_ids": [label_to_add.category.public_id]
+            + [label_["id"] for label_ in labels]
+        },
     )
     labels = json.loads(response.data)["labels"]
     assert len(labels) == 1
@@ -186,21 +189,21 @@ def test_adding_a_mutually_exclusive_label_does_not_affect_custom_labels(
         resp_data = api_client.get_data("/messages/{}".format(message.public_id))
         labels = resp_data["labels"]
         assert len(labels) == 2
-        assert key in [l["name"] for l in labels]
-        assert "<3" in [l["display_name"] for l in labels]
+        assert key in [label_["name"] for label_ in labels]
+        assert "<3" in [label_["display_name"] for label_ in labels]
 
         # Adding only 'all'/ 'trash'/ 'spam' does not change custom labels.
         response = api_client.put_data(
             "/messages/{}".format(message.public_id),
             {
                 "label_ids": [label_to_add.category.public_id]
-                + [l["id"] for l in labels]
+                + [label_["id"] for label_ in labels]
             },
         )
         labels = json.loads(response.data)["labels"]
         assert len(labels) == 2
-        assert label in [l["name"] for l in labels]
-        assert "<3" in [l["display_name"] for l in labels]
+        assert label in [label_["name"] for label_ in labels]
+        assert "<3" in [label_["display_name"] for label_ in labels]
 
 
 @pytest.mark.parametrize("label", ["all", "trash", "spam"])
@@ -230,7 +233,7 @@ def test_adding_inbox_adds_all_and_removes_trash_spam(
     db.session.commit()
     labels = json.loads(response.data)["labels"]
     assert len(labels) == 2
-    assert set([l["name"] for l in labels]) == set(["all", "inbox"])
+    assert set([label_["name"] for label_ in labels]) == set(["all", "inbox"])
 
 
 @pytest.mark.parametrize("label", ["all", "trash", "spam"])
@@ -257,8 +260,8 @@ def test_adding_a_custom_label_preserves_other_labels(
     )
     labels = json.loads(response.data)["labels"]
     assert len(labels) == 2
-    assert set([l["name"] for l in labels]) == set([label, None])
-    assert "<3" in [l["display_name"] for l in labels]
+    assert set([label_["name"] for label_ in labels]) == set([label, None])
+    assert "<3" in [label_["display_name"] for label_ in labels]
 
 
 @pytest.mark.parametrize("label", ["all", "trash", "spam"])
@@ -284,5 +287,5 @@ def test_removing_a_mutually_exclusive_label_does_not_orphan_a_message(
     )
     labels = json.loads(response.data)["labels"]
     assert len(labels) == 2
-    assert set([l["name"] for l in labels]) == set([label, None])
-    assert "<3" in [l["display_name"] for l in labels]
+    assert set([label_["name"] for label_ in labels]) == set([label, None])
+    assert "<3" in [label_["display_name"] for label_ in labels]

--- a/tests/imap/test_smtp.py
+++ b/tests/imap/test_smtp.py
@@ -42,7 +42,6 @@ def test_use_starttls():
 @pytest.mark.skipif(True, reason="Need to investigate")
 @pytest.mark.networkrequired
 def test_use_plain():
-    ssl = True
     with pytest.raises(SendMailException):
         conn = SMTPConnection(
             account_id=1,
@@ -54,7 +53,6 @@ def test_use_plain():
             log=get_logger(),
         )
 
-    ssl = False
     conn = SMTPConnection(
         account_id=1,
         email_address="test@tivertical.com",

--- a/tests/search/conftest.py
+++ b/tests/search/conftest.py
@@ -1,4 +1,0 @@
-from tests.api.base import api_client
-from tests.util.base import absolute_path, config, db, default_namespace
-
-__all__ = ["config", "db", "absolute_path", "default_namespace", "api_client"]

--- a/tests/security/test_smtp_ssl.py
+++ b/tests/security/test_smtp_ssl.py
@@ -10,7 +10,7 @@ import sys
 import gevent
 import pytest
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import default_account
 
 smtpd.DEBUGSTREAM = sys.stderr

--- a/tests/transactions/test_delta_sync.py
+++ b/tests/transactions/test_delta_sync.py
@@ -4,10 +4,7 @@ import time
 
 from freezegun import freeze_time
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message
-
-__all__ = ["api_client"]
 
 
 def add_account_with_different_namespace_id(


### PR DESCRIPTION
Some parts of the code hint me that there used to be Flake8 running on this code. For the sake of more safety let's bring that static analysis back. I brought back the latest version of Flake8

Problems that needed to be fixed:
- comparing `None` and `True` with `==` in sqlalchemy queries
- dead imports
- mixing tabs and spaces, missing new lines
- incorrect string escapes in regexps such as `"\s"` (needs to be either `"\\s"` or `r"\s"`)
- nondescriptive var names

One particularly annoying problem I had to solve is incorrectly using imports to make pytest fixtures visible instead of relying on coftests.py / plugins. This chokes flake8 because fixture such as `api_client` would be imported and then used as a param in test which shadows the original import. I moved fixtures to conftest.py.
