### PR TITLE
Upgrade enum34 to meet version constraints

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -23,7 +23,7 @@ coverage==5.5
 cryptography==2.1.4
 dnspython==1.11.1
 docutils==0.14
-enum34==1.0.4
+enum34==1.1.3
 faulthandler==2.3
 flake8==2.1.0
 flake8-pep3101==0.6


### PR DESCRIPTION
Currently we don't run pip check. This pull is a step towards running it.

Not satisfied constraint:

```
* astroid==1.6.1
 - enum34 [required: >=1.1.3, installed: 1.0.4]
```

Changelog:

This project was versioned in hg (Mercurial) and hosted on Bitbucket that has since removed support for hg and deleted all the repos hosted there. I found a copy of the repo here: https://bitbucket-archive.softwareheritage.org/projects/st/stoneleaf/enum34.html

The project did not maintain a CHANGELOG file

<img width="431" alt="Screenshot 2021-10-05 at 17 26 04" src="https://user-images.githubusercontent.com/754356/136053905-2731bc3a-870b-4692-a3b8-844746c81006.png">

The best I can do is `hg log`

```
2016-04-14 | Ethan Furman | version 1.1.3
2016-04-14 | Ethan Furman | Added tag 1.1.3 for changeset e5be6fbdf3e0
2016-04-14 | Ethan Furman | fix typo    1.1.3
2016-04-14 | Ethan Furman | add wheel support
2016-04-14 | Ethan Furman | add short long description
2016-04-14 | Ethan Furman | move tracked README to package root
2016-04-14 | Ethan Furman | add README in package root
2016-04-14 | Ethan Furman | make enum classes True (bugs.python.org/issue26748)
2016-04-14 | Ethan Furman | change test_enum.py to test.py
2016-04-14 | Ethan Furman | standardize values for FieldTypes example
2016-04-14 | Ethan Furman | remove __bool__, it will not be added
2015-11-29 | Ethan Furman | version 1.1.1
2015-11-29 | Ethan Furman | Added tag 1.1.1 for changeset 48385cd36fa3
2015-11-29 | Ethan Furman | add performance boost to member lookup    1.1.1
2015-11-29 | Ethan Furman | issue7: fix MANIFEST.in so extra files are not included
2015-11-29 | Ethan Furman | issue9: fix bug with empty iterable crashing functional API
2015-11-29 | Ethan Furman | version 1.1.0
2015-11-29 | Ethan Furman | Added tag 1.1.0 for changeset c8a8742f178c
2015-11-29 | Ethan Furman | change to match Enum in Python 3.5    1.1.0
2014-11-26 | Ethan Furman | update version in setup.py
2014-11-26 | Ethan Furman | fix incompatibility with 2.7 and unicode_literals and class name when using functional API
2014-11-26 | Ethan Furman | Added tag 1.0.04 for changeset c873eedb598c
```

🤷🏼