### PR TITLE
Upgrade certifi

### DIFF
--- a/inbox/config.py
+++ b/inbox/config.py
@@ -14,13 +14,6 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-# TODO[mike]: This shold be removed once we've updated our base OS. openssl 1.0.1 doesn't support cross-signed certs
-# https://github.com/certifi/python-certifi/issues/26#issuecomment-138322515
-import certifi
-
-os.environ["REQUESTS_CA_BUNDLE"] = certifi.old_where()
-
-
 __all__ = ["config"]
 
 

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -14,7 +14,7 @@ boto3==1.1.4
 botocore==1.2.11
 bumpversion==0.5.3
 cchardet==2.1.1
-certifi==2018.1.18
+certifi==2020.4.5.1
 cffi==1.11.4
 chardet==3.0.4
 ciso8601==2.2.0


### PR DESCRIPTION
Upgrades certificate store. This is the last verion that works on Python 2.7