### PR TITLE
Conditionally install enum34

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -28,7 +28,7 @@ cryptography==2.1.4
 decorator==4.4.2
 dnspython==1.11.1
 docutils==0.14
-enum34==1.1.3
+enum34==1.1.3; python_version < '3.4'
 faulthandler==3.2; python_version < '3.3'
 flake8==2.1.0
 flake8-pep3101==0.6


### PR DESCRIPTION
This module is a backport of Python 3 enum and only needs to be installed on Python < 3.4.