### PR TITLE
Upgrade boto

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -9,7 +9,7 @@ git+https://github.com/closeio/authalligator-client.git@fe93c9d2333d2949e44c48a2
 backports.functools-lru-cache==1.4
 backports.shutil_get_terminal_size==1.0
 backports.ssl==0.0.9
-boto==2.10.0
+boto==2.32.0
 boto3==1.1.4
 botocore==1.2.11
 bumpversion==0.5.3


### PR DESCRIPTION
This upgrtades boto to the latest version. Note that we only use boto for S3 access. I tested this change locally with MinIO.

Changelog:

```
v2.49.0
    Import the latest CA Bundle from certifi (issue 3818, commit e4699cba)
    Fix to support uploads to KMS-encrypted buckets. (issue 3800, commit 0a1d9040)
    Support fetching GCS bucket encryption metadata. (issue 3799, commit 132b64d2)
    Update layer1.py (issue 3765, commit 53340159)
    Fix tests/unit/glacier/test_writer.py to make work with pypy. (issue 3762, commit 8402c5d6)

v2.48.0
    Fix generate_url() AttributeError when using anonymous connections (issue 3734, commit 83481807)
    Use RegionInfo by default with heuristics (issue 3737, commit 0a9b1140)
    Allow specifying s3 host from boto config file. (issue 3738, commit dcfc7512)

v2.47.0
    Loosen requirements for ID field in PROJECT_PRIVATE_RE. (issue 3729, commit 5e85d7c7)
    Populate storage class from HEAD Object responses. (issue 3691, commit 315b76e0)

v2.46.1
    Add boto.vendored.regions to setup.py (issue 3682, commit 43e796d1)

v2.45.0
    Add support for eu-west-2 (issue 3654, commit 40c68db)

v2.44.0
    Update endpoints (issue 3649, commit a1eae11)
    Add gs support for object-level storage class features. (issue 3635, commit dc4bf34)

v2.43.0
    Add support for us-east-2 endpoint (commit 262ed00)
    Account for metadata update propagation delay (issue 3615, commit 592dae3)
    boto.dynamodb2.table.Table#batch_get() fails to paginate results if provisioned throughput is exceeded (issue 3574, commit abb3847)

v2.42.0
    Respect is_secure parameter in generate_url_sigv4 (commit 59ba28d)
    Update MTurk API (issue 3563, commit 250d891)

v2.41.0
    Update endpoints.json (issue 3564, commit 5e786b4)
    Remove the broken link to PDF’s (issue 3562, commit 46ffb0c)

v2.40.0
    ryansydnor-s3: Allow s3 bucket lifecycle policies with multiple transitions (commit c6d5af3)
    Fixes upload parts for glacier (issue 3524, commit d1973a4)
    pslawski-unicode-parse-qs: Move utility functions over to compat Add S3 integ test for non-ascii keys with sigv4 Fix quoting of tilde in S3 canonical_uri for sigv4 Parse unicode query string properly in Python 2 (issue 2844, commit 5092c6d)
    ninchat-config-fix: Add __setstate__ to fix pickling test fail Add unit tests for config parsing Don’t access parser through __dict__ Config: Catch specific exceptions when wrapping ConfigParser methods Config: Don’t inherit from ConfigParser (issue 3474, commit c21aa54)

v2.39.0
    Autodetect sigv4 for ap-northeast-2 (issue 3461, commit c2a17ce)
    Added support for ap-northeast-2 (issue 3454, commit c3c1ddd)
    Remove VeriSign Class 3 CA from trusted certs (issue 3450, commit 8a025df)
    Add note about boto3 on all pages of boto docs (commit 9bd904c)
    Fix for listing EMR steps based on cluster_states filter (issue 3399, commit 0f92f35)
    Fixed param name in set_contents_from_string docstring (issue 3420, commit e30297b)
    Closes #3441 Remove py3 test whitelist Update rds to pass on py3 Update mturk to pass tests on py3 Update cloudsearchdomain tests to work with py3 (issue 3441, commit 5b2f552)
    Run tests against py35 (commit 7d039d0)
    Fix Glacier test failure in python 3.5 due to MagicMock (issue 3412, commit d042f07)
    Undo log message change BF(PY3): use except … as syntax instead of except …, (commit 607cad7)
    Fix travis CI builds for PY3 (issue 3439, commit 22ab610)
    Spelling fixes (issue 3425, commit f43bbbd)
    Fixed docs (issue 3401, commit 4f66311)
    Add deprecation notice to emr methods (issue 3422, commit cee6159)
    Add some GovCloud endpoints (issue 3421, commit 5afc068)

v2.38.0
    Add support for Amazon Machine Learning (commit ab32d572)
    Fix issue with modify reserved instances for modifying instance type (issue 3085, commit b8ea7a04)

v2.37.0
    Update AWS CloudTrail to the latest API. (issue 3074, commit bccc29a)
    Add support for UsePreviousValue to CloudFormation UpdateStack. (issue 3029, commit 8a8a22a)
    Fix BOTH_PATH to work with Windows drives (issue 2823, commit 7ba973e)
    Fix division calculation in S3 docs. (issue 3018, commit 4ffd9ba)
    Add Boto 3 link in README. (issue 3013, commit 561716c)
    Add more regions for configservice (issue 3009, commit a82244f)
    Add eu-central-1 endpoints (Frankfurt region) for IAM and Route53 (commit 5ff4add)
    Fix unit tests from hanging (commit da9f9b7)
    Fixed wording in dynamodb tutorial (issue 2993, commit 36cadf4)
    Update SWF objects to keep a consistent region name. (issue 2985, issue 2980, issue 2606, commit ce75a19)
    Print archive ID in glacier upload script. (issue 2951, commit 047c7d3)
    Add some minor documentation for Route53 tutorial. (issue 2952, commit b855fb3)
    Add Amazon DynamoDB online indexing support on High level API (issue 2925, commit 0621c53)
    Ensure Content-Length header is a string. (issue 2932, commit 34a0f63)
    Correct docs around overriding SGs on ELBs (issue 2937, commit 84d0ff9)
    Fix DynamoDB tests. (commit 616ee80)
    Fix region bug. (issue 2927, commit b1cb61e)
    Fix import for boto.cloudhsm.layer1.CloudHSMConnection. (issue 2926, commit 1944d35)

v2.36.0
    Add Amazon DynamoDB online indexing support.
    Allow for binary to be passed to sqs message (issue 2913, commit 8af9b42)
    Kinesis update (issue 2891, commit 4874e19)
    Fixed spelling of boto.awslambda package. (issue 2914, commit de769ac)
    Add support for Amazon EC2 Container Service (issue 2908, commit 4480fb4)
    Add support for CloudHSM (issue 2905, commit 6055a35)
    Add support for AWS Config (issue 2904, commit 51e9221)
    Add support for AWS CodeDeploy (issue 2899, commit d935356)
    Add support for AWS Lambda (issue 2896, commit 6748016)
    Update both Cognito’s to the latest APIs (issue 2909, commit 18c1251)
    Add sts for eu-central-1. (issue 2906, commit 54714ff)
    Update opsworks to latest API (issue 2892, commit aed3302)
    Add AWS Key Managment Support (issue 2894, commit ef7d2cd)

v2.35.2    
    Add support for new data types in DynamoDB. (issue 2667, commit 68ad513)
    Expose cloudformation UsePreviousTemplate parameter. (issue 2843, issue 2628, commit 873e89c)
    Fix documentation around using custom connections for DynamoDB tables. (issue 2842, issue 1585, commit 71d677f)
    Fixed bug that unable call query_2 after call describe method on dynamodb2 module. (issue 2829, commit 66addce)

v2.35.1
    Check for results left after computing self._keys_left (issue 2871, commit d3c2595)

v2.35.0
    Add Amazon EC2 Classic Link support (:sha: 5dbd2d7)
    Add query string to body for anon STS POST (issue 2812, commit 6513789)
    Fix bug that prevented initializing a dynamo item from existing item (issue 2764, commit 743e814)
        switchover-sigv4: Add integ tests for sigv4 switchover Switch elb/ec2 over to signature version 4 (commit 0dadce8)
    Return SetStackPolicyResponse - (issue 2822, issue 2346, issue 2639, commit c4defb4)
    Added ELB Attributes to docs. (issue 2821, commit 5dfeba9)
    Fix bug by using correct string joining syntax. (issue 2817, commit 8426148)
    Fix SES get_identity_dkim_attributes when input length > 1. (issue 2810, commit cc4d42d)
    DynamoDB table batch_get fails to process all remaining results if single batch result is empty. (issue 2809, commit a193bc0)
    Added suppport for additional fields in EMR objects. (issue 2807, commit 2936ac0)
    Pass version_id in copy if key is versioned. (issue 2803, commit 66b3604)
    Add support for SQS PurgeQueue operation. (issue 2806, commit 90a5d44)
    Update documentation for launchconfig. (issue 2802, commit 0dc8412)
    Remove unimplemented config param. (issue 2801, issue 2572, commit f1a5ebd)
    Add support for private hosted zones. (issue 2785, commit 2e7829b)
    Fix Key.change_storage_class so that it obeys dst_bucket. (issue 2752, commit 55ed184)
    Fix for s3put host specification. (issue 2736, issue 2522, commit 1af31f2)
    Improve handling of Glacier HTTP 204 responses. (issue 2726, commit c314298)
    Fix raising exception syntax in Python 3. (issue 2735, issue 2563, commit 58f76f6)
    Privatezone: Adding unit/integration test coverage (issue 1, commit d1ff14e)
    Minor documentation/pep8 fixes. (issue 2753, commit 6a853be)
    Correct argument type in doc string. (issue 2728, commit 1ddf6df)
    Use exclusive start key to get all items from DynamoDB query. (issue 2676, issue 2573, commit 419d8a5)
    Updated link to current config documentation. (issue 2755, commit 9be3f85)
    Fix the SQS certificate error for region cn-north-1. (issue 2766, commit 1d5368a)
    Adds support for getting health checker IP ranges from Route53. (issue 2792, commit ee14911)
    fix: snap.create_volume documentation lists general purpose ssd. Fixes @2774. (issue 2774, commit 36fae2b)
    Fixed param type in get_contents_to_filename docstring. (issue 2783, commit 478f66a)
    Update DynamoDB local example to include fake access key id. (issue 2791, commit 2c1f8d5)
    Added ‘end’ attribute to ReservedInstance. (issue 2793, issue 2757, commit 28814d8)
    Parse ClusterStatus’s StateChangeReason. (issue 2696, commit 48c5d17)
    Adds SupportedProducts field to EMR JobFlow objects. (issue 2775, commit 6771d04)
    Fix EMR endpoint. (issue 2750, commit 8329e02)
    Detect old-style S3 URL for auto-sigv4. (issue 2773, commit f5be409)
    Throw host warning for cloudsearch domain (issue 2765, commit 9af6f41)
    Fix CloudSearch2 to work with IAM-based search and upload requests (issue 2717, commit 9f4fe8b)
    iam: add support for Account Password Policy APIs (issue 2574, commit 6c9bd53)
    Handle sigv4 non-string header values properly (issue 2744, commit e043e4b)
    Url encode query string for pure query (issue 2720, commit bbbf9d2)

v2.34.0
    Calculate sha_256 correctly for s3 (issue 2691, commit c0a001f)
    Fix MTurk typo. (issue 2429, issue 2428, commit 9bfff19)
    Fix Amazon Cognito links in docs (issue 2674, commit 7c28577)
    Add the ability to IAM to create a virtual mfa device. (issue 2675, commit 075d402)
    PEP8 tidy up for several modules. (issue 2673, commit 38abbd9)
    Fix s3 create multipart upload for sigv4 (issue 2684, commit fc73641)
    Updated endpoints.json for cloudwatch logs to support more regions. (issue 2685, commit 5db2ea8)

v2.33.0
    Added TaggedEC2Object.remove_tags. (issue 2610, issue 2269, issue 2414, commit bce8fcf)
    Fixed 403 error from url encoded User-Agent header (issue 2621, commit 2043a89)
    Inserted break when iterating Route53 records. (issue 2631, commit 2de8716)
    Fix typo in ELB ConnectionSettings attribute (issue 2602, commit 63bd53b)
    PEP8 fixes to various common modules. (issue 2611, commit 44d873d)
    Route Tables: Update describe_route_tables to support additional route types (VPC peering connection, NIC). (issue 2598, issue 2597, commit bbe8ce7)
    Fix an error in Python 3 when creating launch configs. Enables AutoScaling unit tests to run by default. (issue 2591, commit fb4aeec)
    Use svg instead of png to get better image quality. (issue 2588, commit 1de6b41)
    STS now signs using sigv4. (issue 2627, commit 36b247f)
    Added support for Amazon Cognito. (issue 2608, commit fa3a39e)
    Fix bug where sigv4 custom metadata headers were presigned incorrectly. (issue 2604, commit 8853e8e)
    Add some regions to cloudsearch (issue 2593, commit 8c6ea21)
    fix typo in s3 tutorial (issue 2612, commit 92dd581)
    fix ELB ConnectionSettings values in documentation (issue 2620, commit d2231a2)
    Few typo in docstring (issue 2590, commit 0238747)
    Add support for Amazon Route 53 Domains. (issue 2601, commit d149a87)
    Support EBS encryption in BlockDeviceType. (issue 2587, issue 2480, commit 7a39741)
    Fix a typo in auth.py: Bejing -> Beijing. (issue 2585, commit 8525616)
    Update boto/cacerts/cacerts.txt. (issue 2567, commit 02b836c)
    route53 module: tidy up to meet PEP8 better. (issue 2571, commit 3a3e960)
    Update count_slow documentation. (issue 2569, commit e926d2d)
    iam module: tidy up to meet PEP8 better. (issue 2566, commit 3c83da9)
    Assigning ACL ID to network_acl_id instead of route_table_id. (issue 2548, commit c017b02)
    Avoid infinite loop with bucket listing and encoding_type=’url’. (issue 2562, issue 2561, commit 39cbcb5)
    Use urllib timeout param instead of hacking socket global timeout. (issue 2560, issue 1935, commit c1dd1fb)
    Support non-ascii unicode strings in _get_all_query_args. Fixes: #2558, #2559. (issue 2559, issue 2558, commit 069d04b)
    Truncated Response Handling in Route53 ListResourceRecordSets. (issue 2542, commit 3ba380f)
    Update to latest OpsWorks API. (issue 2547, commit ac2b311)
    Better S3 key repr support for unicode. (issue 2525, issue 2516, commit 8198884)
    Skip test when locale is missing. (issue 2554, issue 2540, commit 2b87583)
    Add profile_name support to SQS. (issue 2459, commit 3837951)
    Include test_endpoints.json in source distribution. (issue 2550, commit 7f907b7)
    Pass along params in make_request for elastic transcoder api. (issue 2537, commit 964999e)
    Documents not found behavior of get_item(). (issue 2544, commit 9b9c1c4)
    Support auth when headers contains bytes. (issue 2521, issue 2520, commit 885348d)
    PEP8 style fixes for ElastiCache. (issue 2539, commit bd0d6db)
    PEP8 style fixes for SES. (issue 2538, commit c620c43)
    Doc updates for CloudSearch. (issue 2546, commit 9efebc2)
    Update to latest Redshift API. (issue 2545, commit 9151092)
    Update to latest support API. (issue 2541, issue 2426, commit 8cf1b52)
    Uses file name as archive description when uploading to glacier. (issue 2535, issue 2528, commit 38478c1)
    Fix the ec2.elb.listener.Listener class’s __getitem__ method. (issue 2533, commit 7b67f98)
    Add recognized HTTP headers for S3 metadata. (issue 2477, issue 2050, commit c8c625a)
    Fix class name for document. (issue 2530, commit 2f0e689)
    Copy CloudSearch proxy settings to endpoint services. (issue 2513, commit 3cbbc21)
    Merge branch ‘develop’ into cloudsearch2-proxy (commit 5b424db)
    Add IAMer as an application built on boto. (issue 2515, commit 1f35224)

v2.32.1
    Fix bin scripts for Python 3. (issue 2502, issue 2490, commit cb78c52)
    Fix parsing of EMR step summary response. (issue 2456, commit 2ffb00a)
    Update wheel to be universal for py2/py3. (issue 2478, commit e872d94)
    Add pypy to tox config. (issue 2458, commit 16c6fbe)
    Fix Glacier file object hash calculation. (issue 2489, issue 2488, commit a9463c5)
    PEP8 fixes for Glacier. (issue 2469, commit 0575a54)
    Use ConfigParser for Python 3 and SafeConfigParser for Python 2. (issue 2498, issue 2497, commit f580f73)
    Remove redundant __future__ imports. (issue 2496, commit e59e199)
    Fix dynamodb.types.Binary non-ASCII handling. (issue 2492, issue 2491, commit 16284ea)
    Add missing dependency to requirements.txt. (issue 2494, commit 33db71a)
    Fix TypeError when getting instance metadata under Python 3. (issue 2486, issue 2485, commit 6ff525e)
    Handle Cloudsearch indexing errors. (issue 2370, commit 494a091)
    Remove obsolete md5 import routine. (issue 2468, commit 9808a77)
    Use encodebytes instead of encodestring. (issue 2484, issue 2483, commit 984c5ff)
    Fix an auth class pickling bug. (issue 2479, commit 07d6424)


v2.30.0
Changes

    Add EC2 T2 instance types (commit 544f8925cb)
    Add new regions for CloudTrail and Kinesis (commit 4d67e19914)
    Fixed some code formatting and typo in SQS tutorial docs. (issue 2332, commit 08c8fed)
    Documentation update – Child workflows and poll API. (issue 2333, issue 2063, issue 2064, commit 4835676)
    DOC Tutorial update for metrics and use of dimensions property. (issue 2340, issue 2336, commit 45fda90)
    Let people know only EC2 supported for cloudwatch. (issue 2341, commit 98f03e2)
    Add namespace to AccessControlPolicy xml representation. (issue 2342, commit ce07446)
    Make ip_addr optional in Route53 HealthCheck. (issue 2345, commit 79c35ca)
    Add S3 SigV4 Presigning. (issue 2349, commit 125c4ce)
    Add missing route53 autodoc. (issue 2343, commit 6472811)
    Adds scan_index_forward and limit to DynamoDB table query count. (issue 2184, commit 4b6d222)
    Add method TaggedEC2Object.add_tags(). (issue 2259, commit eea5467)
    Add network interface lookup to EC2. Add update/attach/detach methods to NetworkInterface object. (issue 2311, commit 4d44530)
    Parse date/time in a locale independent manner. (issue 2317, issue 2271, commit 3b715e5)
    Add documentation for delete_hosted_zone. (issue 2316, commit a0fdd39)
    s/existance/existence/ (issue 2315, commit b8dfa1c)
    Add multipart upload section to the S3 tutorial. (issue 2308, commit 99953d4)
    Only attempt shared creds load if path is a file. (issue 2305, commit 0bffa3b)



v2.29.0
Changes

    Added support for shared credentials file. (issue 2292, commit d5ed49f)
    Added support for EBS encryption. (issue 2282, commit d85a449)
    Added GovCloud CloudFormation endpoint. (issue 2297, commit 0f75fb9)
    Added new CloudTrail endpoints to endpoints.json. (issue 2269, commit 1168580)
    Added ‘name’ param to documentation of ELB LoadBalancer. (issue 2291, commit 86e1174)
    Fix typo in ELB docs. (issue 2294, commit 37aaa0f)
    Fix typo in ELB tutorial. (issue 2290, commit 40a758a)
    Fix OpsWorks connect_to_region exception. (issue 2288, commit 26729c7)
    Fix timezones in CloudWatch date range example. (issue 2285, commit 138a6d0)
    Fix description of param tags into rds2.create_db_subnet_group. (issue 2279, commit dc1037f)
    Fix the incorrect name of a test case. (issue 2273, commit ee195a1)
    Fix “consistent” argument to boto.dynamodb2.table.Table.batch_get. (issue 2272, commit c432b09)
    Update the wheel to be python 2 compatible only. (issue 2286, commit 6ad0b75)
    Crate.io is no longer a package index. (issue 2289, commit 7f23de0)




v2.28.0
Changes

    Add support for SQS message attributes. (issue 2257, commit a04ca92)
    Update DynamoDB to support query filters. (issue 2242, commit 141eb71)
    Implement new Cloudsearch API 2013-01-01 as cloudsearch2 module (commit b0ababa)
    Miscellaneous improvements to the MTurk CLI. (issue 2188, commit c213ff1)
    Update MWS to latest API version and adds missing API calls. (issue 2203, issue 2201, commit 8adf720, commit 8d0a6a8)
    Update EC2 register_image to expose an option which sets whether an instance store is deleted on termination. The default value is left as-is. (commit d295ee9)
    Correct typo “possile” –> “possible”. (issue 2196, commit d228352)
    Update Boto configuration tutorial (issue 2191, commit f2a7a08)
    Clarify that MTurkConnection.get_assignments attributes are actually strings. (issue 2187, issue 2176, commit 075636b)
    Fix EC2 documentation typo (issue 2178, commit 2627843)
    Add support for ELB Connection Draining attribute. (issue 2174, issue 2173, commit 78fa43c)
    Add support for setting failure threshold for Route53 health checks. (issue 2171, issue 2170, commit 15b812f)
    Fix specification of Elastic Beanstalk tier parameter. (issue 2168, commit 4492e86)
    Fixed part of roboto for euca2ools. (issue 2166, issue 1730, commit 63b7a34)
    Fixed removing policies from listeners. (issue 2165, issue 1708, commit e5a2d9b)
    Reintroduced the reverse fix for DDB. (issue 2163, commit 70ec722)
    Several fixes to DynamoDB describe calls. (issue 2161, issue 1649, issue 1663, commit 84fb748)
    Fixed how reverse works in DynamoDBv2. (issue 2160, issue 2070, issue 2115, commit afdd805)
    Update Kinesis exceptions (issue 2159, issue 2153, commit 22c6751)
    Fix ECS problem using new-style classes (issue 2103, commit dc466c7)
    Add support for passing region info from SWF layer2 to layer1 (issue 2137, commit 0dc8ce6)
    Handle plus signs in S3 metadata (issue 2145, commit c2a0f95)
    Fix Glacier vault date parsing (issue 2158, commit 9e7b132)
    Documentation fix. (issue 2156, commit 7592a58)
    Fix Route53 evaluate target health bug. (issue 2157, commit 398bb62)
    Removing obselete core directory. (issue 1987, commit 8e83292)
    Improve IAM behavior in the cn-north-1 region. (issue 2152, commit 4050e70)
    Add SetIdentityFeedbackForwardingEnabled and SetIdentityNotificationTopic for SES. (issue 2130, issue 2128, commit 83002d5)
    Altered Route53 bin script to use UPSERT rather than CREATE. (issue 2151, commit 2cd20e7)



v2.27.0
Changes

    Added support for AccessLog in ELB (issue 2150, commit 7aa35ea)
    Added better BlockDeviceType deserialization in Autoscaling. (issue 2149, commit 04d29a5)
    Updated CloudFormation documentation (issue 2147, commit 2535aca)
    Updated Kinesis documentation (issue 2146, commit 01425dc)
    Add optional bucket tags to lss3 output. (issue 2132, commit 0f35924)
    Fix getting instance types for Eucalyptus 4.0. (issue 2118, commit 18dc07d)
    Fixed how quoted strings are handled in SigV4 (issue 2142, commit 2467547)
    Use system supplied certs without a bundle file (issue 2139, commit 70d15b8)
    Fixed incorrect test failures in EC2 trim_snapshots (commit 1fa9df7)
    Raise any exceptions that are tagSet not found (commit 56d7d3e)
    Added request hook docs (issue 2129, commit 64eedce)
    Fixed Route53 alias-healthcheck (issue 2126, commit 141077f)
    Fixed Elastic IP association in EC2 (issue 2131, issue 1310, commit d75fdfa)
    Fixed builds on Travis for installing dependencies (commit 5e84e30)
    Support printing tags on buckets when listing buckets (commit c42a5dd)
    PEP8/pyflakes/(some)pylint (commit 149175e)



boto v2.26.1
Changes

    Fixed boto.connect_rds2 to use kwargs. (commit 3828ece)


v2.26.0
Changes

    Added support for MFA in STS AssumeRole. (commit 899810c)
    Fixed how DynamoDB v2 works with Global Secondary Indexes. (issue 2122, commit f602c95)
    Add request hooks and request logger. (issue 2125, commit e8b20fe)
    Don’t pull the security token from the environment or config when a caller supplies the access key and secret. (issue 2123, commit 4df1694)
    Read EvaluateTargetHealth from Route53 resource record set. (issue 2120, commit 0a97158)
    Prevent implicit string decode in hmac-v4 handlers. (issue 2037, issue 2033, commit 8e56a5f)
    Updated Datapipeline to include all current regions. (issue 2121, commit dff5e3e)
    Bug fix for Google Storage generate_url authentication. (issue 2116, issue 2108, commit 5a50932)
    Handle JSON error responses in BotoServerError. (issue 2113, issue 2077, commit 221085e)
    Corrected a typo in SQS tutorial. (issue 2114, commit 7ed41f7)
    Add CloudFormation template capabilities support. (issue 2111, issue 2075, commit 65a4323)
    Add SWF layer1_decisions to docs. (issue 2110, issue 2062, commit 6039cc9)
    Add support for request intervals in health checks. (issue 2109, commit 660b01a)
    Added checks for invalid regions to the bin scripts (issue 2107, commit bbb9f1e)
    Better error output for unknown region - (issue 2041, issue 1983, commit cd63f92)
    Added certificate tests for CloudTrail. (issue 2106, commit a7e9b4c)
    Updated Kinesis endpoints. (commit 7bd4b6e)
    Finished implementation of RDS’s DescribeDBLogFiles. (issue 2084, commit f3c706c)
    Added support for RDS log file downloading. (issue 2086, issue 1993, commit 4c51841)
    Added some unit tests for CloudFront. (issue 2076, commit 6c46b1d)
    GS should ignore restore_headers as they are never set. (issue 2067, commit f02aeb3)
    Update CloudFormation to support the latest API. (issue 2101, commit ea1b1b6)
    Added Route53 health checks. (issue 2054, commit 9028f7d)
    Merge branch ‘rds2’ into develop Fixes #2097. (issue 2097, commit 6843c16)
    Fix Param class convert method (issue 2094, commit 5cd4598)
    Added support for Route53 aliasing. (issue 2096, commit df5fa40)
    Removed the dependence on example.com within the Route53 tests. (issue 2098, commit 6ce9e0f)
    Fixed has_item support in DynamoDB v2. (issue 2090, commit aada5d3)
    Fix a little typo bug in the S3 tutorial. (issue 2088, commit c091d27)




boto v2.25.0
Features

    Add support for Route53 API version 2013-04-01 (issue 2080, commit 600dcd0)
    Add option to opt-in for EC2 SigV4 (issue 2074, commit 4d780bd)
    Add Autoscale feature to get all adjustment types (issue 2058, issue 1538, commit b9c7e15)
    Add Route53 unit tests (issue 2066, commit e859576)
    Add a basic Route53 tutorial (issue 2060, commit f0ad46b)
    Add Autoscale associated public IP to launch configuration (issue 2051, issue 2028, issue 2029, commit c58bda6)
    Add option to pass VPC zone identifiers as a Python list (issue 2047, issue 1772, commit 07ef9e1)
    Add RDS call to get all log files (issue 2040, issue 1994, commit 925b8cb)

Bugfixes

    Changed S3 get_bucket to use HEAD in place of GET. (issue 2078, issue 2082, commit 016be83)
    Fix EMR’s describe_cluster_command. (issue 2034, commit 1c5621e)
    Tutorial small code fix (issue 2072, commit 38e7db1)
    Fix CloudFront string representation (issue 2069, commit 885c397)
    Route53 doc cleanup (issue 2059, commit d2fc38e)
    Fix MWS parsing of GetProductCategoriesForASIN response. (issue 2024, commit 0af08ce)
    Fix SQS docs for get_queue_attributes (issue 2061, commit 1cdc326)
    Don’t insert a ‘?’ in URLs unless there is a query string (issue 2042, issue 1943, commit c15ce60)



v2.24.0
Features

    Load region and endpoint information from a JSON file (commit b9dbaad)
    Return the x-amz-restore header with GET KEY and fix provider prefix. (issue 1990, commit 43e8e0a)
    Make S3 key validation optional with the validate parameter (issue 2013, issue 1996, commit fd6b632)
    Adding new eu-west-1 and eu-west-2 endpoints for SES. (issue 2015, commit d5ef862, commit 56ba3e5)
    Google Storage now uses new-style Python classes (issue 1927, commit 86c9f77)
    Add support for step summary list to Elastic MapReduce (issue 2011, commit d3af158)
    Added the M3 instance types. (issue 2012, commit 7c82f57)
    Add credential profile configuration (issue 1979, commit e3ab708)
    Add support for dead letter queues to SQS (commit 93c7d05)

Bugfixes

    Make the Lifecycle Id optional and fix prefix=None in XML generation. (issue 2021, commit 362a04a)
    Fix DynamoDB query limit bug (issue 2014, commit 7ecb3f7)
    Add documentation about the version_id behavior of Key objects. (issue 2026, commit b6b242c)
    Fixed typo in Table.create example (issue 2023, commit d81a660)
    Adding a license/copyright header. (issue 2025, commit 26ded39)
    Update the docstring for the SNS subscribe method (issue 2017, commit 4c806de)
    Renamed unit test with duplicate name (issue 2016, commit c7bd0bd)
    Use UTC instead of local time in test_refresh_credentials (issue 2020, commit b5a2eaf)
    Fix missing security_token option in some connection classes (issue 1989, issue 1942, commit 2b72f32)
    Fix listing S3 multipart uploads with some parameter combinations (issue 2000, commit 49045bc)
    Fix elbadmin crash because of non-extant instances in load balancer (issue 2001, commit d47cc14)
    Fix anonymous S3 fetch test case (issue 1988, issue 1992, commit 8fb1666)
    Fix elbadmin boto import (issue 2002, commit 674c3a6)
    Fixing SQS tutorial to correctly describe behavior of the write operation (issue 1986, commit 6147d86)
    Fix various grammar mistakes (issue 1980, commit ada40b5)



v2.23.0
Features

    Added pagination & date range filtering to Glacier inventory options. (issue 1977, commit 402a305)
    Added the ability to select the specific attributes to fetch in the scan & get_item calls within DynamoDB v2. (issue 1945, issue 1972, commit f6451fb & commit 96cd413)
    Allow getting a security token from either an environment or configuration variable. (:issue:, :sha:)
    Ported the has_item call from the original DynamoDB (v1) module to DynamoDB v2. (issue 1973, issue 1822, commit f96e9e3)
    Added an associate_address_object method to EC2. (issue 1967, issue 1874, issue 1893, commit dd6180c)
    Added a download_to_fileobj method to Glacier,similar to the S3 call of the same name. (issue 1960, issue 1941, commit 67266e5)
    Added support for arbitrary dict inputs to MWS. (issue 1966, commit 46f193f)

Bugfixes

    Made the usage of is/is not more consistent. (issue 1930, commit 8597c54)

    Imported with_statement for old Python versions (issue 1975, commit a53a574)

    Changed the Binary data object within DynamoDB to throw an error if an invalid data type is used. (issue 1963, issue 1956, commit e5d30c8)

    Altered the integration tests to avoid connection errors to certain regions. (commit 2555b8a)

    Changed the GCS resumable upload handler to save tracker files with protection 0600. (commit 7cb344c)

    Documentation:

            Clarified documentation around the list_metrics call in CloudFormation. (issue 1962, commit c996a72)
            Added Tag to the Autoscale API docs. (issue 1964, commit 31118d9)
            Updated the AWS Support documentation to the latest. (commit 29f9264)



boto v2.22.1
Bugfixes

    Fixed key names with special characters in S3 when using SigV4. (commit 8b37180)
    Re-added the nextToken attribute to the EC2 result set object. (issue 1968, commit 6928928)



boto v2.22.0
Features

    Updated Auto Scaling to support the latest API. (commit 9984c4f)
    Added the ability to alter response sizes in DynamoDB queries/scans. (issue 1949, commit 6761b01)

Bugfixes

    Fix string instance tests. (issue 1959, commit ee203bf)
    Add missing parameters to get_spot_price_history method. (issue 1958, commit f635474)
    Fix unicode string parameter handling in S3Connection. (issue 1954, issue 1952, commit 12e6b0c)
    Fix typo in docstring for SSHClient.run. (issue 1953, commit 5263b20)
    Properly handle getopt long options in s3put. (issue 1950, issue 1946, commit cf693ff)



boto v2.21.2
Bugfixes

    Fixed a missed inheritance bug in mturk. (issue 1936, commit 0137f29)



boto v2.21.1
Bugfixes

    Added cn-north-1 to regions. (commit 9c89de1)

    Fixed threading issues related to datetime.strptime. (issue 1898, commit 2ef66c9)

    Updated all the old-style inheritance calls. (issue 1918, issue 1936, issue 1937, commit 39a997f & commit 607624f)

    Documentation:

            Added missed notes about the cn-north-1 region. (commit 738c8cb)
            Added the C3 family of EC2 instances. (issue 1938, commit 05b7482)




v2.21.0
Features¶

    Add support for Elastic Transcoder pagination and new codecs (commit dcb1c5a)
    Add support for new CloudTrail calling format (commit aeafe9b)
    Update to the latest Support API (commit 45e1884)
    Add support for arbitrarily large SQS messages stored in S3 via BigMessage. (issue 1917, commit e6cd665)
    Add support for encoding_type to S3 (commit 6b2d967)
    Add support for Elastic MapReduce tags (issue 1928, issue 1920, commit b9749c6, commit 8e4c595)
    Add high level support for global secondary indexes in DynamoDB (issue 1924, issue 1913, commit 32dac5b)
    Add support for Elastic Beanstalk worker environments. (issue 1911, commit bbd4fbf)
    Add support for OpsWorks IAM user permissions per stack (commit ac6e4e7)
    Add support for SigV4 to S3 (commit deb9e18)
    Add support for SigV4 to EC2 (commit bdebfe0)
    Add support for SigV4 to ElastiCache (commit b892b45)

Bugfixes

    Add documentation describing account usage for multipart uploads in S3 (commit af03d8d)
    Update DesiredCapacity if AutoScalingGroup.desired_capacity is not None. (issue 1906, issue 1906, issue 1757, commit b6670ce)
    Documentation: add Kinesis API reference (issue 1921, commit c169836)
    Documentation: sriovNetSupport instance attribute (issue 1915, commit e1bafcc)
    Update RDS documentation for API version: 2013-09-09 (issue 1914, commit fcf702a)
    Switch all classes to new style classes which results in memory use improvements (commit ca36fa2)



v2.20.0
Features

    Add support for Amazon Kinesis (commit d0b684e)
    Add support for i2 instance types to EC2. (commit 0f5371f)
    Add support for DynamoDB Global Secondary Indexes (commit 297cacb)
    Add support for AWS Direct Connect. (issue 1894, issue 1894, commit 3cbca26)
    Add option for sorting SDB dumps to sdbadmin. (issue 1888, issue 1888, commit 070e4f6)
    Add a retry when EC2 metadata is returned as corrupt JSON. (issue 1883, issue 1883, issue 1868, commit 41470a0)
    Added some missing attributes to DBInstance and DBSnapshot. (issue 1880, issue 1880, commit 2751dff)

Bugfixes

    Implement nonzero for DynamoDB Item to consider empty items falsey (issue 1899, commit 808e550)
    Remove dimensions from Metric.query() docstring. (issue 1901, issue 1901, commit ba6b8c7)
    Make trailing slashes for EC2 metadata URLs explicit & remove them from userdata requests. This fixes using boto for CloudStack (issue 1900, issue 1900, issue 1897, issue 1856, commit 5f4506e)
    Fix the DynamoDB ‘scan in’ filter to compare the same attribute types in a list rather than using an attribute set. (issue 1896, issue 1896, commit 5fc59d6)
    Updating Amazon ElastiCache parameters to be optional when creating a new cache cluster. (issue 1876, issue 1876, commit 342b8df)
    Fix honor cooldown AutoScaling parameter serialization to prevent an exception and bad request. (issue 1895, issue 1895, issue 1892, commit fc4674f)
    Fix ignored RDS backup_retention_period when value was 0. (issue 1887, issue 1887, issue 1886, commit a19eb14)
    Use auth_handler to specify host header value including custom ports if possible, which are used by Eucalyptus. (issue 1862, issue 1862, commit ce6df03)
    Fix documentation of launch config in Autoscaling Group. (issue 1881, issue 1881, commit 6f704d9)
    typo: AIM -> IAM (issue 1882, commit 7ea2d5c)




boto v2.19.0
Features

    Add max results parameters to EC2 describe instances and describe tags.
        (issue 1873, issue 1873, commit ad8a64a)

    Add support for RDS CopyDBSnapshot. (issue 1872, issue 1872,
        issue 1865, commit bffb758)

Bugfixes

    Update README.rst to link to ReadTheDocs changelogs. (issue 1869,
        commit 26f3dbe)

    Delete the old changelog in favor of the README link to ReadTheDocs
        changelogs. (issue 1870, issue 1870, commit 32bc333)



v2.18.0
Features

    Add support for new STS and IAM calls related to SAML. (issue 1867,
        issue 1867, commit 1c51d17)

    Add SigV4 support to Cloudwatch (commit ef43035)

    Add support for ELB Attributes and Cross Zone Balancing. (issue 1852,
        issue 1852, commit 76f8b7f)

    Add RDS promote and rename support. (issue 1857, issue 1857,
        commit 0b62c70)

    Update EC2 get_all_snapshots and add support for registering an image
        with a snapshot. (issue 1850, issue 1850, commit 3007956)

Bugfixes

    Fix issues related to encoding of values in HTTP headers when using
        unicode. (issue 1864, issue 1864, issue 1839, issue 1829, issue 1828, issue 702, commit 5610dd7)

    Fix order of Beanstalk documetation to match param order. (issue 1863,
        issue 1863, commit a3a29f8)

    Make sure file is closed before attempting to delete it when downloading
        an S3 key. (issue 1791, commit 0e6dcbe)

    Fix minor CloudTrail documentation typos. (issue 1861, issue 1861,
        commit 256a115)

    Fix DynamoDBv2 tutorial sentence with missing verb. (issue 1859,
        issue 1825, issue 1859, commit 0fd5300)

    Fix parameter validation for gs (issue 1858, commit 6b9a869)




v2.17.0
Features

    Add support for AWS CloudTrail (commit 53ba0c9)
    Add support for new Amazon Redshift features (commit d94b48c)

Bugfixes

    Add missing argument for Google Storage resumable uploads. (commit b777b62)



v2.16.0
Features¶

    Added recipe for parallel execution of activities to SWF tutorial. (issue 1800, issue 1800, commit 52c5432)
    Added launch_config’s parameter associate_ip_address for VPC. (issue 1799, issue 1799, commit 6685adb)
    Update elbadmin add/remove commands to support multiple instance arguments. (issue 1806, issue 1806, commit 4aad26d)
    Added documentation for valid auto scaling event types and tags. (issue 1807, issue 1807, commit 664f6e8)
    Support VPC tenancy restrictions and filters for DHCP options. (issue 1801, issue 1801, commit 8c5d8de)
    Add VPC network ACL support. (issue 1809, issue 1098, issue 1809, commit 9043d09)
    Add convenience functions to make DynamoDB2 behave more like DynamoDB (issue 1780, commit 2cecaca)
    EC2 cancel_spot_instance_requests now returns a list of SpotInstanceRequest objects. (issue 1811, issue 1811, issue 1754, commit f3361b9)
    Fix VPC DescribeVpnConnections call argument; Add support for static_routes_only when creating a new VPC. (issue 1816, issue 1816, issue 1481, commit b408637)
    Add a section about DynamoDB Local to the DynamoDBv2 high level docs. (issue 1821, issue 1821, issue 1818, commit 639505f)
    Add support for new Elastic MapReduce APIs (issue 1836, commit 5562264)
    Modify EMR add_jobflow_steps to return a JobFlowStepList. (issue 1838, issue 1838, commit ef9564f)
    Generate docs for route53/zone, remove docs for route53/hostedzone. (issue 1837, issue 1837, commit 99e2e67)

BugFixes

    Fix for MWS iterator handling (commit 7e6f98d)
    Clarify documentation for MetricAlarm dimensions. (issue 1808, issue 1808, issue 1803, commit 4233fbf)
    Fixes for general connection behind proxy. (issue 1781, issue 1781, commit dc8bbea)
    Validate S3 method kwarg names to prevent misspelling. (issue 1810, issue 1810, issue 1782, commit 947a14a)
    Fix dependencies so they show up as optional in CheeseShop (issue 1617, commit 54da8b6)
    Route53 retry HTTP error 400s (issue 1618, commit 6e355b3)
    Fix typo in IAMConnection documentation (issue 1820, commit 3fc335d)
    Fix MWS MemberLists parsing. (issue 1815, issue 1815, commit 0f6f089)
    Fix typo in SQS documentation (issue 1830, commit 20532a6)
    Update auto scaling documentation. (issue 1824, issue 1824, issue 1823, commit 9a359ec)
    Fixing region endpoints for EMR (issue 1831, commit ed669f7)
    Raising an exception in SQS message decode() should not abort parsing. (issue 1835, issue 1835, issue 1833, commit 2a00c92)
    Replace correct VPC ACL association instead of just the first one. (issue 1844, issue 1844, issue 1843, commit c70b8d6)
    Prevent swallowing CloudSearch errors (issue 1846, issue 1842, commit c2f955b)



v2.15.0
Features

    Add SWF tutorial and code sample (issue 1769, commit 36524f5)
    Add ap-southeast-2 region to S3WebsiteEndpointTranslate (issue 1777, commit e7b0b39)
    Add support for owner_acct_id in SQS get_queue (issue 1786, commit c1ad303)
    Add ap-southeast-2 region to Glacier (commit c316266)
    Add ap-southeast-1 and ap-southeast-2 to Redshift (commit 3d67a03)
    Add SSH timeout option (issue 1755, commit d8e70ef, commit 653b82b)
    Add support for markers in lss3 (issue 1783, commit 8ee4b1f)
    Add block_device_mapping to EC2 create_image (issue 1794, commit 86afe2e)
    Updated SWF tutorial (issue 1797, commit 3804b16)
    Support Elastic Transcoder audio transcoding (commit 03a5087)

Bugfixes

    Fix VPC module docs, ELB docs, some formatting (issue 1770, commit 75de377)
    Fix DynamoDB item attrs initialization (issue 1776, commit 8454a2b)
    Fix parsing of empty member lists for MWS (issue 1785, commit 7b46ca5)
    Fix link to release notes in docs (commit a6bf794)
    Do not validate bucket when copying a key (issue 1763, commit 5505113)
    Retry HTTP 502, 504 errors (issue 1798, commit c832e2d)



v2.14.0
Features

    Add support for a --region argument to s3put and auto-detect bucket
        regions if possible (issue 1731, commit d9c28f6)

    Add delete_notification_configuration for EC2 autoscaling
        (issue 1717, commit ebb7ace)

    Add support for registering HVM instances (issue 1733, commit 2afc68e)

    Add support for ReplaceRouteTableAssociation for EC2 (issue 1736,
        commit 4296835)

    Add sms as an option for SNS subscribe (issue 1744, commit 8ff08e5)
    Allow overriding has_google_credentials (issue 1752, commit 052cc91)
    Add EPUB output format for docs (issue 1759, commit def7c67)

    Add handling of Connection: close HTTP headers in responses
        (issue 1773, commit 1a38f32)

    Make connection pooling port-aware (issue 1764, issue 1737,
        commit b6c7330)

    Add support for instance_type to modify_reserved_instances
        (commit bf07eee)

    Add support for new OpsWorks features (commit f512898)

Bugfixes

    Remove erroneous dry_run parameter (issue 1729, commit 35a516e)

    Fix task_list override in poll methods of SWF Deciders and Workers (
        issue 1724, commit fa8d871)

    Remove Content-Encoding header from metadata test (issue 1735,
        commit c8b0130)

    Fix the ability to override DynamoDBv2 host and port when creating
        connections (issue 1734, commit 8d2b492)

    Fix UnboundLocalError (commit e0e6aeb)

    self.rules is of type IPPermissionsList, remove takes no kwargs
        (commit 3c56b3f)

    Nicer error messages for 403s (issue 1753, commit d3d9eab)
    Various documentation fixes (issue 1762, commit 76aef10)
    Various Python 2.5 fixes (commit 150aef6, commit 67ae9ff)

    Prevent certificate tests from failing for non-govcloud accounts
        (commit 2d3d9f6)

    Fix flaky resumable upload test (issue 1768, commit 6aa8ae2)

    Force the Host HTTP header to fix an issue with older httplibs
        (commit 202c456)

    Blacklist S3 from forced Host HTTP header (commit 9193226)
    Fix propagate_at_launch spelling error (issue 1739, commit e78d88a)

    Remove unused code that causes exceptions with bad response data
        (issue 1771, commit bec5e70)

    Fix detach_subnets typo (issue 1760, commit 4424e1b)

    Fix result list handling of GetMatchingProductForIdResponse for MWS
        (issue 1751, commit 977b7dc)




boto v2.13.3
This release fixes a packaging error with the previous version of boto. The version v2.13.2 was provided instead of 2.13.2, causing things like pip to incorrectly resolve the latest release.

That release was only available for several minutes & was removed from PyPI due to the way it would break installation for users.

v2.13.2
Bugfixes

    Fixed test fallout from the EC2 dry-run change. (commit 2159456)

    Added tests for more of SWF’s layer2. (issue 1718, commit 35fb741, commit a84d401, commit 1cf1641, commit a36429c)

    Changed EC2 to allow name to be optional in calls to copy_image. (issue 1672, :sha:` 26285aa`)

    Added billingProducts support to EC2 Image. (issue 1703, commit cccadaf, commit 3914e91)

    Fixed a place where dry_run was handled in EC2. (issue 1722, commit 0a52c82)

    Fixed run_instances with a block device mapping. (issue 1723, commit 974743f, commit 9049f05, commit d7edafc)

    Fixed s3put to accept headers with a = in them. (issue 1700, commit 7958c70)

    Fixed a bug in DynamoDB v2 where scans with filters over large sets may not return all values. (issue 1713, commit 02893e1)

    Cloudsearch now uses SigV4. (commit b2bdbf5)

    Several documentation improvements/fixes:

            Added the “Apps Built On Boto” doc. (commit 3bd628c)



boto v2.13.0
Bugfixes¶

    Fixed EC2’s associate_public_ip to work correctly. (commit 9db6101)

    Fixed a bug with dynamodb_load when working with sets. (issue 1664, commit ef2d28b)

    Changed SNS publish to use POST. (commit 9c11772)

    Fixed inability to create LaunchConfigurations when using Block Device Mappings. (issue 1709, issue 1710, commit 5fd728e)

    Fixed DynamoDBv2’s batch_write to appropriately handle UnprocessedItems. (issue 1566, issue 1679, issue 1714, commit 2fc2369)

    Several documentation improvements/fixes:

            Added Opsworks docs to the index. (commit 5d48763)
            Added docs on the correct string values for get_all_images. (issue 1674, commit 1e4ed2e)
            Removed a duplicate boto.s3.prefix entry from the docs. (issue 1707, commit b42d34c)
            Added an API reference for boto.swf.layer2. (issue 1712, commit 9f7b15f)


boto v2.12.0
Features

    Added support for Redis & replication groups to Elasticache. (commit f744ff6)

Bugfixes

    Boto’s User-Agent string has changed. Mostly additive to include more information. (commit edb038a)

    Headers that are part of S3’s signing are now correctly coerced to the proper case. (issue 1687, commit 89eae8c)

    Altered S3 so that it’s possible to track what portions of a multipart upload succeeded. (issue 1305, issue 1675, commit e9a2c59)

    Added create_lb_policy & set_lb_policies_of_backend_server to ELB. (issue 1695, commit 77a9458)

    Fixed pagination when listing vaults in Glacier. (issue 1699, commit 9afecca)

    Several documentation improvements/fixes:

            Added some docs about what command-line utilities ship with boto. (commit 5d7d54d)



boto v2.11.0
Features

    Added Public IP address support within VPCs created by EC2. (commit be132d1)
    All services can now easily use GovCloud. (issue 1651, commit 542a301, commit 3c56121, commit 9167d89)
    Added db_subnet_group to RDSConnection.restore_dbinstance_from_point_in_time. (issue 1640, commit 06592b9)
    Added monthly_backups to EC2’s trim_snapshots. (issue 1688, commit a2ad606, commit 2998c11, commit e32d033)
    Added get_all_reservations & get_only_instances methods to EC2. (issue 1572, commit ffc6cc0)

Bugfixes

    Fixed the parsing of CloudFormation’s LastUpdatedTime. (issue 1667, :sha:` 70f363a`)

    Fixed STS’ assume_role_with_web_identity to work correctly. (issue 1671, commit ed1f403, commit ca794d5, commit ed7e563, commit 859762d)

    Fixed how VPC security group filtering is done in EC2. (issue 1665, issue 1677, commit be00956, commit 5e85dd1, commit e63aae8)

    Fixed fetching more than 100 records with ResourceRecordSet. (issue 1647, issue 1648, issue 1680, commit b64dd4f, commit 276df7e, commit e57cab0, commit e62a58b, commit 4c81bea, commit a3c635b)

    Fixed how VPC Security Groups are referred to when working with RDS. (issue 1602, issue 1683, issue 1685, issue 1694, commit 012aa0c, commit d5c6dfa, commit 7841230, commit 0a90627, commit ed4fd8c, commit 61d394b, commit ebe84c9, commit a6b0f7e)

    Google Storage Key now uses transcoding-invariant headers where possible. (commit d36eac3)

    Doing non-multipart uploads when using s3put no longer requires having the ListBucket permission. (issue 1642, issue 1693, commit f35e914)

    Fixed the serialization of attributes in a variety of SNS methods. (issue 1686, commit 4afb3dd, commit a58af54)

    Fixed SNS to be better behaved when constructing an mobile push notification. (issue 1692, commit 62fdf34)

    Moved SWF to SigV4. (commit ef7d255)

    Several documentation improvements/fixes:

            Updated the DynamoDB v2 docs to correct how the connection is built. (issue 1662, commit 047962d)
            Fixed a typo in the DynamoDB v2 docstring for Table.create. (commit be00956)
            Fixed a typo in the DynamoDB v2 docstring for Table for custom connections. (issue 1681, commit 6a53020)
            Fixed incorrect parameter names for DBParameterGroup in RDS. (issue 1682, commit 0d46aed)
            Fixed a typo in the SQS tutorial. (issue 1684, commit 38b7889)


```