### PR TITLE
Upgrade statsd

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -120,7 +120,7 @@ singledispatch==3.4.0.3
 six==1.11.0
 sortedcontainers==2.4.0
 git+https://github.com/mhahnenberg/sqlalchemy.git@e5f7586346ce5fafe2c182f70bf6ef998aa59b68#egg=SQLAlchemy
-statsd==3.1
+statsd==3.3.0
 structlog==17.2.0
 tldextract==1.7.5
 toml==0.10.2


### PR DESCRIPTION
Changelog:

```
Version 3.3
-----------

- Drop support for Python 2.5, 2.6, 3.2, 3.3 (#108, #116).
- Add UnixSocketStatsClient (#76, #112).
- Add support for timedeltas in timing() (#104, #111).
- Fix timer decorator with partial functions (#85).
- Remove ABCMeta metaclass (incompatible with Py3) (#109).
- Refactor client module (#115).
- Various doc updates (#99, #102, #110, #113, #114).


Version 3.2.2
-------------

- Use a monotomic timer to avoid clock adjustments (#96).
- Test on Python 3.5 and 3.6.
- Various doc updates.


Version 3.2.1
-------------

- Restore `StatsClient(host, port, prefix)` argument order.


Version 3.2
-----------

- Add an explicit IPv6 flag.
- Add support for sub-millisecond timings

```

no API changes, mostly bugfixes and internal refactors