### PR TITLE
MD5 lives in hashlib now

### DIFF
--- a/tests/api/test_files.py
+++ b/tests/api/test_files.py
@@ -2,8 +2,8 @@
 import json
 import os
 from datetime import datetime
+from hashlib import md5
 
-import md5
 import mock
 import pytest
 
@@ -145,8 +145,8 @@ def test_download(api_client, uploaded_file_ids, filename):
         original_filename.encode("utf-8"),
     )
     local_data = open(path, "rb").read()
-    local_md5 = md5.new(local_data).digest()
-    dl_md5 = md5.new(data).digest()
+    local_md5 = md5(local_data).digest()
+    dl_md5 = md5(data).digest()
     assert local_md5 == dl_md5
 
 


### PR DESCRIPTION
md5 module was deprecated at least from Python 2.5 https://docs.python.org/2.7/library/md5.html and was removed in Python 3. It lives now in https://docs.python.org/2.7/library/hashlib.html module.