### PR TITLE
Fix tests/events/test_google_events.py for Python3 compatibility

### DIFF
--- a/tests/events/test_google_events.py
+++ b/tests/events/test_google_events.py
@@ -380,10 +380,10 @@ def test_pagination():
     first_response.status_code = 200
     first_response._content = json.dumps(
         {"items": ["A", "B", "C"], "nextPageToken": "CjkKKzlhb2tkZjNpZTMwNjhtZThllU"}
-    )
+    ).encode()
     second_response = requests.Response()
     second_response.status_code = 200
-    second_response._content = json.dumps({"items": ["D", "E"]})
+    second_response._content = json.dumps({"items": ["D", "E"]}).encode()
 
     requests.get = mock.Mock(side_effect=[first_response, second_response])
     provider = GoogleEventsProvider(1, 1)
@@ -398,7 +398,7 @@ def test_handle_http_401():
 
     second_response = requests.Response()
     second_response.status_code = 200
-    second_response._content = json.dumps({"items": ["A", "B", "C"]})
+    second_response._content = json.dumps({"items": ["A", "B", "C"]}).encode()
 
     requests.get = mock.Mock(side_effect=[first_response, second_response])
     provider = GoogleEventsProvider(1, 1)
@@ -427,11 +427,11 @@ def test_handle_quota_exceeded():
                 "message": "User Rate Limit Exceeded",
             }
         }
-    )
+    ).encode()
 
     second_response = requests.Response()
     second_response.status_code = 200
-    second_response._content = json.dumps({"items": ["A", "B", "C"]})
+    second_response._content = json.dumps({"items": ["A", "B", "C"]}).encode()
 
     requests.get = mock.Mock(side_effect=[first_response, second_response])
     provider = GoogleEventsProvider(1, 1)
@@ -449,7 +449,7 @@ def test_handle_internal_server_error():
 
     second_response = requests.Response()
     second_response.status_code = 200
-    second_response._content = json.dumps({"items": ["A", "B", "C"]})
+    second_response._content = json.dumps({"items": ["A", "B", "C"]}).encode()
 
     requests.get = mock.Mock(side_effect=[first_response, second_response])
     provider = GoogleEventsProvider(1, 1)
@@ -478,7 +478,7 @@ def test_handle_api_not_enabled():
                 ],
             }
         }
-    )
+    ).encode()
 
     requests.get = mock.Mock(return_value=response)
     provider = GoogleEventsProvider(1, 1)
@@ -490,7 +490,7 @@ def test_handle_api_not_enabled():
 def test_handle_other_errors():
     response = requests.Response()
     response.status_code = 403
-    response._content = "This is not the JSON you're looking for"
+    response._content = b"This is not the JSON you're looking for"
     requests.get = mock.Mock(return_value=response)
     provider = GoogleEventsProvider(1, 1)
     provider._get_access_token = mock.Mock(return_value="token")


### PR DESCRIPTION
These tests mock requests internals to fake responses.

Both on Python 2 and Python 3 requests expects `_content` to be `bytes` binary data. To make it work across Python 2 and Python 3 extra `.encode()` calls are needed or just simply dropping `b` prefix for constants.