### PR TITLE
Cleanup fixtures for Flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,8 +2,6 @@
 ignore=
     # TODO: undefined name 'name'
     F821
-    # TODO: redefinition of unused 'symbol' from line n
-    F811
     # TODO: 'module' imported but unused
     F401
     # TODO: expected 2 blank lines after class or function definition

--- a/tests/api/base.py
+++ b/tests/api/base.py
@@ -1,8 +1,6 @@
 import json
 from base64 import b64encode
 
-from pytest import fixture, yield_fixture
-
 
 def new_api_client(db, namespace):
     from inbox.api.srv import app
@@ -10,20 +8,6 @@ def new_api_client(db, namespace):
     app.config["TESTING"] = True
     with app.test_client() as c:
         return TestAPIClient(c, namespace.public_id)
-
-
-@yield_fixture
-def api_client(db, default_namespace):
-    from inbox.api.srv import app
-
-    app.config["TESTING"] = True
-    with app.test_client() as c:
-        yield TestAPIClient(c, default_namespace.public_id)
-
-
-@fixture
-def imap_api_client(db, generic_account):
-    return new_api_client(db, generic_account.namespace)
 
 
 class TestAPIClient(object):

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1,5 +1,5 @@
 # flake8: noqa: F811
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import add_fake_yahoo_account, db, generic_account, gmail_account
 
 __all__ = ["db", "api_client", "generic_account", "gmail_account"]

--- a/tests/api/test_calendars.py
+++ b/tests/api/test_calendars.py
@@ -2,10 +2,9 @@ from sqlalchemy import true
 
 from inbox.models import Calendar
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_event, db, default_namespace
 
-__all__ = ["api_client", "db", "default_namespace"]
+__all__ = ["db", "default_namespace"]
 
 
 def test_get_calendar(db, default_namespace, api_client):

--- a/tests/api/test_contacts.py
+++ b/tests/api/test_contacts.py
@@ -1,9 +1,8 @@
 from inbox.models import Contact
 
-from tests.api.base import api_client
 from tests.util.base import contact_sync, contacts_provider
 
-__all__ = ["contacts_provider", "contact_sync", "api_client"]
+__all__ = ["contacts_provider", "contact_sync"]
 
 
 def test_api_list(contacts_provider, contact_sync, db, api_client, default_namespace):

--- a/tests/api/test_data_processing.py
+++ b/tests/api/test_data_processing.py
@@ -4,10 +4,9 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from inbox.models import DataProcessingCache
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread, default_namespace
 
-__all__ = ["api_client", "default_namespace"]
+__all__ = ["default_namespace"]
 
 
 def test_contact_rankings(db, api_client, default_namespace):

--- a/tests/api/test_drafts.py
+++ b/tests/api/test_drafts.py
@@ -8,10 +8,7 @@ from datetime import datetime
 import pytest
 from freezegun import freeze_time
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread
-
-__all__ = ["api_client"]
 
 
 @pytest.fixture

--- a/tests/api/test_event_participants.py
+++ b/tests/api/test_event_participants.py
@@ -2,10 +2,9 @@ import json
 
 import pytest
 
-from tests.api.base import api_client
 from tests.util.base import calendar
 
-__all__ = ["calendar", "api_client"]
+__all__ = ["calendar"]
 
 
 # TODO(emfree) WTF is all this crap anyways?

--- a/tests/api/test_event_when.py
+++ b/tests/api/test_event_when.py
@@ -3,10 +3,6 @@ import json
 import arrow
 import pytest
 
-from tests.api.base import api_client
-
-__all__ = ["api_client"]
-
 
 class CreateError(Exception):
     pass

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -4,10 +4,9 @@ from inbox.api.ns_api import API_VERSIONS
 from inbox.models import Calendar, Event
 from inbox.sqlalchemy_ext.util import generate_public_id
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_event, calendar, db
 
-__all__ = ["api_client", "calendar", "db"]
+__all__ = ["calendar", "db"]
 
 
 def test_create_event(db, api_client, calendar):

--- a/tests/api/test_events_recurring.py
+++ b/tests/api/test_events_recurring.py
@@ -6,7 +6,6 @@ import pytest
 
 from inbox.models import Calendar, Event
 
-from tests.api.base import api_client
 from tests.util.base import message
 
 __all__ = ["api_client"]

--- a/tests/api/test_files.py
+++ b/tests/api/test_files.py
@@ -10,10 +10,6 @@ import pytest
 from inbox.models import Block, Part
 from inbox.util.testutils import FILENAMES
 
-from tests.api.base import api_client
-
-__all__ = ["api_client"]
-
 
 @pytest.fixture
 def draft(db, default_account):

--- a/tests/api/test_filtering.py
+++ b/tests/api/test_filtering.py
@@ -7,10 +7,9 @@ from sqlalchemy import desc
 from inbox.models import Block, Category, Message, Namespace, Thread
 from inbox.util.misc import dt_to_timestamp
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread, test_client
 
-__all__ = ["api_client", "test_client"]
+__all__ = ["test_client"]
 
 
 def test_filtering(db, api_client, default_namespace):

--- a/tests/api/test_folders.py
+++ b/tests/api/test_folders.py
@@ -4,7 +4,6 @@ import mock
 
 from inbox.util.testutils import mock_imapclient  # noqa
 
-from tests.api.base import imap_api_client
 from tests.util.base import add_fake_category, add_fake_folder
 
 

--- a/tests/api/test_folders_labels.py
+++ b/tests/api/test_folders_labels.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from inbox.api.ns_api import API_VERSIONS
 from inbox.models.category import EPOCH, Category
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import (
     add_fake_message,
     add_fake_thread,

--- a/tests/api/test_invalid_account.py
+++ b/tests/api/test_invalid_account.py
@@ -5,10 +5,9 @@ import mock
 import pytest
 import requests
 
-from tests.api.base import api_client
 from tests.util.base import db
 
-__all__ = ["api_client", "db"]
+__all__ = ["db"]
 
 
 @pytest.fixture

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -7,7 +7,7 @@ import pytest
 from inbox.api.ns_api import API_VERSIONS
 from inbox.util.blockstore import get_from_blockstore
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import (
     add_fake_message,
     add_fake_thread,

--- a/tests/api/test_searching.py
+++ b/tests/api/test_searching.py
@@ -13,7 +13,6 @@ from inbox.search.backends.gmail import GmailSearchClient
 from inbox.search.backends.imap import IMAPSearchClient
 from inbox.search.base import get_search_client
 
-from tests.api.base import api_client, imap_api_client
 from tests.util.base import (
     add_fake_folder,
     add_fake_imapuid,

--- a/tests/api/test_sending.py
+++ b/tests/api/test_sending.py
@@ -16,7 +16,6 @@ from inbox.basicauth import OAuthError
 from inbox.models import Event, Message
 from inbox.sendmail.smtp.postel import _substitute_bcc
 
-from tests.api.base import api_client
 from tests.util.base import imported_event, message, thread
 
 __all__ = ["thread", "message", "api_client", "imported_event"]

--- a/tests/api/test_srv.py
+++ b/tests/api/test_srv.py
@@ -1,7 +1,5 @@
 import json
 
-from tests.api.base import api_client
-
 
 def test_create_generic_account(db, api_client):
     resp = api_client.post_data(

--- a/tests/api/test_streaming.py
+++ b/tests/api/test_streaming.py
@@ -6,13 +6,10 @@ from gevent import Greenlet
 
 from inbox.util.url import url_concat
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message
 
 GEVENT_EPSILON = 0.5  # Greenlet switching time. VMs on Macs suck :()
 LONGPOLL_EPSILON = 2 + GEVENT_EPSILON  # API implementation polls every second
-
-__all__ = ["api_client"]
 
 
 @pytest.yield_fixture

--- a/tests/api/test_threads.py
+++ b/tests/api/test_threads.py
@@ -5,10 +5,9 @@ import pytest
 
 from inbox.api.ns_api import API_VERSIONS
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message, add_fake_thread, db, default_account
 
-__all__ = ["db", "api_client", "default_account"]
+__all__ = ["db", "default_account"]
 
 
 def test_thread_received_recent_date(db, api_client, default_account):

--- a/tests/api/test_validation.py
+++ b/tests/api/test_validation.py
@@ -6,10 +6,9 @@ import pytest
 from inbox.api.validation import noop_event_update, valid_email
 from inbox.models import Namespace
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_event, calendar, db
 
-__all__ = ["api_client", "db", "calendar"]
+__all__ = ["db", "calendar"]
 
 
 # TODO(emfree): Add more comprehensive parameter-validation tests.

--- a/tests/api/test_views.py
+++ b/tests/api/test_views.py
@@ -1,7 +1,7 @@
 # flake8: noqa: F811
 import pytest
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import generic_account
 
 __all__ = ["api_client", "generic_account"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,24 @@ import gevent_openssl
 
 gevent_openssl.monkey_patch()
 
+from pytest import yield_fixture
+
 from inbox.util.testutils import files  # noqa
 from inbox.util.testutils import mock_dns_resolver  # noqa
 from inbox.util.testutils import mock_imapclient  # noqa
 from inbox.util.testutils import mock_smtp_get_connection  # noqa
-from inbox.util.testutils import uploaded_file_ids
+from inbox.util.testutils import uploaded_file_ids  # noqa
 
+from tests.api.base import TestAPIClient
 from tests.util.base import *  # noqa
 
 from inbox.util.testutils import dump_dns_queries  # noqa; noqa
+
+
+@yield_fixture
+def api_client(db, default_namespace):
+    from inbox.api.srv import app
+
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield TestAPIClient(c, default_namespace.public_id)

--- a/tests/imap/network/test_send.py
+++ b/tests/imap/network/test_send.py
@@ -3,11 +3,10 @@ from datetime import datetime
 
 import pytest
 
-from tests.api.base import api_client
 from tests.util.base import default_account
 from tests.util.crispin import crispin_client
 
-__all__ = ["default_account", "api_client"]
+__all__ = ["default_account"]
 
 
 @pytest.fixture

--- a/tests/imap/test_labels.py
+++ b/tests/imap/test_labels.py
@@ -4,7 +4,6 @@ import pytest
 
 from inbox.mailsync.backends.imap.common import update_message_metadata
 
-from tests.api.base import api_client
 from tests.util.base import (
     add_fake_folder,
     add_fake_imapuid,
@@ -13,7 +12,7 @@ from tests.util.base import (
     default_account,
 )
 
-__all__ = ["default_account", "api_client"]
+__all__ = ["default_account"]
 
 
 def add_fake_label(db_session, default_account, display_name, name):

--- a/tests/security/test_smtp_ssl.py
+++ b/tests/security/test_smtp_ssl.py
@@ -10,7 +10,7 @@ import sys
 import gevent
 import pytest
 
-from tests.api.base import api_client, new_api_client
+from tests.api.base import new_api_client
 from tests.util.base import default_account
 
 smtpd.DEBUGSTREAM = sys.stderr

--- a/tests/transactions/test_delta_sync.py
+++ b/tests/transactions/test_delta_sync.py
@@ -4,10 +4,7 @@ import time
 
 from freezegun import freeze_time
 
-from tests.api.base import api_client
 from tests.util.base import add_fake_message
-
-__all__ = ["api_client"]
 
 
 def add_account_with_different_namespace_id(


### PR DESCRIPTION
It seems to me that the original authors were confused about how pytest fixture discovery works. Instead of relaying on how pytest inspects `conftest.py` files to decide which fixtures are visible, some fixtures were imported explicitly.

This also throws off Flake8 because if it sees sections like:

```python
from tests.api.base import api_client

def test(api_client):
    ...
```

triggers name shadowing errors.

I moved the `api_client` fixture instead to closest `conftest.py` I could put it, `tests/conftest.py` since it is used across the whole test suite. `imap_api_client` is not used anywhere so I just removed it.

In the future we could think about organizing fixtures into plugins but for now I wanted to make the smallest improvement change.
