### PR TITLE
Remove lunatic-python-bugfix

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -62,7 +62,6 @@ Jinja2==2.10
 jmespath==0.9.3
 lazy-object-proxy==1.3.1
 limitlion==0.9.2
-lunatic-python-bugfix==1.1.1  # For Redis mocking in tests
 lxml==3.4.2
 Mako==1.0.7
 MarkupSafe==1.0


### PR DESCRIPTION
It seems this was used at some point in the test suite but is no longer needed as it passes without it.