### PR TITLE
Conditionally install typing

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -123,7 +123,7 @@ structlog==17.2.0
 tldextract==1.7.5
 toml==0.10.2
 traitlets==4.3.2
-typing==3.10.0.0
+typing==3.10.0.0; python_version < '3.5'
 uritemplate==0.6
 urllib3==1.22
 vobject==0.8.2


### PR DESCRIPTION
This module is included with Python 3.5.