### PR TITLE
wait-for-it.sh on PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ RUN \
   pip install -r requirements_frozen.txt && \
   pip install -e .
 
+RUN ln -s /opt/app/bin/wait-for-it.sh /opt/venv/bin/
+
 ENV \
   LANG="en_US.UTF-8" \
   LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
Fixes: https://github.com/closeio/sync-engine/issues/72

```
❯ docker-compose run app wait-for-it.sh    
Creating sync-engine_app_run ... done
Error: you need to provide a host and port to test.
Usage:
    wait-for-it.sh host:port [-s] [-t timeout] [-- command args]
    -h HOST | --host=HOST       Host or IP under test
    -p PORT | --port=PORT       TCP port under test
                                Alternatively, you specify the host and port as host:port
    -s | --strict               Only execute subcommand if the test succeeds
    -q | --quiet                Don't output any status messages
    -t TIMEOUT | --timeout=TIMEOUT
                                Timeout in seconds, zero for no timeout
    -- COMMAND ARGS             Execute command with args after the test finishes
```