### PR TITLE
Build arm image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,51 @@ jobs:
       - store_artifacts:
           path: .circleci/artifacts.html
           destination: artifacts.html
+  build_arm:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    working_directory: ~/sync-engine
+
+    steps:
+      - checkout
+
+      - run:
+          name: build sync-engine image
+          command: docker-compose build app
+
+      - run:
+          name: run tests
+          command: |
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            docker-compose run app bash -ec '
+              pip install -e . \
+              && bin/wait-for-it.sh mysql:3306 \
+              && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
+              && coverage html -d pythoncov
+            '
+
+      - run:
+          name: Push the tested image to docker hub
+          environment:
+            PROJECT: sync-engine
+            PROJECT_NAMESPACE: closeio
+          command: |
+            PROJECT_VSN="$CIRCLE_BRANCH"
+            PROJECT_SHA="$CIRCLE_SHA1"
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            # tag and push both sync-engine:master and sync-engine:<sha1>
+            docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-arm"
+            docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm"
+            docker push "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-arm"
+            docker push "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm"
+
+      - store_artifacts:
+          path: pythoncov
+
+      - store_artifacts:
+          path: .circleci/artifacts.html
+          destination: artifacts.html
 
 workflows:
   version: 2
@@ -96,3 +141,4 @@ workflows:
       - static-code-analysis
       - static-code-analysis-flake8
       - build
+      - build_arm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,17 +101,8 @@ jobs:
           name: build sync-engine image
           command: docker-compose build app
 
-#  mysql:5.7.31 has no arm image. mysql has arm images from version 8
-#      - run:
-#          name: run tests
-#          command: |
-#            docker login -u $DOCKER_USER -p $DOCKER_PASS
-#            docker-compose run app bash -ec '
-#              pip install -e . \
-#              && bin/wait-for-it.sh mysql:3306 \
-#              && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
-#              && coverage html -d pythoncov
-#            '
+      # Not running tests for arm.
+      # mysql:5.7.31 has no arm image (arm images start at version 8)
 
       - run:
           name: Push the tested image to docker hub
@@ -127,13 +118,6 @@ jobs:
             docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm64"
             docker push "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-arm64"
             docker push "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm64"
-
-      - store_artifacts:
-          path: pythoncov
-
-      - store_artifacts:
-          path: .circleci/artifacts.html
-          destination: artifacts.html
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,16 +101,17 @@ jobs:
           name: build sync-engine image
           command: docker-compose build app
 
-      - run:
-          name: run tests
-          command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker-compose run app bash -ec '
-              pip install -e . \
-              && bin/wait-for-it.sh mysql:3306 \
-              && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
-              && coverage html -d pythoncov
-            '
+#  mysql:5.7.31 has no arm image. mysql has arm images from version 8
+#      - run:
+#          name: run tests
+#          command: |
+#            docker login -u $DOCKER_USER -p $DOCKER_PASS
+#            docker-compose run app bash -ec '
+#              pip install -e . \
+#              && bin/wait-for-it.sh mysql:3306 \
+#              && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
+#              && coverage html -d pythoncov
+#            '
 
       - run:
           name: Push the tested image to docker hub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,10 @@ jobs:
             PROJECT_SHA="$CIRCLE_SHA1"
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             # tag and push both sync-engine:master and sync-engine:<sha1>
-            docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-arm"
-            docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm"
-            docker push "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-arm"
-            docker push "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm"
+            docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-arm64"
+            docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm64"
+            docker push "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-arm64"
+            docker push "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-arm64"
 
       - store_artifacts:
           path: pythoncov

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get dist-upgrade -y 
   telnet \
   tzdata \
   vim \
+  libffi-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /etc/inboxapp && \


### PR DESCRIPTION
Arm images are built on arm machine and with `-arm64` tag suffix.

Not running tests for arm - we don't do that for any of the other services as well.