### PR TITLE
Fix tests/api/test_searching.py

### DIFF
--- a/inbox/search/backends/imap.py
+++ b/inbox/search/backends/imap.py
@@ -156,7 +156,7 @@ class IMAPSearchClient(object):
         self._open_crispin_connection(db_session)
 
         try:
-            criteria = ["TEXT", search_query.encode("ascii")]
+            criteria = [b"TEXT", search_query.encode("ascii")]
             charset = None
         except UnicodeEncodeError:
             criteria = [u"TEXT", search_query]

--- a/tests/api/test_searching.py
+++ b/tests/api/test_searching.py
@@ -389,7 +389,7 @@ def test_imap_message_search(
     else:
         messages = imap_api_client.get_data("/messages/search?" "q=blah%20blah%20blah")
 
-    imap_connection.assert_search(["TEXT", "blah blah blah"])
+    imap_connection.assert_search([b"TEXT", b"blah blah blah"])
     assert_search_result(sorted_imap_messages, messages)
 
 
@@ -413,7 +413,7 @@ def test_imap_thread_search(
     else:
         threads = imap_api_client.get_data("/threads/search?q=blah%20blah%20blah")
 
-    imap_connection.assert_search(["TEXT", "blah blah blah"])
+    imap_connection.assert_search([b"TEXT", b"blah blah blah"])
     assert_search_result(sorted_imap_threads, threads)
 
 


### PR DESCRIPTION
This is about the internals of imaplib. When searching over an IMAP connection you are either supposed to send all the criteria items as `bytes` or all of them as `unicode`, but don't mix `bytes` with `unicode` at the same time.

This is better explained here:

https://github.com/mjs/imapclient/blob/1.0.0/imapclient/imapclient.py#L667-L717