### PR TITLE
old_div

### DIFF
--- a/inbox/contacts/algorithms.py
+++ b/inbox/contacts/algorithms.py
@@ -1,5 +1,9 @@
+from __future__ import division
+
 import datetime
 from collections import defaultdict
+
+from past.utils import old_div
 
 """
 This file currently contains algorithms for the contacts/rankings endpoint
@@ -27,7 +31,7 @@ SOCIAL_MOLECULE_LIMIT = 5000  # Give up if there are too many messages
 
 def _get_message_weight(now, message_date):
     timediff = now - message_date
-    weight = 1 - (timediff.total_seconds() / LOOKBACK_TIME)
+    weight = 1 - (old_div(timediff.total_seconds(), LOOKBACK_TIME))
     return max(weight, MIN_MESSAGE_WEIGHT)
 
 
@@ -173,10 +177,9 @@ def _subsume_molecules(molecules_list, get_message_list_weight):
             g2, m2 = molecules_list[j]  # Bigger group
             m2_size = mol_weights[j]
             if g1.issubset(g2):
-                sharing_error = (
-                    (len(g2) - len(g1))
-                    * (m1_size - m2_size)
-                    / (1.0 * (len(g2) * m1_size))
+                sharing_error = old_div(
+                    (len(g2) - len(g1)) * (m1_size - m2_size),
+                    (1.0 * (len(g2) * m1_size)),
                 )
                 if sharing_error < SELF_IDENTITY_THRESHOLD:
                     is_subsumed[i] = True

--- a/inbox/instrumentation.py
+++ b/inbox/instrumentation.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import collections
 import math
 import signal
@@ -11,6 +13,7 @@ import gevent.hub
 import greenlet
 import psutil
 import thread
+from past.utils import old_div
 
 from inbox.config import config
 from inbox.logging import get_logger
@@ -130,7 +133,7 @@ class GreenletTracer(object):
 
     def stats(self):
         total_time = time.time() - self.start_time
-        idle_fraction = self.time_spent_by_context.get("hub", 0) / total_time
+        idle_fraction = old_div(self.time_spent_by_context.get("hub", 0), total_time)
         return {
             "times": self.time_spent_by_context,
             "idle_fraction": idle_fraction,
@@ -196,7 +199,7 @@ class GreenletTracer(object):
         # are waiting to run.
         pendingcnt = self._hub.loop.pendingcnt
         for k, v in self.pending_avgs.items():
-            exp = math.exp(-self.sampling_interval / (60.0 * k))
+            exp = math.exp(old_div(-self.sampling_interval, (60.0 * k)))
             self.pending_avgs[k] = exp * v + (1.0 - exp) * pendingcnt
 
     def _calculate_cpu_avgs(self):
@@ -204,7 +207,7 @@ class GreenletTracer(object):
         new_total_time = times.user + times.system
         delta = new_total_time - self.total_cpu_time
         for k, v in self.cpu_avgs.items():
-            exp = math.exp(-self.sampling_interval / (60.0 * k))
+            exp = math.exp(old_div(-self.sampling_interval, (60.0 * k)))
             self.cpu_avgs[k] = exp * v + (1.0 - exp) * delta
         self.total_cpu_time = new_total_time
 


### PR DESCRIPTION
Brings back old Python 2 style truncating division to Python 3 where needed. Similarily this is verbatim output of one of futurize passes.