### PR TITLE
Upgrade hypothesis

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -44,7 +44,7 @@ guppy==0.1.10
 hiredis==0.1.5
 html2text==2014.9.8
 httplib2==0.8
-hypothesis==1.10.3
+hypothesis==4.57.1
 icalendar==3.9.1
 iconv==1.0
 idna==2.6

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -14,7 +14,6 @@ os.environ["HYPOTHESIS_DATABASE_FILE"] = os.path.join(hyp_dir, "db")
 import flanker
 from flanker import mime
 from hypothesis import strategies as s
-from hypothesis.extra.datetime import datetimes
 
 
 def _build_address_header(addresslist):
@@ -78,7 +77,7 @@ randint = s.basic(generate=lambda random, _: random.getrandbits(63))
 
 uid_data = s.builds(
     build_uid_data,
-    datetimes(timezones=[]),
+    s.datetimes(timezones=[]),
     s.sampled_from([(), ("\\Seen",)]),
     mime_message,
     s.sampled_from([(), ("\\Inbox",)]),

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -69,7 +69,7 @@ mime_message = s.builds(
     basic_text,
 )
 
-randint = s.integers(0, 1 << 62)
+randint = s.integers(min_value=0, max_value=1 << 63)
 
 uid_data = s.builds(
     build_uid_data,
@@ -82,4 +82,6 @@ uid_data = s.builds(
 )
 
 
-uids = s.dictionaries(s.integers(min_value=22), uid_data, min_size=5, max_size=10)
+uids = s.dictionaries(
+    s.integers(min_value=22, max_value=1 << 63), uid_data, min_size=5, max_size=10
+)

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -7,10 +7,6 @@ import os
 import string
 import tempfile
 
-# don't try writing to .hypothesis
-os.environ["HYPOTHESIS_STORAGE_DIRECTORY"] = hyp_dir = tempfile.mkdtemp()
-os.environ["HYPOTHESIS_DATABASE_FILE"] = os.path.join(hyp_dir, "db")
-
 import flanker
 from flanker import mime
 from hypothesis import strategies as s
@@ -73,11 +69,11 @@ mime_message = s.builds(
     basic_text,
 )
 
-randint = s.basic(generate=lambda random, _: random.getrandbits(63))
+randint = s.integers(0, 1 << 62)
 
 uid_data = s.builds(
     build_uid_data,
-    s.datetimes(timezones=[]),
+    s.datetimes(),
     s.sampled_from([(), ("\\Seen",)]),
     mime_message,
     s.sampled_from([(), ("\\Inbox",)]),

--- a/tests/security/test_blobstorage.py
+++ b/tests/security/test_blobstorage.py
@@ -1,18 +1,19 @@
 import zlib
 
 import hypothesis
+from hypothesis import strategies as s
 
 from inbox.security.blobstorage import decode_blob, encode_blob
 
 
 # This will run the test for a bunch of randomly-chosen values of sample_input.
-@hypothesis.given(str, bool)
+@hypothesis.given(s.binary(), s.booleans())
 def test_blobstorage(config, sample_input, encrypt):
     config["ENCRYPT_SECRETS"] = encrypt
     assert decode_blob(encode_blob(sample_input)) == sample_input
 
 
-@hypothesis.given(str, bool)
+@hypothesis.given(s.binary(), s.booleans())
 def test_encoded_format(config, sample_input, encrypt):
     config["ENCRYPT_SECRETS"] = encrypt
     encoded = encode_blob(sample_input)
@@ -25,7 +26,7 @@ def test_encoded_format(config, sample_input, encrypt):
         assert data == zlib.compress(sample_input)
 
 
-@hypothesis.given(unicode, bool)
+@hypothesis.given(s.text(), s.booleans())
 def test_message_body_storage(config, message, sample_input, encrypt):
     config["ENCRYPT_SECRETS"] = encrypt
     message.body = None


### PR DESCRIPTION
This is the last version support Python 2.

It also solves this kind of DeprecationWarnings:

```
security/test_blobstorage.py::test_message_body_storage
security/test_blobstorage.py::test_encoded_format
security/test_blobstorage.py::test_blobstorage
  /opt/venv/local/lib/python2.7/site-packages/hypothesis/core.py:517: HypothesisDeprecationWarning: Calling strategy with non-strategy object <type 'bool'> is deprecated and will be removed in Hypothesis 2.0. Use the functions in hypothesis.strategies instead.
    return strategy(v.value, settings)
```
