### PR TITLE
Upgrade mysqlclient

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -70,7 +70,7 @@ mccabe==0.6.1
 mock==1.3.0
 mockredispy==2.9.0.10
 more-itertools==5.0.0
-mysqlclient==1.3.10
+mysqlclient==1.3.14
 ndg-httpsclient==0.4.3
 nylas==1.2.3
 packaging==20.9
@@ -95,7 +95,6 @@ pyinstrument-cext==0.2.2
 pylint==1.5.1
 pymongo==2.5.2  # For json_util in bson
 Pympler==0.9
-PyMySQL==0.6.2
 PyNaCl==0.3.0
 pyOpenSSL==17.5.0
 pyparsing==2.4.7


### PR DESCRIPTION
We use mysqlclient to talk to MySQL. This is the last version of mysqlclient that supports gevent. Support for gevent was removed in 1.4. For some historical reasons PyMySQL was also included in requirements but we no longer use it.

Changelog

```
Release: 2018-12-04

    Support static linking of MariaDB Connector/C (#265)
    Better converter for Decimal and Float (#267, #268, #273, #286)
    Add Connection._get_native_connection for XTA project (#269)
    Fix SEGV on MariaDB Connector/C when some methods of Connection objects are called after Connection.close() is called. (#270, #272, #276) See jira.mariadb.org/browse/CONC-289
    Fix Connection.client_flag (#266)
    Fix SSCursor may raise same exception twice (#282)
        This removed Cursor._last_executed which was duplicate of Cursor._executed. Both members are private. So this type of changes are not documented in changelog generally. But Django used the private member for last_executed_query implementation. If you use the method the method directly or indirectly, this version will break your application. See code.djangoproject.com/ticket/30013
    waiter option is now deprecated. (#285)
    Fixed SSL support is not detected when built with MySQL < 5.1 (#291)

What's new in 1.3.13

Support build with MySQL 8

Fix decoding tiny/medium/long blobs (#215)

Remove broken row_seek() and row_tell() APIs (#220)

Reduce callproc roundtrip time (#223)
What's new in 1.3.12

Fix tuple argument again (#201)

InterfaceError is raised when Connection.query() is called for closed connection (#202)
What's new in 1.3.11

Support MariaDB 10.2 client library (#197, #177, #200)

Add NEWDECIMAL to the NUMBER DBAPISet (#167)

Allow bulk insert which no space around VALUES (#179)

Fix leak of connection->converter. (#182)

Support error numbers > CR_MAX_ERROR (#188)

Fix tuple argument support (#145)
```