### PR TITLE
Conditionally replace guppy

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -45,7 +45,8 @@ gevent-socketio==0.3.5rc2
 gevent-websocket==0.10.1
 greenlet==0.4.9
 gunicorn==19.10.0
-guppy==0.1.10
+guppy==0.1.10; python_version < '3.0'
+guppy3==3.1.2; python_version >= '3.0'
 hiredis==0.1.5
 html2text==2014.9.8
 httplib2==0.8


### PR DESCRIPTION
https://pypi.org/project/guppy3/

> A Python Programming Environment & Heap analysis toolset. Guppy 3 is a fork of Guppy-PE, created by Sverker Nilsson for Python 2.

The version for Python 2 has different package name since the original Python 2 version was abandoned and is no longer maintained.

We don't use this module `guppy` anywhere in the code base but it's mentioned in some comments as useful tool to see what is happening with memory pressure in the interpreter. Let's keep it for now.

