### PR TITLE
Upgrade PyYAML

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -105,7 +105,7 @@ pytest-cov==2.12.1
 git+https://github.com/nylas/dateutil.git@da336a366cd3f31e3bd7ca925e676e169189e48d#egg=python-dateutil
 python-magic==0.4.6
 pytz==2017.3
-PyYAML==3.12
+PyYAML==5.4.1
 redis==2.10.6
 regex==2018.1.10
 requests==2.11.0

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -85,7 +85,6 @@ psutil==5.8.0
 ptyprocess==0.7.0
 prompt-toolkit==1.0.18
 py==1.10.0
-pyaml==21.10.1
 pyasn1==0.2.3
 pycparser==2.18
 pyflakes==0.7.3

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -85,7 +85,7 @@ psutil==5.8.0
 ptyprocess==0.7.0
 prompt-toolkit==1.0.18
 py==1.10.0
-pyaml==14.5.7
+pyaml==21.10.1
 pyasn1==0.2.3
 pycparser==2.18
 pyflakes==0.7.3


### PR DESCRIPTION
We use PyYAML to read the config which is stored in YAML. This is the last version that works on Python 2.

For some historical reason pyaml was also listed but we no longer use it.

PyYAML changelog:

```
5.4.1 (2021-01-20)

* https://github.com/yaml/pyyaml/pull/480 -- Fix stub compat with older pyyaml versions that may unwittingly load it

5.4 (2021-01-19)

* https://github.com/yaml/pyyaml/pull/407 -- Build modernization, remove distutils, fix metadata, build wheels, CI to GHA
* https://github.com/yaml/pyyaml/pull/472 -- Fix for CVE-2020-14343, moves arbitrary python tags to UnsafeLoader
* https://github.com/yaml/pyyaml/pull/441 -- Fix memory leak in implicit resolver setup
* https://github.com/yaml/pyyaml/pull/392 -- Fix py2 copy support for timezone objects
* https://github.com/yaml/pyyaml/pull/378 -- Fix compatibility with Jython

5.3.1 (2020-03-18)

* https://github.com/yaml/pyyaml/pull/386 -- Prevents arbitrary code execution during python/object/new constructor

5.3 (2020-01-06)

* https://github.com/yaml/pyyaml/pull/290 -- Use `is` instead of equality for comparing with `None`
* https://github.com/yaml/pyyaml/pull/270 -- Fix typos and stylistic nit
* https://github.com/yaml/pyyaml/pull/309 -- Fix up small typo
* https://github.com/yaml/pyyaml/pull/161 -- Fix handling of __slots__
* https://github.com/yaml/pyyaml/pull/358 -- Allow calling add_multi_constructor with None
* https://github.com/yaml/pyyaml/pull/285 -- Add use of safe_load() function in README
* https://github.com/yaml/pyyaml/pull/351 -- Fix reader for Unicode code points over 0xFFFF
* https://github.com/yaml/pyyaml/pull/360 -- Enable certain unicode tests when maxunicode not > 0xffff
* https://github.com/yaml/pyyaml/pull/359 -- Use full_load in yaml-highlight example
* https://github.com/yaml/pyyaml/pull/244 -- Document that PyYAML is implemented with Cython
* https://github.com/yaml/pyyaml/pull/329 -- Fix for Python 3.10
* https://github.com/yaml/pyyaml/pull/310 -- Increase size of index, line, and column fields
* https://github.com/yaml/pyyaml/pull/260 -- Remove some unused imports
* https://github.com/yaml/pyyaml/pull/163 -- Create timezone-aware datetimes when parsed as such
* https://github.com/yaml/pyyaml/pull/363 -- Add tests for timezone

5.2 (2019-12-02)
------------------

* Repair incompatibilities introduced with 5.1. The default Loader was changed,
  but several methods like add_constructor still used the old default
  https://github.com/yaml/pyyaml/pull/279 -- A more flexible fix for custom tag constructors
  https://github.com/yaml/pyyaml/pull/287 -- Change default loader for yaml.add_constructor
  https://github.com/yaml/pyyaml/pull/305 -- Change default loader for add_implicit_resolver, add_path_resolver
* Make FullLoader safer by removing python/object/apply from the default FullLoader
  https://github.com/yaml/pyyaml/pull/347 -- Move constructor for object/apply to UnsafeConstructor
* Fix bug introduced in 5.1 where quoting went wrong on systems with sys.maxunicode <= 0xffff
  https://github.com/yaml/pyyaml/pull/276 -- Fix logic for quoting special characters
* Other PRs:
  https://github.com/yaml/pyyaml/pull/280 -- Update CHANGES for 5.1

5.1.2 (2019-07-30)
------------------

* Re-release of 5.1 with regenerated Cython sources to build properly for Python 3.8b2+

5.1.1 (2019-06-05)
------------------

* Re-release of 5.1 with regenerated Cython sources to build properly for Python 3.8b1

5.1 (2019-03-13)
----------------

* https://github.com/yaml/pyyaml/pull/35 -- Some modernization of the test running
* https://github.com/yaml/pyyaml/pull/42 -- Install tox in a virtualenv
* https://github.com/yaml/pyyaml/pull/45 -- Allow colon in a plain scalar in a flow context
* https://github.com/yaml/pyyaml/pull/48 -- Fix typos
* https://github.com/yaml/pyyaml/pull/55 -- Improve RepresenterError creation
* https://github.com/yaml/pyyaml/pull/59 -- Resolves #57, update readme issues link
* https://github.com/yaml/pyyaml/pull/60 -- Document and test Python 3.6 support
* https://github.com/yaml/pyyaml/pull/61 -- Use Travis CI built in pip cache support
* https://github.com/yaml/pyyaml/pull/62 -- Remove tox workaround for Travis CI
* https://github.com/yaml/pyyaml/pull/63 -- Adding support to Unicode characters over codepoint 0xffff
* https://github.com/yaml/pyyaml/pull/75 -- add 3.12 changelog
* https://github.com/yaml/pyyaml/pull/76 -- Fallback to Pure Python if Compilation fails
* https://github.com/yaml/pyyaml/pull/84 -- Drop unsupported Python 3.3
* https://github.com/yaml/pyyaml/pull/102 -- Include license file in the generated wheel package
* https://github.com/yaml/pyyaml/pull/105 -- Removed Python 2.6 & 3.3 support
* https://github.com/yaml/pyyaml/pull/111 -- Remove commented out Psyco code
* https://github.com/yaml/pyyaml/pull/129 -- Remove call to `ord` in lib3 emitter code
* https://github.com/yaml/pyyaml/pull/149 -- Test on Python 3.7-dev
* https://github.com/yaml/pyyaml/pull/158 -- Support escaped slash in double quotes "\/"
* https://github.com/yaml/pyyaml/pull/175 -- Updated link to pypi in release announcement
* https://github.com/yaml/pyyaml/pull/181 -- Import Hashable from collections.abc
* https://github.com/yaml/pyyaml/pull/194 -- Reverting https://github.com/yaml/pyyaml/pull/74
* https://github.com/yaml/pyyaml/pull/195 -- Build libyaml on travis
* https://github.com/yaml/pyyaml/pull/196 -- Force cython when building sdist
* https://github.com/yaml/pyyaml/pull/254 -- Allow to turn off sorting keys in Dumper (2)
* https://github.com/yaml/pyyaml/pull/256 -- Make default_flow_style=False
* https://github.com/yaml/pyyaml/pull/257 -- Deprecate yaml.load and add FullLoader and UnsafeLoader classes
* https://github.com/yaml/pyyaml/pull/261 -- Skip certain unicode tests when maxunicode not > 0xffff
* https://github.com/yaml/pyyaml/pull/263 -- Windows Appveyor build

3.13 (2018-07-05)
-----------------

* Resolved issues around PyYAML working in Python 3.7.

```