### PR TITLE
Upgrade cffi

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -15,7 +15,7 @@ botocore==1.2.11
 bumpversion==0.5.3
 cchardet==2.1.1
 certifi==2020.4.5.1
-cffi==1.11.4
+cffi==1.14.6
 chardet==3.0.4
 ciso8601==2.2.0
 click==2.4


### PR DESCRIPTION
Upgrade to a version explicitely tested on Python 3.6

Reverse dependencies:

```
cffi==1.14.6
  - cryptography==2.1.4 [requires: cffi>=1.7]
    - flanker==0.9.11 [requires: cryptography>=0.5]
    - pyOpenSSL==17.5.0 [requires: cryptography>=2.1.4]
      - gevent-openssl==1.2 [requires: pyOpenSSL>=0.11]
      - IMAPClient==1.1.0a0 [requires: pyopenssl>=0.15.1]
      - ndg-httpsclient==0.4.3 [requires: PyOpenSSL]
        - nylas==1.2.3 [requires: ndg-httpsclient]
      - nylas==1.2.3 [requires: pyOpenSSL]
  - PyNaCl==0.3.0 [requires: cffi>=0.8]
```

Changelog

```
v1.14.6

Test fixes for CPython 3.10.0b3
Support for sys.unraisablehook() on Python >= 3.8
Fix two minor memory leaks (thanks Sebastian!)
Like many projects that had an IRC channel on freenode, we moved it to
irc.libera.chat.


v1.14.5

Source fix for old gcc versions
This and future releases should include wheels on more platforms,
thanks to our new release managers Matt and Matt!


v1.14.4
Release done for pip reasons.

v1.14.3
Release done for pip reasons.

v1.14.2


CPython 3 on Windows: we again try to compile with Py_LIMITED_API
by default.  This flag is not added if you run the compilation with
CPython 3.4, as it only works with CPython >= 3.5, but by now this
version of Python is quite old (and we no longer distribute cffi
wheels for it).
This may require that you upgrade virtualenv (requires version 16
or newer) or at least copy manually python3.dll into your existing
virtualenvs.  For distributing wheels with your cffi modules, you may
also need to upgrade wheel to the just-released version 0.35.
You can manually disable Py_LIMITED_API by calling
ffi.set_source(..., py_limited_api=False).



v1.14.1

CFFI source code is now hosted on Heptapod.
Improved support for typedef int my_array_t[...]; with an explicit
dot-dot-dot in API mode (issue #453)
Windows (32 and 64 bits): multiple fixes for ABI-mode call to functions
that return a structure.
Experimental support for MacOS 11 on aarch64.
and a few other minor changes and bug fixes.


v1.14


ffi.dlopen() can now be called with a handle (as a void *) to an
already-opened C library.


CPython only: fixed a stack overflow issue for calls like
lib.myfunc([large list]).  If the function is declared as taking a
float * argument, for example, then the array is temporarily converted
into a C array of floats---however, the code used to use alloca() for
this temporary storage, no matter how large.  This is now fixed.
The fix concerns all modes: in-line/out-of-line API/ABI.  Also note that your
API-mode C extension modules need to be regenerated with cffi 1.14 in order
to get the fix; i.e. for API mode, the fix is in the generated C sources.
(The C sources generated from cffi 1.14 should also work when running in
a different environment in which we have an older version of cffi.  Also,
this change makes no difference on PyPy.)
As a workaround that works on all versions of cffi, you can write
lib.myfunc(ffi.new("float[]", [large list])), which is
equivalent but explicity builds the intermediate array as a regular
Python object on the heap.


fixed a memory leak inside ffi.getwinerror() on CPython 3.x.



v1.13.2

re-release because the Linux wheels came with an attached version of libffi
that was very old and buggy (issue #432).


v1.13.1

deprecate the way to declare in cdef() a global variable with only
void *foo;.  You should always use a storage class, like extern void
*foo; or maybe static void *foo;.  These are all equivalent for
the purposes of cdef(), but the reason for deprecating the bare version
is that (as far as I know) it would always be mistake in a real C header.
fix the regression RuntimeError: found a situation in which we try
to build a type recursively (issue #429).
fixed issue #427 where a multithreading mistake in the embedding logic
initialization code would cause deadlocks on CPython 3.7.


v1.13


ffi.from_buffer("type *", ..) is now supported, in addition to
"type[]".  You can then write p.field to access the items, instead
of only p[0].field.  Be careful that no bounds checking is performed, so
p[n] might access data out of bounds.
fix for structs containing unnamed bitfields like int : 1;.
when calling cdata of "function pointer" type, give a RuntimeError instead
of a crash if the pointer happens to be NULL
support some more binary operations between constants in enum definitions
(PR #96)
silence a warning incorrectly emitted if you use a quote in a preprocessor
line
detect a corner case that would throw the C code into an infinite
recursion, with ffi.cdef("""struct X { void(*fnptr)(struct X); };""")



Older Versions

v1.12.3

Fix for nested struct types that end in a var-sized array (#405).
Add support for using U and L characters at the end of integer
constants in ffi.cdef() (thanks Guillaume).
More 3.8 fixes.


v1.12.2

Added temporary workaround to compile on CPython 3.8.0a2.


v1.12.1


CPython 3 on Windows: we again no longer compile with Py_LIMITED_API
by default because such modules still cannot be used with virtualenv.
The problem is that it doesn't work in CPython <= 3.4, and for
technical reason we can't enable this flag automatically based on the
version of Python.
Like before, Issue #350 mentions a workaround if you still want
the Py_LIMITED_API flag and either you are not concerned about
virtualenv or you are sure your module will not be used on CPython
<= 3.4: pass define_macros=[("Py_LIMITED_API", None)] as a keyword to the
ffibuilder.set_source() call.



v1.12


Direct support for pkg-config.

ffi.from_buffer() takes a new optional first argument that gives
the array type of the result.  It also takes an optional keyword argument
require_writable to refuse read-only Python buffers.

ffi.new(), ffi.gc() or ffi.from_buffer() cdata objects
can now be released at known times, either by using the with
keyword or by calling the new ffi.release().
Windows, CPython 3.x: cffi modules are linked with python3.dll
again.  This makes them independant on the exact CPython version,
like they are on other platforms.  It requires virtualenv 16.0.0.

Accept an expression like ffi.new("int[4]", p) if p is itself
another cdata int[4].
CPython 2.x: ffi.dlopen() failed with non-ascii file names on Posix
CPython: if a thread is started from C and then runs Python code (with
callbacks or with the embedding solution), then previous versions of
cffi would contain possible crashes and/or memory leaks.  Hopefully,
this has been fixed (see issue #362).
Support for ffi.cdef(..., pack=N) where N is a power of two.
Means to emulate #pragma pack(N) on MSVC.  Also, the default on
Windows is now pack=8, like on MSVC.  This might make a difference
in corner cases, although I can't think of one in the context of CFFI.
The old way ffi.cdef(..., packed=True) remains and is equivalent
to pack=1 (saying e.g. that fields like int should be aligned
to 1 byte instead of 4).


v1.11.5


Issue #357: fix ffi.emit_python_code() which generated a buggy
Python file if you are using a struct with an anonymous union
field or vice-versa.
Windows: ffi.dlopen() should now handle unicode filenames.
ABI mode: implemented ffi.dlclose() for the in-line case (it used
to be present only in the out-of-line case).
Fixed a corner case for setup.py install --record=xx --root=yy
with an out-of-line ABI module.  Also fixed Issue #345.
More hacks on Windows for running CFFI's own setup.py.

Issue #358: in embedding, to protect against (the rare case of)
Python initialization from several threads in parallel, we have to use
a spin-lock.  On CPython 3 it is worse because it might spin-lock for
a long time (execution of Py_InitializeEx()).  Sadly, recent
changes to CPython make that solution needed on CPython 2 too.
CPython 3 on Windows: we no longer compile with Py_LIMITED_API
by default because such modules cannot be used with virtualenv.
Issue #350 mentions a workaround if you still want that and are not
concerned about virtualenv: pass define_macros=[("Py_LIMITED_API",
None)] as a keyword to the ffibuilder.set_source() call.
```