### PR TITLE
Upgrade psutil and add tests for GreenletTracer

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -84,7 +84,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pluggy==0.13.1
 ply==3.10
-psutil==3.3.0
+psutil==5.8.0
 ptyprocess==0.7.0
 prompt-toolkit==1.0.18
 py==1.10.0

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,0 +1,26 @@
+import time
+
+import mock
+
+from inbox.instrumentation import GreenletTracer
+
+
+def test_greenlet_tracer(monkeypatch):
+    logging_interval = 5
+    greenlet_tracer = GreenletTracer(logging_interval=logging_interval)
+
+    logger_mock = mock.Mock()
+    get_logger_mock = mock.Mock(return_value=logger_mock)
+    monkeypatch.setattr("inbox.instrumentation.get_logger", get_logger_mock)
+
+    greenlet_tracer.start()
+
+    time.sleep(logging_interval * 1.5)
+
+    (call,) = logger_mock.method_calls
+    method, args, kwargs = call
+    assert method == "info"
+    assert args == ("greenlet stats",)
+    assert kwargs["total_time"] >= logging_interval
+
+    greenlet_tracer.stop()

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -22,5 +22,6 @@ def test_greenlet_tracer(monkeypatch):
     assert method == "info"
     assert args == ("greenlet stats",)
     assert kwargs["total_time"] >= logging_interval
+    assert kwargs["pending_avgs"] == {1: 0, 5: 0, 15: 0}  # always 0 after one cycle
 
     greenlet_tracer.stop()


### PR DESCRIPTION
https://pypi.org/project/psutil/

> psutil (process and system utilities) is a cross-platform library for retrieving information on running processes and system utilization (CPU, memory, disks, network, sensors) in Python.

We are using it to monitor CPU times. The logic runs in a separate OS thread (that is not monkeypatched by gevent):

https://github.com/closeio/sync-engine/blob/b615cec56154209f3af525afd7d271b89fe2e33e/inbox/instrumentation.py#L121-L125)

Initialized here:

https://github.com/closeio/sync-engine/blob/b615cec56154209f3af525afd7d271b89fe2e33e/inbox/instrumentation.py#L106

Calculation done here:

https://github.com/closeio/sync-engine/blob/b615cec56154209f3af525afd7d271b89fe2e33e/inbox/instrumentation.py#L202-L209

This is the last version of psutil since it still works on Python 2.7.

I included lightweight test to ensure that at least things are not exploding, since previously this was not covered at all.
