### PR TITLE
Upgrade greenlet to meet version constraints

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -38,7 +38,7 @@ gevent==1.1.2
 gevent-openssl==1.2
 gevent-socketio==0.3.5rc2
 gevent-websocket==0.10.1
-greenlet==0.4.2
+greenlet==0.4.9
 gunicorn==19.4.5
 guppy==0.1.10
 hiredis==0.1.5


### PR DESCRIPTION
Currently we don't run pip check. This pull is a step towards running it.

Not satisfied constraint:

```
* gevent==1.1.2
 - greenlet [required: >=0.4.9, installed: 0.4.2]
```

Changelog:

https://github.com/python-greenlet/greenlet/blob/master/CHANGES.rst?plain=1#L161-L206

Definitely should be deployed separately. Also contains some ARM fixes according to changelog.