### PR TITLE
gevent.coros has been renamed to gevent.lock

### DIFF
--- a/inbox/util/file.py
+++ b/inbox/util/file.py
@@ -4,7 +4,7 @@ import os
 import string
 import sys
 
-from gevent.coros import BoundedSemaphore
+from gevent.lock import BoundedSemaphore
 
 if sys.version_info < (3,):
     import builtins


### PR DESCRIPTION
This import warns:

`DeprecationWarning: gevent.coros has been renamed to gevent.lock`