### PR TITLE
BaseException.message is deprecated since 2.6 and removed in Python 3

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -390,9 +390,9 @@ class CrispinClient(object):
             # checking for Yahoo / Gmail / Outlook (Hotmail) specific errors:
             # TODO: match with FolderSyncEngine.get_new_uids
             if (
-                "[NONEXISTENT] Unknown Mailbox:" in e.message
-                or "does not exist" in e.message
-                or "doesn't exist" in e.message
+                "[NONEXISTENT] Unknown Mailbox:" in e.args[0]
+                or "does not exist" in e.args[0]
+                or "doesn't exist" in e.args[0]
             ):
                 raise FolderMissingError(folder)
 

--- a/inbox/logging.py
+++ b/inbox/logging.py
@@ -317,8 +317,11 @@ def create_error_log_context(exc_info):
     if hasattr(exc_value, "code"):
         out["error_code"] = exc_value.code
 
-    if hasattr(exc_value, "message"):
-        out["error_message"] = exc_value.message
+    if hasattr(exc_value, "args") and hasattr(exc_value.args, "__getitem__"):
+        try:
+            out["error_message"] = exc_value.args[0]
+        except IndexError:
+            pass
 
     try:
         if exc_tb:

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -119,7 +119,7 @@ def retry_with_logging(
 
         if mysql_error:
             for msg in TRANSIENT_MYSQL_MESSAGES:
-                if msg in mysql_error.message:
+                if msg in mysql_error.args[0]:
                     is_transient = True
 
         if is_transient:


### PR DESCRIPTION
You want to use `.args[0]` which is forward and backward compatible.