### PR TITLE
Remove pytest-xdist

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -1,6 +1,5 @@
 alembic==0.6.5
 aniso8601==2.0.0
-apipkg==1.4
 arrow==0.5.4
 asn1crypto==0.24.0
 astroid==1.6.1
@@ -25,7 +24,6 @@ cryptography==2.1.4
 dnspython==1.11.1
 docutils==0.14
 enum34==1.0.4
-execnet==1.5.0
 faulthandler==2.3
 flake8==2.1.0
 flake8-pep3101==0.6
@@ -89,7 +87,6 @@ PyMySQL==0.6.2
 PyNaCl==0.3.0
 pyOpenSSL==17.5.0
 pytest==2.8.3
-pytest-xdist==1.13.1
 git+https://github.com/nylas/dateutil.git@da336a366cd3f31e3bd7ca925e676e169189e48d#egg=python-dateutil
 python-magic==0.4.6
 pytz==2017.3


### PR DESCRIPTION
It looks like the support for running tests in parallel has been long rotten.

If I try to enable xdist with 1 node I get:

```
============================ test session starts =============================
platform linux2 -- Python 2.7.12, pytest-2.8.3, py-1.5.2, pluggy-0.3.1
rootdir: /opt/app, inifile: 
plugins: xdist-1.13.1
gw0 okINTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/main.py", line 90, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/main.py", line 121, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 596, in execute
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "<remote exec>", line 47, in pytest_runtestloop
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/execnet/gateway_base.py", line 732, in receive
INTERNALERROR>     x = itemqueue.get(timeout=timeout)
INTERNALERROR>   File "/usr/lib/python2.7/Queue.py", line 168, in get
INTERNALERROR>     self.not_empty.wait()
INTERNALERROR>   File "/usr/lib/python2.7/threading.py", line 340, in wait
INTERNALERROR>     waiter.acquire()
INTERNALERROR>   File "gevent/_semaphore.py", line 198, in gevent._semaphore.Semaphore.acquire (gevent/gevent._semaphore.c:4117)
INTERNALERROR>     def acquire(self, blocking=True, timeout=None):
INTERNALERROR>   File "gevent/_semaphore.py", line 226, in gevent._semaphore.Semaphore.acquire (gevent/gevent._semaphore.c:3944)
INTERNALERROR>     timeout = self._do_wait(timeout)
INTERNALERROR>   File "gevent/_semaphore.py", line 166, in gevent._semaphore.Semaphore._do_wait (gevent/gevent._semaphore.c:3178)
INTERNALERROR>     result = get_hub().switch()
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/gevent/hub.py", line 609, in switch
INTERNALERROR>     return greenlet.switch(self)
INTERNALERROR> LoopExit: ('This operation would block forever', <Hub at 0x7f7de99420f0 epoll default pending=0 ref=0 fileno=30 resolver=<gevent.resolver_thread.Resolver at 0x7f7de251dcd0 pool=<ThreadPool at 0x7f7de2282510 0/1/10>> threadpool=<ThreadPool at 0x7f7de2282510 0/1/10>>)
gw0 [590]
scheduling tests via LoadScheduling
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/main.py", line 90, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/main.py", line 121, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 724, in __call__
INTERNALERROR>     return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 338, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 333, in <lambda>
INTERNALERROR>     _MultiCall(methods, kwargs, hook.spec_opts).execute()
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/_pytest/vendored_packages/pluggy.py", line 596, in execute
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/xdist/dsession.py", line 521, in pytest_runtestloop
INTERNALERROR>     self.loop_once()
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/xdist/dsession.py", line 539, in loop_once
INTERNALERROR>     call(**kwargs)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/xdist/dsession.py", line 629, in slave_collectionfinish
INTERNALERROR>     self.sched.init_distribute()
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/xdist/dsession.py", line 371, in init_distribute
INTERNALERROR>     self._send_tests(node, node_chunksize)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/xdist/dsession.py", line 378, in _send_tests
INTERNALERROR>     node.send_runtest_some(tests_per_node)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/xdist/slavemanage.py", line 237, in send_runtest_some
INTERNALERROR>     self.sendcommand("runtests", indices=indices)
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/xdist/slavemanage.py", line 252, in sendcommand
INTERNALERROR>     self.channel.send((name, kwargs))
INTERNALERROR>   File "/opt/venv/local/lib/python2.7/site-packages/execnet/gateway_base.py", line 716, in send
INTERNALERROR>     raise IOError("cannot send to %r" % (self,))
INTERNALERROR> IOError: cannot send to <Channel id=1 closed>

=============================  in 11.11 seconds ==============================
ERROR: 3
```

This can be solved by downgrading execnet to a version compatible with gevent.

If I do that I hit the next roadblock: tests are written in a way they no longer work in parallel. For this reason it would be better to remove it fully at least for now.
