### PR TITLE
Always send HTML with base64 encoding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax = docker/dockerfile:1.3
 FROM ubuntu:xenial-20210804
 ARG PYTHON_VERSION=2.7
 
@@ -63,7 +62,6 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN \
-  --mount=type=cache,target=/home/sync-engine/.cache/pip,uid=5000,gid=5000 \
   python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==44.0.0 pip==20.3.4 && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements_frozen.txt && \
@@ -75,5 +73,4 @@ RUN ln -s /opt/app/bin/wait-for-it.sh /opt/venv/bin/
 
 ENV \
   LANG="en_US.UTF-8" \
-  LC_ALL="en_US.UTF-8" \
-  PYTHONDONTWRITEBYTECODE=1
+  LC_ALL="en_US.UTF-8"


### PR DESCRIPTION
There is a test that insists on sending HTML part of the email as `base64` and not `quoted-printable`.

https://github.com/closeio/sync-engine/blob/6453c90263cb743a02c2266b2b52d39ed580e3c2/tests/api/test_sending.py#L423-L452

Flanker, the library we use to handle parts has a behavior change between Python 2 & 3. On Python 3 it will prefer to use `quoted-printable`. A conforming mail client of course will handle both OK but apparently the test insist that `base64` is more widely supported/compatible. The change forces base64 on both Python 2 & 3

We are not using this part of sync-engine ourselves as we are not sending mails over SMTP. This is just to make the test suite happy...