### PR TITLE
Upgrade vobject

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -126,7 +126,7 @@ traitlets==4.3.2
 typing==3.10.0.0
 uritemplate==0.6
 urllib3==1.22
-vobject==0.8.2
+vobject==0.9.1
 wcwidth==0.2.5
 WebOb==1.7.4
 Werkzeug==0.14.1


### PR DESCRIPTION
> VObject is intended to be a full-featured Python package for parsing and generating vCard and vCalendar files

This is the minimal change to upgrade this to version that works on Python 3

The project has no changelog and the commit diff is rather non descriptive: https://github.com/eventable/vobject/compare/0.8.2...0.9.1