### PR TITLE
Passwords are always text

### DIFF
--- a/inbox/models/backends/generic.py
+++ b/inbox/models/backends/generic.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from sqlalchemy import Boolean, Column, ForeignKey, String
 from sqlalchemy.orm import relationship
 
@@ -62,6 +64,7 @@ class GenericAccount(ImapAccount):
         return self.provider
 
     def valid_password(self, value):
+        # type: (UnionType[str, bytes]) -> bytes
         # Must be a valid UTF-8 byte sequence without NULL bytes.
         if not isinstance(value, bytes):
             value = value.encode("utf-8")
@@ -78,11 +81,13 @@ class GenericAccount(ImapAccount):
 
     @property
     def imap_password(self):
-        return self.imap_secret.secret
+        # type: () -> str
+        return self.imap_secret.secret.decode("utf-8")
 
     @imap_password.setter
     def imap_password(self, value):
-        value = self.valid_password(value)
+        # type: (Union[str, bytes]) -> None
+        value = self.valid_password(value)  # type: bytes
         if not self.imap_secret:
             self.imap_secret = Secret()
         self.imap_secret.secret = value
@@ -90,11 +95,13 @@ class GenericAccount(ImapAccount):
 
     @property
     def smtp_password(self):
-        return self.smtp_secret.secret
+        # type: () -> str
+        return self.smtp_secret.secret.decode("utf-8")
 
     @smtp_password.setter
     def smtp_password(self, value):
-        value = self.valid_password(value)
+        # type: (Union[str, bytes]) -> None
+        value = self.valid_password(value)  # type: bytes
         if not self.smtp_secret:
             self.smtp_secret = Secret()
         self.smtp_secret.secret = value

--- a/inbox/models/secret.py
+++ b/inbox/models/secret.py
@@ -30,6 +30,7 @@ class Secret(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     @property
     def secret(self):
+        # type: () -> bytes
         with get_decryption_oracle("SECRET_ENCRYPTION_KEY") as d_oracle:
             return d_oracle.decrypt(
                 self._secret, encryption_scheme=self.encryption_scheme


### PR DESCRIPTION
Passwords are stored in MySQL in binary BLOB fields.

The logic already accepts bytes and text, and if it receives text it will encode it UTF-8 before saving.

On Python 3 the getters will return `bytes`. This is fine on Python 2 where it is a synonym of string and silently coerces to unicode in comparisons. But Python 3 needs an extra `.decode('utf-8')`.