### PR TITLE
Upgrade faulthandler

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -29,7 +29,7 @@ decorator==4.4.2
 dnspython==1.11.1
 docutils==0.14
 enum34==1.1.3
-faulthandler==2.3
+faulthandler==3.2; python_version < '3.3'
 flake8==2.1.0
 flake8-pep3101==0.6
 git+https://github.com/closeio/flanker.git@c86e8c2599497f234988acfcef726bbc3228c787#egg=flanker


### PR DESCRIPTION
https://pypi.org/project/faulthandler/

> Fault handler for SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL signals: display the Python traceback and restore the previous handler. Allocate an alternate stack for this handler, if sigaltstack() is available, to be able to allocate memory on the stack, even on stack overflow (not available on Windows).

This is fairly safe to update as it has minimal API (`faulthandler.enable()`) and is only called in catastrophic situations, like some C extension crashing the whole interpreter.

https://github.com/closeio/sync-engine/blob/64e70ec06139ab63f676c98c51db9eaccfbbbe6d/inbox/util/startup.py#L78-L83

This module was part of stdlib since Python 3.3.
