### PR TITLE
Python 3 misc backward compatible changes

### DIFF
--- a/inbox/instrumentation.py
+++ b/inbox/instrumentation.py
@@ -318,7 +318,9 @@ class Tracer(object):
     def log_stats(self, max_stats=60):
         total_time = round(time.time() - self.start_time, 2)
         greenlets_by_cost = sorted(
-            self.time_spent_by_context.items(), key=lambda (k, v): v, reverse=True
+            self.time_spent_by_context.items(),
+            key=lambda key_and_value: key_and_value[1],
+            reverse=True,
         )
         formatted_times = {k: round(v, 2) for k, v in greenlets_by_cost[:max_stats]}
         self.log.info(
@@ -328,7 +330,8 @@ class Tracer(object):
             total_time=total_time,
         )
 
-    def _trace(self, event, (origin, target)):
+    def _trace(self, event, origin_and_target):
+        (origin, target) = origin_and_target
         self.total_switches += 1
         current_time = time.time()
         if self.gather_stats and self._last_switch_time is not None:

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -512,7 +512,7 @@ class GmailFolderSyncEngine(FolderSyncEngine):
             batch = []
             while dl_size < max_download_bytes and len(batch) < max_download_count:
                 try:
-                    uid = expanded_pending_uids.next()
+                    uid = next(expanded_pending_uids)
                 except StopIteration:
                     break
                 batch.append(uid)

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -789,7 +789,9 @@ class FolderSyncEngine(Greenlet):
         # objects into the SQLAlchemy session and then issue lots of commits;
         # we avoid that by batching.
         flag_batches = chunk(
-            sorted(changed_flags.items(), key=lambda (k, v): v.modseq),
+            sorted(
+                changed_flags.items(), key=lambda key_and_value: key_and_value[1].modseq
+            ),
             CONDSTORE_FLAGS_REFRESH_BATCH_SIZE,
         )
         for flag_batch in flag_batches:

--- a/tests/events/test_ics_parsing.py
+++ b/tests/events/test_ics_parsing.py
@@ -540,7 +540,7 @@ def test_truncate_bogus_sequence_numbers(db, default_account):
 
     # Check that the sequence number got truncated to the biggest possible
     # number.
-    assert ev.sequence_number == 2147483647L
+    assert ev.sequence_number == 2147483647
 
 
 def test_handle_missing_sequence_number(db, default_account):


### PR DESCRIPTION
Includes:
  - Python 3 no longer supports unpacking in arguments
  - .next() is no longer in Python 3, next() works in Python 2.7 and 3
  - long (L) prefix is gone in Python 3
