### PR TITLE
Load_module fix for Python 3 compatibility

### DIFF
--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -4,6 +4,7 @@ import sys
 import time
 from datetime import datetime
 from email.utils import mktime_tz, parsedate_tz
+from importlib import import_module
 
 from inbox.logging import get_logger
 from inbox.providers import providers
@@ -138,11 +139,11 @@ def load_modules(base_name, base_path):
     """
     modules = []
 
-    for importer, module_name, _ in pkgutil.iter_modules(base_path):
+    for _, module_name, _ in pkgutil.iter_modules(base_path):
         full_module_name = "{}.{}".format(base_name, module_name)
 
         if full_module_name not in sys.modules:
-            module = importer.find_module(module_name).load_module(full_module_name)
+            module = import_module(full_module_name)
         else:
             module = sys.modules[full_module_name]
         modules.append(module)


### PR DESCRIPTION
This project uses rather curious way of importing modules. It walks some packages and imports every single module file it can find. I think it was meant to implement some kind of "plugins systems" but it's mostly not used these days and could probably use explicit imports instead. Anyway I had to fix it first.

`pkgutil.iter_modules(base_path)` returns a legacy importer that works differently between Python 2 and 3. Hopefully we can already use a very limited importlib on Python 2.7 to import module: https://docs.python.org/2/library/importlib.html. That module is also much bigger and available on Python 3.