### PR TITLE
Upgrade lxml

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -65,7 +65,7 @@ Jinja2==2.10
 jmespath==0.9.3
 lazy-object-proxy==1.3.1
 limitlion==0.9.2
-lxml==3.4.2
+lxml==4.6.4
 Mako==1.0.7
 MarkupSafe==1.0
 mccabe==0.6.1


### PR DESCRIPTION
This is the last version of lxml and it still works on Python 2.

lxml is only used by contacts syncing which we don't use, updating for now nevertheless.