### PR TITLE
Upgrade setproctitle

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -112,7 +112,7 @@ regex==2018.1.10
 requests==2.11.0
 rollbar==0.16.1
 scandir==1.10.0
-setproctitle==1.1.8
+setproctitle==1.1.10
 setuptools==44.0.0
 simplegeneric==0.8.1
 simplejson==3.6.0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,10 @@
+import setproctitle
+
+
+def test_setproctitle_works():
+    original_proctitle = setproctitle.getproctitle()
+
+    setproctitle.setproctitle(test_setproctitle_works.__name__)
+    assert setproctitle.getproctitle() == test_setproctitle_works.__name__
+
+    setproctitle.setproctitle(original_proctitle)


### PR DESCRIPTION
https://pypi.org/project/setproctitle/

> The setproctitle module allows a process to change its title (as displayed by system tools such as ps and top).

This is the last version working on Python 2.

We only use `setproctitle.setproctitle()` API in "entrypoints" inside `bin/` and such are not covered by any tests e.g.:

https://github.com/closeio/sync-engine/blob/64e70ec06139ab63f676c98c51db9eaccfbbbe6d/bin/inbox-api#L15-L15

I added a really simple test to ensure that it works across upgrades.
