### PR TITLE
Upgrade redis to meet version constraints

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -91,7 +91,7 @@ git+https://github.com/nylas/dateutil.git@da336a366cd3f31e3bd7ca925e676e169189e4
 python-magic==0.4.6
 pytz==2017.3
 PyYAML==3.12
-redis==2.10.3
+redis==2.10.6
 regex==2018.1.10
 requests==2.11.0
 rollbar==0.16.1


### PR DESCRIPTION
Currently we don't run `pip check`. This pull is a step towards running it.

Not satisfied constraint:

```
* limitlion==0.9.2
 - redis [required: ==2.10.6, installed: 2.10.3]
```

Changelog:

```
* 2.10.6
    * Various performance improvements. Thanks cjsimpson
    * Fixed a bug with SRANDMEMBER where the behavior for `number=0` did
      not match the spec. Thanks Alex Wang
    * Added HSTRLEN command. Thanks Alexander Putilin
    * Added the TOUCH command. Thanks Anis Jonischkeit
    * Remove unnecessary calls to the server when registering Lua scripts.
      Thanks Ben Greenberg
    * SET's EX and PX arguments now allow values of zero. Thanks huangqiyin
    * Added PUBSUB {CHANNELS, NUMPAT, NUMSUB} commands. Thanks Angus Pearson
    * PubSub connections that encounter `InterruptedError`s now
      retry automatically. Thanks Carlton Gibson and Seth M. Larson
    * LPUSH and RPUSH commands run on PyPy now correctly returns the number
      of items of the list. Thanks Jeong YunWon
    * Added support to automatically retry socket EINTR errors. Thanks
      Thomas Steinacher
    * PubSubWorker threads started with `run_in_thread` are now daemonized
      so the thread shuts down when the running process goes away. Thanks
      Keith Ainsworth
    * Added support for GEO commands. Thanks Pau Freixes, Alex DeBrie and
      Abraham Toriz
    * Made client construction from URLs smarter. Thanks Tim Savage
    * Added support for CLUSTER * commands. Thanks Andy Huang
    * The RESTORE command now accepts an optional `replace` boolean.
      Thanks Yoshinari Takaoka
    * Attempt to connect to a new Sentinel if a TimeoutError occurs. Thanks
      Bo Lopker
    * Fixed a bug in the client's `__getitem__` where a KeyError would be
      raised if the value returned by the server is an empty string.
      Thanks Javier Candeira.
    * Socket timeouts when connecting to a server are now properly raised
      as TimeoutErrors.
* 2.10.5
    * Allow URL encoded parameters in Redis URLs. Characters like a "/" can
      now be URL encoded and redis-py will correctly decode them. Thanks
      Paul Keene.
    * Added support for the WAIT command. Thanks https://github.com/eshizhan
    * Better shutdown support for the PubSub Worker Thread. It now properly
      cleans up the connection, unsubscribes from any channels and patterns
      previously subscribed to and consumes any waiting messages on the socket.
    * Added the ability to sleep for a brief period in the event of a
      WatchError occurring. Thanks Joshua Harlow.
    * Fixed a bug with pipeline error reporting when dealing with characters
      in error messages that could not be encoded to the connection's
      character set. Thanks Hendrik Muhs.
    * Fixed a bug in Sentinel connections that would inadvertently connect
      to the master when the connection pool resets. Thanks
      https://github.com/df3n5
    * Better timeout support in Pubsub get_message. Thanks Andy Isaacson.
    * Fixed a bug with the HiredisParser that would cause the parser to
      get stuck in an endless loop if a specific number of bytes were
      delivered from the socket. This fix also increases performance of
      parsing large responses from the Redis server.
    * Added support for ZREVRANGEBYLEX.
    * ConnectionErrors are now raised if Redis refuses a connection due to
      the maxclients limit being exceeded. Thanks Roman Karpovich.
    * max_connections can now be set when instantiating client instances.
      Thanks Ohad Perry.
* 2.10.4
    (skipped due to a PyPI snafu)
```

Definitely needs to be deployed separately.
