### PR TITLE
Upgrade requests and urllib3

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -16,7 +16,7 @@ bumpversion==0.5.3
 cchardet==2.1.1
 certifi==2020.4.5.1
 cffi==1.14.6
-chardet==3.0.4; python_version < '3.0'
+chardet==3.0.4
 charset-normalizer==2.0.7; python_version >= '3.5'
 ciso8601==2.2.0
 click==2.4

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -16,7 +16,8 @@ bumpversion==0.5.3
 cchardet==2.1.1
 certifi==2020.4.5.1
 cffi==1.14.6
-chardet==3.0.4
+chardet==3.0.4; python_version < '3.0'
+charset-normalizer==2.0.7; python_version >= '3.5'
 ciso8601==2.2.0
 click==2.4
 colorama==0.3.9

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -110,7 +110,7 @@ pytz==2017.3
 PyYAML==3.12
 redis==2.10.6
 regex==2018.1.10
-requests==2.11.0
+requests==2.26.0
 rollbar==0.16.1
 scandir==1.10.0
 setproctitle==1.1.10
@@ -128,7 +128,7 @@ toml==0.10.2
 traitlets==4.3.2
 typing==3.10.0.0; python_version < '3.5'
 uritemplate==0.6
-urllib3==1.22
+urllib3==1.26.7
 vobject==0.9.1
 wcwidth==0.2.5
 WebOb==1.7.4


### PR DESCRIPTION
These are the latest versions of requests and urrlib3, they still work on Python 2.

We use requests to:
* talk to authalligator
* fetch Google calendar events
* fetch contacts (we don't use this feature)

I've tested those paths locally and everything is working.

Requests changelog

```

2.26.0 (2021-07-13)

Improvements

    Requests now supports Brotli compression, if either the brotli or brotlicffi package is installed. (#5783)
    Session.send now correctly resolves proxy configurations from both the Session and Request. Behavior now matches Session.request. (#5681)

Bugfixes

    Fixed a race condition in zip extraction when using Requests in parallel from zip archive. (#5707)

Dependencies

    Instead of chardet, use the MIT-licensed charset_normalizer for Python3 to remove license ambiguity for projects bundling requests. If chardet is already installed on your machine it will be used instead of charset_normalizer to keep backwards compatibility. (#5797)

    You can also install chardet while installing requests by specifying [use_chardet_on_py3] extra as follows:

        `shell pip install "requests[use_chardet_on_py3]" `

    Python2 still depends upon the chardet module.

    Requests now supports idna 3.x on Python 3. idna 2.x will continue to be used on Python 2 installations. (#5711)

Deprecations

    The requests[security] extra has been converted to a no-op install. PyOpenSSL is no longer the recommended secure option for Requests. (#5867)
    Requests has officially dropped support for Python 3.5. (#5867)

2.25.1 (2020-12-16)

Bugfixes

    Requests now treats application/json as utf8 by default. Resolving inconsistencies between r.text and r.json output. (#5673)

Dependencies

    Requests now supports chardet v4.x.

2.25.0 (2020-11-11)

Improvements

    Added support for NETRC environment variable. (#5643)

Dependencies

    Requests now supports urllib3 v1.26.

Deprecations

    Requests v2.25.x will be the last release series with support for Python 3.5.
    The requests[security] extra is officially deprecated and will be removed in Requests v2.26.0.

2.24.0 (2020-06-17)

Improvements

    pyOpenSSL TLS implementation is now only used if Python either doesn’t have an ssl module or doesn’t support SNI. Previously pyOpenSSL was unconditionally used if available. This applies even if pyOpenSSL is installed via the requests[security] extra (#5443)
    Redirect resolution should now only occur when allow_redirects is True. (#5492)
    No longer perform unnecessary Content-Length calculation for requests that won’t use it. (#5496)

2.23.0 (2020-02-19)

Improvements

    Remove defunct reference to prefetch in Session __attrs__ (#5110)

Bugfixes

    Requests no longer outputs password in basic auth usage warning. (#5099)

Dependencies

    Pinning for chardet and idna now uses major version instead of minor. This hopefully reduces the need for releases everytime a dependency is updated.

2.22.0 (2019-05-15)

Dependencies

    Requests now supports urllib3 v1.25.2. (note: 1.25.0 and 1.25.1 are incompatible)

Deprecations

    Requests has officially stopped support for Python 3.4.

2.21.0 (2018-12-10)

Dependencies

    Requests now supports idna v2.8.

2.20.1 (2018-11-08)

Bugfixes

    Fixed bug with unintended Authorization header stripping for redirects using default ports (http/80, https/443).

2.20.0 (2018-10-18)

Bugfixes

    Content-Type header parsing is now case-insensitive (e.g. charset=utf8 v Charset=utf8).
    Fixed exception leak where certain redirect urls would raise uncaught urllib3 exceptions.
    Requests removes Authorization header from requests redirected from https to http on the same hostname. (CVE-2018-18074)
    should_bypass_proxies now handles URIs without hostnames (e.g. files).

Dependencies

    Requests now supports urllib3 v1.24.

Deprecations

    Requests has officially stopped support for Python 2.6.

2.19.1 (2018-06-14)

Bugfixes

    Fixed issue where status_codes.py’s init function failed trying to append to a __doc__ value of None.

2.19.0 (2018-06-12)

Improvements

    Warn user about possible slowdown when using cryptography version &lt; 1.3.4
    Check for invalid host in proxy URL, before forwarding request to adapter.
    Fragments are now properly maintained across redirects. (RFC7231 7.1.2)
    Removed use of cgi module to expedite library load time.
    Added support for SHA-256 and SHA-512 digest auth algorithms.
    Minor performance improvement to Request.content.
    Migrate to using collections.abc for 3.7 compatibility.

Bugfixes

    Parsing empty Link headers with parse_header_links() no longer return one bogus entry.
    Fixed issue where loading the default certificate bundle from a zip archive would raise an IOError.
    Fixed issue with unexpected ImportError on windows system which do not support winreg module.
    DNS resolution in proxy bypass no longer includes the username and password in the request. This also fixes the issue of DNS queries failing on macOS.
    Properly normalize adapter prefixes for url comparison.
    Passing None as a file pointer to the files param no longer raises an exception.
    Calling copy on a RequestsCookieJar will now preserve the cookie policy correctly.

Dependencies

    We now support idna v2.7.
    We now support urllib3 v1.23.

2.18.4 (2017-08-15)

Improvements

    Error messages for invalid headers now include the header name for easier debugging

Dependencies

    We now support idna v2.6.

2.18.3 (2017-08-02)

Improvements

    Running $ python -m requests.help now includes the installed version of idna.

Bugfixes

    Fixed issue where Requests would raise ConnectionError instead of SSLError when encountering SSL problems when using urllib3 v1.22.

2.18.2 (2017-07-25)

Bugfixes

    requests.help no longer fails on Python 2.6 due to the absence of ssl.OPENSSL_VERSION_NUMBER.

Dependencies

    We now support urllib3 v1.22.

2.18.1 (2017-06-14)

Bugfixes

    Fix an error in the packaging whereby the *.whl contained incorrect data that regressed the fix in v2.17.3.

2.18.0 (2017-06-14)

Improvements

    Response is now a context manager, so can be used directly in a with statement without first having to be wrapped by contextlib.closing().

Bugfixes

    Resolve installation failure if multiprocessing is not available
    Resolve tests crash if multiprocessing is not able to determine the number of CPU cores
    Resolve error swallowing in utils set_environ generator

2.17.3 (2017-05-29)

Improvements

    Improved packages namespace identity support, for monkeypatching libraries.

2.17.2 (2017-05-29)

Improvements

    Improved packages namespace identity support, for monkeypatching libraries.

2.17.1 (2017-05-29)

Improvements

    Improved packages namespace identity support, for monkeypatching libraries.

2.17.0 (2017-05-29)

Improvements

    Removal of the 301 redirect cache. This improves thread-safety.

2.16.5 (2017-05-28)

    Improvements to $ python -m requests.help.

2.16.4 (2017-05-27)

    Introduction of the $ python -m requests.help command, for debugging with maintainers!

2.16.3 (2017-05-27)

    Further restored the requests.packages namespace for compatibility reasons.

2.16.2 (2017-05-27)

    Further restored the requests.packages namespace for compatibility reasons.

No code modification (noted below) should be necessary any longer.
2.16.1 (2017-05-27)

    Restored the requests.packages namespace for compatibility reasons.
    Bugfix for urllib3 version parsing.

Note: code that was written to import against the requests.packages namespace previously will have to import code that rests at this module-level now.

For example:

    from requests.packages.urllib3.poolmanager import PoolManager

Will need to be re-written to be:

    from requests.packages import urllib3 urllib3.poolmanager.PoolManager

Or, even better:

    from urllib3.poolmanager import PoolManager

2.16.0 (2017-05-26)

    Unvendor ALL the things!

2.15.1 (2017-05-26)

    Everyone makes mistakes.

2.15.0 (2017-05-26)

Improvements

    Introduction of the Response.next property, for getting the next PreparedResponse from a redirect chain (when allow_redirects=False).
    Internal refactoring of __version__ module.

Bugfixes

    Restored once-optional parameter for requests.utils.get_environ_proxies().

2.14.2 (2017-05-10)

Bugfixes

    Changed a less-than to an equal-to and an or in the dependency markers to widen compatibility with older setuptools releases.

2.14.1 (2017-05-09)

Bugfixes

    Changed the dependency markers to widen compatibility with older pip releases.

2.14.0 (2017-05-09)

Improvements

    It is now possible to pass no_proxy as a key to the proxies dictionary to provide handling similar to the NO_PROXY environment variable.
    When users provide invalid paths to certificate bundle files or directories Requests now raises IOError, rather than failing at the time of the HTTPS request with a fairly inscrutable certificate validation error.
    The behavior of SessionRedirectMixin was slightly altered. resolve_redirects will now detect a redirect by calling get_redirect_target(response) instead of directly querying Response.is_redirect and Response.headers[‘location’]. Advanced users will be able to process malformed redirects more easily.
    Changed the internal calculation of elapsed request time to have higher resolution on Windows.
    Added win_inet_pton as conditional dependency for the [socks] extra on Windows with Python 2.7.
    Changed the proxy bypass implementation on Windows: the proxy bypass check doesn’t use forward and reverse DNS requests anymore
    URLs with schemes that begin with http but are not http or https no longer have their host parts forced to lowercase.

Bugfixes

    Much improved handling of non-ASCII Location header values in redirects. Fewer UnicodeDecodeErrors are encountered on Python 2, and Python 3 now correctly understands that Latin-1 is unlikely to be the correct encoding.
    If an attempt to seek file to find out its length fails, we now appropriately handle that by aborting our content-length calculations.
    Restricted HTTPDigestAuth to only respond to auth challenges made on 4XX responses, rather than to all auth challenges.
    Fixed some code that was firing DeprecationWarning on Python 3.6.
    The dismayed person emoticon (/o\) no longer has a big head. I’m sure this is what you were all worrying about most.

Miscellaneous

    Updated bundled urllib3 to v1.21.1.
    Updated bundled chardet to v3.0.2.
    Updated bundled idna to v2.5.
    Updated bundled certifi to 2017.4.17.

2.13.0 (2017-01-24)

Features

    Only load the idna library when we’ve determined we need it. This will save some memory for users.

Miscellaneous

    Updated bundled urllib3 to 1.20.
    Updated bundled idna to 2.2.

2.12.5 (2017-01-18)

Bugfixes

    Fixed an issue with JSON encoding detection, specifically detecting big-endian UTF-32 with BOM.

2.12.4 (2016-12-14)

Bugfixes

    Fixed regression from 2.12.2 where non-string types were rejected in the basic auth parameters. While support for this behaviour has been readded, the behaviour is deprecated and will be removed in the future.

2.12.3 (2016-12-01)

Bugfixes

    Fixed regression from v2.12.1 for URLs with schemes that begin with “http”. These URLs have historically been processed as though they were HTTP-schemed URLs, and so have had parameters added. This was removed in v2.12.2 in an overzealous attempt to resolve problems with IDNA-encoding those URLs. This change was reverted: the other fixes for IDNA-encoding have been judged to be sufficient to return to the behaviour Requests had before v2.12.0.

2.12.2 (2016-11-30)

Bugfixes

    Fixed several issues with IDNA-encoding URLs that are technically invalid but which are widely accepted. Requests will now attempt to IDNA-encode a URL if it can but, if it fails, and the host contains only ASCII characters, it will be passed through optimistically. This will allow users to opt-in to using IDNA2003 themselves if they want to, and will also allow technically invalid but still common hostnames.
    Fixed an issue where URLs with leading whitespace would raise InvalidSchema errors.
    Fixed an issue where some URLs without the HTTP or HTTPS schemes would still have HTTP URL preparation applied to them.
    Fixed an issue where Unicode strings could not be used in basic auth.
    Fixed an issue encountered by some Requests plugins where constructing a Response object would cause Response.content to raise an AttributeError.

2.12.1 (2016-11-16)

Bugfixes

    Updated setuptools ‘security’ extra for the new PyOpenSSL backend in urllib3.

Miscellaneous

    Updated bundled urllib3 to 1.19.1.

2.12.0 (2016-11-15)

Improvements

    Updated support for internationalized domain names from IDNA2003 to IDNA2008. This updated support is required for several forms of IDNs and is mandatory for .de domains.
    Much improved heuristics for guessing content lengths: Requests will no longer read an entire StringIO into memory.
    Much improved logic for recalculating Content-Length headers for PreparedRequest objects.
    Improved tolerance for file-like objects that have no tell method but do have a seek method.
    Anything that is a subclass of Mapping is now treated like a dictionary by the data= keyword argument.
    Requests now tolerates empty passwords in proxy credentials, rather than stripping the credentials.
    If a request is made with a file-like object as the body and that request is redirected with a 307 or 308 status code, Requests will now attempt to rewind the body object so it can be replayed.

Bugfixes

    When calling response.close, the call to close will be propagated through to non-urllib3 backends.
    Fixed issue where the ALL_PROXY environment variable would be preferred over scheme-specific variables like HTTP_PROXY.
    Fixed issue where non-UTF8 reason phrases got severely mangled by falling back to decoding using ISO 8859-1 instead.
    Fixed a bug where Requests would not correctly correlate cookies set when using custom Host headers if those Host headers did not use the native string type for the platform.

Miscellaneous

    Updated bundled urllib3 to 1.19.
    Updated bundled certifi certs to 2016.09.26.


```

urllib3 changelog

```
1.26.7 (2021-09-22)

    Fixed a bug with HTTPS hostname verification involving IP addresses and lack of SNI. (Issue #2400)
    Fixed a bug where IPv6 braces weren't stripped during certificate hostname matching. (Issue #2240)

1.26.6 (2021-06-25)

    Deprecated the urllib3.contrib.ntlmpool module. urllib3 is not able to support it properly due to reasons listed in this issue. If you are a user of this module please leave a comment.
    Changed HTTPConnection.request_chunked() to not erroneously emit multiple Transfer-Encoding headers in the case that one is already specified.
    Fixed typo in deprecation message to recommend Retry.DEFAULT_ALLOWED_METHODS.

1.26.5 (2021-05-26)

    Fixed deprecation warnings emitted in Python 3.10.
    Updated vendored six library to 1.16.0.
    Improved performance of URL parser when splitting the authority component.

1.26.4 (2021-03-15)

    Changed behavior of the default SSLContext when connecting to HTTPS proxy during HTTPS requests. The default SSLContext now sets check_hostname=True.

1.26.3 (2021-01-26)

    Fixed bytes and string comparison issue with headers (Pull #2141)
    Changed ProxySchemeUnknown error message to be more actionable if the user supplies a proxy URL without a scheme. (Pull #2107)

1.26.2 (2020-11-12)

    Fixed an issue where wrap_socket and CERT_REQUIRED wouldn't be imported properly on Python 2.7.8 and earlier (Pull #2052)

1.26.1 (2020-11-11)

    Fixed an issue where two User-Agent headers would be sent if a User-Agent header key is passed as bytes (Pull #2047)

1.26.0 (2020-11-10)

    NOTE: urllib3 v2.0 will drop support for Python 2. Read more in the v2.0 Roadmap.
    Added support for HTTPS proxies contacting HTTPS servers (Pull #1923, Pull #1806)
    Deprecated negotiating TLSv1 and TLSv1.1 by default. Users that still wish to use TLS earlier than 1.2 without a deprecation warning should opt-in explicitly by setting ssl_version=ssl.PROTOCOL_TLSv1_1 (Pull #2002) Starting in urllib3 v2.0: Connections that receive a ``DeprecationWarning`` will fail
    Deprecated Retry options Retry.DEFAULT_METHOD_WHITELIST, Retry.DEFAULT_REDIRECT_HEADERS_BLACKLIST and Retry(method_whitelist=...) in favor of Retry.DEFAULT_ALLOWED_METHODS, Retry.DEFAULT_REMOVE_HEADERS_ON_REDIRECT, and Retry(allowed_methods=...) (Pull #2000) Starting in urllib3 v2.0: Deprecated options will be removed
    Added default User-Agent header to every request (Pull #1750)
    Added urllib3.util.SKIP_HEADER for skipping User-Agent, Accept-Encoding, and Host headers from being automatically emitted with requests (Pull #2018)
    Collapse transfer-encoding: chunked request data and framing into the same socket.send() call (Pull #1906)
    Send http/1.1 ALPN identifier with every TLS handshake by default (Pull #1894)
    Properly terminate SecureTransport connections when CA verification fails (Pull #1977)
    Don't emit an SNIMissingWarning when passing server_hostname=None to SecureTransport (Pull #1903)
    Disabled requesting TLSv1.2 session tickets as they weren't being used by urllib3 (Pull #1970)
    Suppress BrokenPipeError when writing request body after the server has closed the socket (Pull #1524)
    Wrap ssl.SSLError that can be raised from reading a socket (e.g. "bad MAC") into an urllib3.exceptions.SSLError (Pull #1939)

1.25.11 (2020-10-19)

    Fix retry backoff time parsed from Retry-After header when given in the HTTP date format. The HTTP date was parsed as the local timezone rather than accounting for the timezone in the HTTP date (typically UTC) (Pull #1932, Pull #1935, Pull #1938, Pull #1949)
    Fix issue where an error would be raised when the SSLKEYLOGFILE environment variable was set to the empty string. Now SSLContext.keylog_file is not set in this situation (Pull #2016)

1.25.10 (2020-07-22)

    Added support for SSLKEYLOGFILE environment variable for logging TLS session keys with use with programs like Wireshark for decrypting captured web traffic (Pull #1867)
    Fixed loading of SecureTransport libraries on macOS Big Sur due to the new dynamic linker cache (Pull #1905)
    Collapse chunked request bodies data and framing into one call to send() to reduce the number of TCP packets by 2-4x (Pull #1906)
    Don't insert None into ConnectionPool if the pool was empty when requesting a connection (Pull #1866)
    Avoid hasattr call in BrotliDecoder.decompress() (Pull #1858)

1.25.9 (2020-04-16)

    Added InvalidProxyConfigurationWarning which is raised when erroneously specifying an HTTPS proxy URL. urllib3 doesn't currently support connecting to HTTPS proxies but will soon be able to and we would like users to migrate properly without much breakage.

    See this GitHub issue for more information on how to fix your proxy config. (Pull #1851)

    Drain connection after PoolManager redirect (Pull #1817)

    Ensure load_verify_locations raises SSLError for all backends (Pull #1812)

    Rename VerifiedHTTPSConnection to HTTPSConnection (Pull #1805)

    Allow the CA certificate data to be passed as a string (Pull #1804)

    Raise ValueError if method contains control characters (Pull #1800)

    Add __repr__ to Timeout (Pull #1795)

1.25.8 (2020-01-20)

    Drop support for EOL Python 3.4 (Pull #1774)
    Optimize _encode_invalid_chars (Pull #1787)

1.25.7 (2019-11-11)

    Preserve chunked parameter on retries (Pull #1715, Pull #1734)
    Allow unset SERVER_SOFTWARE in App Engine (Pull #1704, Issue #1470)
    Fix issue where URL fragment was sent within the request target. (Pull #1732)
    Fix issue where an empty query section in a URL would fail to parse. (Pull #1732)
    Remove TLS 1.3 support in SecureTransport due to Apple removing support (Pull #1703)

1.25.6 (2019-09-24)

    Fix issue where tilde (~) characters were incorrectly percent-encoded in the path. (Pull #1692)

1.25.5 (2019-09-19)

    Add mitigation for BPO-37428 affecting Python <3.7.4 and OpenSSL 1.1.1+ which caused certificate verification to be enabled when using cert_reqs=CERT_NONE. (Issue #1682)

1.25.4 (2019-09-19)

    Propagate Retry-After header settings to subsequent retries. (Pull #1607)
    Fix edge case where Retry-After header was still respected even when explicitly opted out of. (Pull #1607)
    Remove dependency on rfc3986 for URL parsing.
    Fix issue where URLs containing invalid characters within Url.auth would raise an exception instead of percent-encoding those characters.
    Add support for HTTPResponse.auto_close = False which makes HTTP responses work well with BufferedReaders and other io module features. (Pull #1652)
    Percent-encode invalid characters in URL for HTTPConnectionPool.request() (Pull #1673)

1.25.3 (2019-05-23)

    Change HTTPSConnection to load system CA certificates when ca_certs, ca_cert_dir, and ssl_context are unspecified. (Pull #1608, Issue #1603)
    Upgrade bundled rfc3986 to v1.3.2. (Pull #1609, Issue #1605)

1.25.2 (2019-04-28)

    Change is_ipaddress to not detect IPvFuture addresses. (Pull #1583)
    Change parse_url to percent-encode invalid characters within the path, query, and target components. (Pull #1586)

1.25.1 (2019-04-24)

    Add support for Google's Brotli package. (Pull #1572, Pull #1579)
    Upgrade bundled rfc3986 to v1.3.1 (Pull #1578)

1.25 (2019-04-22)

    Require and validate certificates by default when using HTTPS (Pull #1507)
    Upgraded urllib3.utils.parse_url() to be RFC 3986 compliant. (Pull #1487)
    Added support for key_password for HTTPSConnectionPool to use encrypted key_file without creating your own SSLContext object. (Pull #1489)
    Add TLSv1.3 support to CPython, pyOpenSSL, and SecureTransport SSLContext implementations. (Pull #1496)
    Switched the default multipart header encoder from RFC 2231 to HTML 5 working draft. (Issue #303, Pull #1492)
    Fixed issue where OpenSSL would block if an encrypted client private key was given and no password was given. Instead an SSLError is raised. (Pull #1489)
    Added support for Brotli content encoding. It is enabled automatically if brotlipy package is installed which can be requested with urllib3[brotli] extra. (Pull #1532)
    Drop ciphers using DSS key exchange from default TLS cipher suites. Improve default ciphers when using SecureTransport. (Pull #1496)
    Implemented a more efficient HTTPResponse.__iter__() method. (Issue #1483)

1.24.3 (2019-05-01)

    Apply fix for CVE-2019-9740. (Pull #1591)

1.24.2 (2019-04-17)

    Don't load system certificates by default when any other ca_certs, ca_certs_dir or ssl_context parameters are specified.
    Remove Authorization header regardless of case when redirecting to cross-site. (Issue #1510)
    Add support for IPv6 addresses in subjectAltName section of certificates. (Issue #1269)

1.24.1 (2018-11-02)

    Remove quadratic behavior within GzipDecoder.decompress() (Issue #1467)
    Restored functionality of ciphers parameter for create_urllib3_context(). (Issue #1462)

1.24 (2018-10-16)

    Allow key_server_hostname to be specified when initializing a PoolManager to allow custom SNI to be overridden. (Pull #1449)
    Test against Python 3.7 on AppVeyor. (Pull #1453)
    Early-out ipv6 checks when running on App Engine. (Pull #1450)
    Change ambiguous description of backoff_factor (Pull #1436)
    Add ability to handle multiple Content-Encodings (Issue #1441 and Pull #1442)
    Skip DNS names that can't be idna-decoded when using pyOpenSSL (Issue #1405).
    Add a server_hostname parameter to HTTPSConnection which allows for overriding the SNI hostname sent in the handshake. (Pull #1397)
    Drop support for EOL Python 2.6 (Pull #1429 and Pull #1430)
    Fixed bug where responses with header Content-Type: message/* erroneously raised HeaderParsingError, resulting in a warning being logged. (Pull #1439)
    Move urllib3 to src/urllib3 (Pull #1409)

1.23 (2018-06-04)

    Allow providing a list of headers to strip from requests when redirecting to a different host. Defaults to the Authorization header. Different headers can be set via Retry.remove_headers_on_redirect. (Issue #1316)
    Fix util.selectors._fileobj_to_fd to accept long (Issue #1247).
    Dropped Python 3.3 support. (Pull #1242)
    Put the connection back in the pool when calling stream() or read_chunked() on a chunked HEAD response. (Issue #1234)
    Fixed pyOpenSSL-specific ssl client authentication issue when clients attempted to auth via certificate + chain (Issue #1060)
    Add the port to the connectionpool connect print (Pull #1251)
    Don't use the uuid module to create multipart data boundaries. (Pull #1380)
    read_chunked() on a closed response returns no chunks. (Issue #1088)
    Add Python 2.6 support to contrib.securetransport (Pull #1359)
    Added support for auth info in url for SOCKS proxy (Pull #1363)


```