### PR TITLE
Dont allow underscores in ids

### DIFF
--- a/inbox/api/validation.py
+++ b/inbox/api/validation.py
@@ -99,6 +99,9 @@ def offset(value):
 
 
 def valid_public_id(value):
+    if "_" in value:
+        raise InputError(u"Invalid id: {}".format(value))
+
     try:
         # raise ValueError on malformed public ids
         # raise TypeError if an integer is passed in


### PR DESCRIPTION
This one is a little bit funny.

sync-engine does not allow `_` to appear in IDs. It uses `int(value, 36)` to validate them. But Python 3 allows numbers to contain underscores as thousand separators e.g. `8_000`.

```python
# Python 2.7.16 (default, Aug 30 2021, 14:43:11) 
>>> int('invalid_id', 36)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: invalid literal for int() with base 36: 'invalid_id'

# Python 3.9.7 (default, Sep  3 2021, 12:37:55) 
>>> int('invalid_id', 36)
52650475151845
>>> 
```