### PR TITLE
Flake8: fix broken escapes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,8 +14,6 @@ ignore=
     F522
     # TODO: expected 2 blank lines after class or function definition
     E305
-    # TODO: invalid escape sequence
-    W605
     # TODO: too many leading '#' for block comment
     E266
     # do not use bare 'except'

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -38,10 +38,10 @@ from inbox.util.startup import preflight
 SOCKET_TIMEOUT = 2 * 60
 socket.setdefaulttimeout(SOCKET_TIMEOUT)
 
+esc = "\033"
 
 banner = (
-    "\033[1;95m"
-    r"""
+    r"""{esc}[1;95m
       _   _       _
      | \ | |     | |
      |  \| |_   _| | __ _ ___
@@ -50,15 +50,12 @@ banner = (
      \_| \_/\__, |_|\__,_|___/
              __/ |
             |___/
-    """
-    "\033[0m\033[94m"
-    """
+     {esc}[0m{esc}[94m
       S Y N C   E N G I N E
-    """
-    "\033[0m"
-    """
+
+     {esc}[0m
      Use CTRL-C to stop.
-    """
+    """.format(esc=esc)
 )
 
 

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -40,8 +40,7 @@ socket.setdefaulttimeout(SOCKET_TIMEOUT)
 
 esc = "\033"
 
-banner = (
-    r"""{esc}[1;95m
+banner = r"""{esc}[1;95m
       _   _       _
      | \ | |     | |
      |  \| |_   _| | __ _ ___
@@ -56,7 +55,6 @@ banner = (
      {esc}[0m
      Use CTRL-C to stop.
     """.format(esc=esc)
-)
 
 
 @click.command()

--- a/bin/inbox-start
+++ b/bin/inbox-start
@@ -39,6 +39,29 @@ SOCKET_TIMEOUT = 2 * 60
 socket.setdefaulttimeout(SOCKET_TIMEOUT)
 
 
+banner = (
+    "\033[1;95m"
+    r"""
+      _   _       _
+     | \ | |     | |
+     |  \| |_   _| | __ _ ___
+     | . ` | | | | |/ _` / __|
+     | |\  | |_| | | (_| \__ \
+     \_| \_/\__, |_|\__,_|___/
+             __/ |
+            |___/
+    """
+    "\033[0m\033[94m"
+    """
+      S Y N C   E N G I N E
+    """
+    "\033[0m"
+    """
+     Use CTRL-C to stop.
+    """
+)
+
+
 @click.command()
 @click.option('--prod/--no-prod', default=False,
               help='Disables the autoreloader and potentially other '
@@ -88,20 +111,7 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
              total_processes=total_processes,
              recursion_limit=sys.getrecursionlimit())
 
-    print >>sys.stderr, """\033[1;95m
-      _   _       _
-     | \ | |     | |
-     |  \| |_   _| | __ _ ___
-     | . ` | | | | |/ _` / __|
-     | |\  | |_| | | (_| \__ \\
-     \_| \_/\__, |_|\__,_|___/
-             __/ |
-            |___/
-\033[0m\033[94m
-      S Y N C   E N G I N E \033[0m
-
-     Use CTRL-C to stop.
-     """
+    print >>sys.stderr, banner
 
     if enable_profiler:
         inbox_config['DEBUG_PROFILING_ON'] = True

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -330,7 +330,7 @@ class CrispinClient(object):
         self.readonly = readonly
 
     def _fetch_folder_list(self):
-        """ NOTE: XLIST is deprecated, so we just use LIST.
+        r""" NOTE: XLIST is deprecated, so we just use LIST.
 
         An example response with some other flags:
 

--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -181,10 +181,10 @@ def cleanup_subject(subject_str):
         return ""
     # TODO consider expanding to all
     # http://en.wikipedia.org/wiki/List_of_email_subject_abbreviations
-    prefix_regexp = "(?i)^((re|fw|fwd|aw|wg|undeliverable|undelivered):\s*)+"
+    prefix_regexp = r"(?i)^((re|fw|fwd|aw|wg|undeliverable|undelivered):\s*)+"
     subject = re.sub(prefix_regexp, "", subject_str)
 
-    whitespace_regexp = "\s+"
+    whitespace_regexp = r"\s+"
     return re.sub(whitespace_regexp, " ", subject)
 
 

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -207,7 +207,7 @@ class MockIMAPClient(object):
             data.append("BODY[]")
         if isinstance(items, (int, long)):
             items = [items]
-        elif isinstance(items, basestring) and re.match("[0-9]+:\*", items):
+        elif isinstance(items, basestring) and re.match(r"[0-9]+:\*", items):
             min_uid = int(items.split(":")[0])
             items = {u for u in uid_dict if u >= min_uid} | {max(uid_dict)}
             if modifiers is not None:

--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -658,7 +658,7 @@ def test_gmail_many_folders_one_role(monkeypatch, constants):
     # in both cases, only one should come out flagged.
     folders = constants["gmail_folders"]
     duplicates = [
-        (("\HasNoChildren"), "/", u"[Imap]/Trash"),
+        (("\\HasNoChildren"), "/", u"[Imap]/Trash"),
         (("\\HasNoChildren"), "/", u"[Imap]/Sent"),
     ]
     folders += duplicates
@@ -744,7 +744,7 @@ def test_imap_many_folders_one_role(monkeypatch, constants):
     """
     folders = constants["imap_folders"]
     duplicates = [
-        (("\HasNoChildren", "\\Trash"), "/", u"[Gmail]/Trash"),
+        (("\\HasNoChildren", "\\Trash"), "/", u"[Gmail]/Trash"),
         (("\\HasNoChildren"), "/", u"[Gmail]/Sent"),
     ]
     folders += duplicates


### PR DESCRIPTION
"\s" would be first escaped on a string level, but since there is no such \s escape it's just included as it is. This is error-prone. Use r"\s" or "\\s" instead.