### PR TITLE
int-long

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -5,6 +5,7 @@ import re
 import time
 
 import imapclient
+from past.builtins import long
 
 # Prevent "got more than 1000000 bytes" errors for servers that send more data.
 imaplib._MAXLINE = 10000000

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta
 
 import gevent
 from gevent.lock import Semaphore
+from past.builtins import long
 from sqlalchemy.orm import joinedload, load_only
 
 from inbox.logging import get_logger

--- a/inbox/security/oracles.py
+++ b/inbox/security/oracles.py
@@ -4,6 +4,7 @@ import enum  # Python 3 style enums from enum34
 
 import nacl.secret
 import nacl.utils
+from past.builtins import long
 
 from inbox.config import config
 

--- a/inbox/util/encoding.py
+++ b/inbox/util/encoding.py
@@ -1,6 +1,8 @@
 import builtins
 import sys
 
+from past.builtins import long
+
 
 def base36encode(number):
     if not isinstance(number, (int, long)):

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -10,6 +10,7 @@ import subprocess
 
 import dns
 import pytest
+from past.builtins import long
 
 from inbox.basicauth import ValidationError
 

--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import imapclient
 import mock
 import pytest
+from past.builtins import long
 
 from inbox.crispin import (
     CrispinClient,


### PR DESCRIPTION
Brings back to Python 3 long (which is just int) for forward compatibility.
