### PR TITLE
Upgrade arrow

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -1,6 +1,6 @@
 alembic==0.6.5
 aniso8601==2.0.0
-arrow==0.5.4
+arrow==0.6.0
 asn1crypto==0.24.0
 astroid==1.6.1
 atomicwrites==1.4.0


### PR DESCRIPTION
This just lightly upgrades arrow to work on Python 3

Changes

```

0.6.0

    [FIX] Added support for Python 3

    [FIX] Avoid truncating oversized epoch timestamps. Fixes #216.

    [FIX] Fixed month abbreviations for Ukrainian

    [FIX] Fix typo timezone

    [FIX] A couple of dialect fixes and two new languages

    [FIX] Spanish locale: Miercoles should have acute accent

    [Fix] Fix Finnish grammar

    [FIX] Fix typo in ‘Arrow.floor’ docstring

    [FIX] Use read() utility to open README

    [FIX] span_range for week frame

    [NEW] Add minimal support for fractional seconds longer than six digits.

    [NEW] Adding locale support for Marathi (mr)

    [NEW] Add count argument to span method

    [NEW] Improved docs

```