### PR TITLE
Upgrade tldextract

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -52,7 +52,7 @@ html2text==2014.9.8
 httplib2==0.8
 hypothesis==4.57.1
 icalendar==3.9.1
-idna==2.6
+idna==2.9
 git+https://github.com/closeio/imapclient.git@aca1b9b3624f28dca8fdf5e140704c8b7d57820f#egg=imapclient
 importlib-metadata==2.1.1
 ipaddress==1.0.19
@@ -109,6 +109,7 @@ PyYAML==3.12
 redis==2.10.6
 regex==2018.1.10
 requests==2.11.0
+requests-file==1.5.1
 rollbar==0.16.1
 scandir==1.10.0
 setproctitle==1.1.10
@@ -121,7 +122,7 @@ sortedcontainers==2.4.0
 git+https://github.com/mhahnenberg/sqlalchemy.git@e5f7586346ce5fafe2c182f70bf6ef998aa59b68#egg=SQLAlchemy
 statsd==3.3.0
 structlog==20.1.0
-tldextract==1.7.5
+tldextract==2.2.3
 toml==0.10.2
 traitlets==4.3.2
 typing==3.10.0.0; python_version < '3.5'


### PR DESCRIPTION
These are the last versions of tldextract and it's dependency idna that still work on Python 2.

We use tldextract to find parent domains of domains.

tldextract Changelog:

```
2.2.3 (2020-08-05)

    Bugfixes
        Fix concurrent access to cache file when using tldextract in multiple threads (#146)
        Relocate version number, to avoid costly imports (#187)
        Catch IndexError caused by upstream punycode bug (#200)
        Drop support for EOL Python 3.4 (#186)
        Explain warning better

2.2.2 (2019-10-15)

    Bugfixes
        Catch file not found
        Use pkgutil instead of pkg_resources (#163)
        Performance: avoid recomputes, a regex, and a partition
    Misc.
        Update LICENSE from GitHub template
        Fix warning about literal comparison
        Modernize testing (#177)
            Use the latest pylint that works in Python 2
            Appease pylint with the new rules
            Support Python 3.8-dev

2.2.1 (2019-03-05)

    Bugfixes
        Ignore case on punycode prefix check (#133)
        Drop support for EOL Python 2.6 (#152)
        Improve sundry doc and README bits

2.2.0 (2017-10-26)

    Features
        Add cache_fetch_timeout kwarg and TLDEXTRACT_CACHE_TIMEOUT env var (#139)
    Bugfixes
        Work around pkg_resources missing, again (#137)
        Always close sessions (#140)

2.1.0 (2017-05-24)

    Features
        Add fqdn convenience property (#129)
        Add ipv4 convenience property (#126)

2.0.3 (2017-05-20)

    Bugfixes
        Switch to explicit Python version check (#124)
    Misc.
        Document public vs. private domains
        Document support for Python 3.6

2.0.2 (2016-10-16)

    Misc.
        Release as a universal wheel (#110)
        Consolidate test suite running with tox (#104)

2.0.1 (2016-04-25)

    Bugfixes
        Relax required requests version: >= 2.1 (#98)
    Misc.
        Include tests in release source tarball (#97)

2.0.0 (2016-04-21)

No changes since 2.0rc1.
2.0rc1 (2016-04-04)

This release focuses on shedding confusing code branches & deprecated cruft.

    Breaking Changes
        Renamed/changed the type of TLDExtract constructor param suffix_list_url
            It used to take a str or iterable. Its replacement, suffix_list_urls only takes an iterable. This better communicates that it tries a sequence of URLs, in order. To only try 1 URL, pass an iterable with exactly 1 URL str.
        Serialize the local cache of the remote PSL as JSON (no more pickle) - #81
            This should be a transparent upgrade for most users.
            However, if you're configured to only read from your local cache file, no other sources or fallbacks, the new version will be unable to read the old cache format, and an error will be raised.
        Remove deprecated code
            TLDExtract's fetch param. To disable live HTTP requests for the latest PSL, instead pass suffix_list_urls=None.
            ExtractResult.tld property. Use ExtractResult.suffix instead.
        Moved code
            Split tldextract.tldextract into a few files.
                The official public interface of this package comes via import tldextract. But if you were relying on direct import from tldextract.tldextract anyway, those imports may have moved.
                You can run the package python -m tldextract for the same effect as the included tldextract console script. This used to be python -m tldextract.tldextract.
    Misc.
        Use requests instead of urllib - #89
            As a side-effect, this fixes #93.
```

idna changelog

```
2.10 (2020-06-27)

    Update to Unicode 13.0.0.
    Throws a more specific exception if "xn--" is provided as a label.
    This is expected to be the last version that supports Python 2.

2.9 (2020-02-16)

    Update to Unicode 12.1.0.
    Prohibit A-labels ending with a hyphen (Thanks, Julien Bernard!)
    Future-proofing: Test on Python 3.7 and 3.8, don't immediately fail should Python 4 come along.
    Made BSD 3-clause license clearer

2.8 (2018-12-04)

    Update to Unicode 11.0.0.
    Provide more specific exceptions for some malformed labels.

2.7 (2018-06-10)

    Update to Unicode 10.0.0.
    No longer accepts dot-prefixed domains (e.g. ".example") as valid. This is to be more conformant with the UTS 46 spec. Users should strip dot prefixes from domains before processing.



```