### PR TITLE
Upgrade ipython

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -7,6 +7,7 @@ atomicwrites==1.4.0
 attrs==20.2.0
 git+https://github.com/closeio/authalligator-client.git@fe93c9d2333d2949e44c48a2dd0a9a266734e026#egg=authalligator_client
 backports.functools-lru-cache==1.4
+backports.shutil_get_terminal_size==1.0
 backports.ssl==0.0.9
 boto==2.10.0
 boto3==1.1.4
@@ -24,6 +25,7 @@ configparser==4.0.2
 contextlib2==0.5.5
 coverage==5.5
 cryptography==2.1.4
+decorator==4.4.2
 dnspython==1.11.1
 docutils==0.14
 enum34==1.1.3
@@ -54,7 +56,8 @@ idna==2.6
 git+https://github.com/closeio/imapclient.git@aca1b9b3624f28dca8fdf5e140704c8b7d57820f#egg=imapclient
 importlib-metadata==2.1.1
 ipaddress==1.0.19
-ipython==1.0.0
+ipython==5.8.0
+ipython_genutils==0.2.0
 itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
@@ -77,14 +80,19 @@ packaging==20.9
 pathlib2==2.3.6
 pbr==3.1.1
 pep8==1.4.6
+pexpect==4.8.0
+pickleshare==0.7.5
 pluggy==0.13.1
 ply==3.10
 psutil==3.3.0
+ptyprocess==0.7.0
+prompt-toolkit==1.0.18
 py==1.10.0
 pyaml==14.5.7
 pyasn1==0.2.3
 pycparser==2.18
 pyflakes==0.7.3
+pygments==2.5.2
 pyinstrument==0.12
 pylint==1.5.1
 pymongo==2.5.2  # For json_util in bson
@@ -106,6 +114,7 @@ rollbar==0.16.1
 scandir==1.10.0
 setproctitle==1.1.8
 setuptools==44.0.0
+simplegeneric==0.8.1
 simplejson==3.6.0
 singledispatch==3.4.0.3
 six==1.11.0
@@ -115,6 +124,7 @@ statsd==3.1
 structlog==17.2.0
 tldextract==1.7.5
 toml==0.10.2
+traitlets==4.3.2
 typing==3.10.0.0
 uritemplate==0.6
 urllib3==1.22


### PR DESCRIPTION
This is totally safe since this is dev-only dependency,

Those are the last versions working on Python 2.
