### PR TITLE
_subsitute_bcc operates on bytes

### DIFF
--- a/inbox/sendmail/smtp/postel.py
+++ b/inbox/sendmail/smtp/postel.py
@@ -108,11 +108,13 @@ def _transform_ssl_error(strerror):
 
 
 def _substitute_bcc(raw_message):
+    # type: (bytes) -> bytes
     """
     Substitute BCC in raw message.
     """
-    bcc_regexp = re.compile(r"^Bcc: [^\r\n]*\r\n", re.IGNORECASE | re.MULTILINE)
-    return bcc_regexp.sub("", raw_message)
+
+    bcc_regexp = re.compile(br"^Bcc: [^\r\n]*\r\n", re.IGNORECASE | re.MULTILINE)
+    return bcc_regexp.sub(b"", raw_message)
 
 
 class SMTPConnection(object):

--- a/tests/api/test_sending.py
+++ b/tests/api/test_sending.py
@@ -937,39 +937,39 @@ def test_multisend_message_rejected_for_security(
 def test_raw_bcc_replacements(patch_smtp, api_client):
     # Check that we're replacing "Bcc:" correctly from messages.
     res = _substitute_bcc(
-        "From: bob@foocorp.com\r\n"
-        "To: \r\n"
-        "Bcc: karim@nylas.com\r\n"
-        "Subject: "
-        "[go-nuts] Runtime Panic On Method"
-        "Call \r\n"
-        "Mime-Version: 1.0\r\n"
-        "Content-Type: "
-        "text/plain; charset=UTF-8\r\n"
-        "Content-Transfer-Encoding: 7bit\r\n"
-        "X-My-Custom-Header: Random"
-        "\r\n\r\n"
+        b"From: bob@foocorp.com\r\n"
+        b"To: \r\n"
+        b"Bcc: karim@nylas.com\r\n"
+        b"Subject: "
+        b"[go-nuts] Runtime Panic On Method"
+        b"Call \r\n"
+        b"Mime-Version: 1.0\r\n"
+        b"Content-Type: "
+        b"text/plain; charset=UTF-8\r\n"
+        b"Content-Transfer-Encoding: 7bit\r\n"
+        b"X-My-Custom-Header: Random"
+        b"\r\n\r\n"
     )
 
-    assert "karim@nylas.com" not in res
+    assert b"karim@nylas.com" not in res
 
     res = _substitute_bcc(
-        "From: bob@foocorp.com\r\n"
-        "To: \r\n"
-        "BCC: karim@nylas.com\r\n"
-        "Subject: "
-        "[go-nuts] Runtime BCC: On Method"
-        "Call \r\n"
-        "Mime-Version: 1.0\r\n"
-        "Content-Type: "
-        "text/plain; charset=UTF-8\r\n"
-        "Content-Transfer-Encoding: 7bit\r\n"
-        "X-My-Custom-Header: Random"
-        "\r\n\r\n"
+        b"From: bob@foocorp.com\r\n"
+        b"To: \r\n"
+        b"BCC: karim@nylas.com\r\n"
+        b"Subject: "
+        b"[go-nuts] Runtime BCC: On Method"
+        b"Call \r\n"
+        b"Mime-Version: 1.0\r\n"
+        b"Content-Type: "
+        b"text/plain; charset=UTF-8\r\n"
+        b"Content-Transfer-Encoding: 7bit\r\n"
+        b"X-My-Custom-Header: Random"
+        b"\r\n\r\n"
     )
 
-    assert "karim@nylas.com" not in res
-    assert "Runtime BCC:" in res
+    assert b"karim@nylas.com" not in res
+    assert b"Runtime BCC:" in res
 
 
 def test_inline_image_send(patch_smtp, api_client, uploaded_file_ids):

--- a/tests/api/test_sending.py
+++ b/tests/api/test_sending.py
@@ -969,7 +969,7 @@ def test_raw_bcc_replacements(patch_smtp, api_client):
     )
 
     assert b"karim@nylas.com" not in res
-    assert b"Runtime BCC:" in res
+    assert b"Runtime BCC: On MethodCall" in res
 
 
 def test_inline_image_send(patch_smtp, api_client, uploaded_file_ids):


### PR DESCRIPTION
`_substitue_bcc` is meant to work always on binary data. Changes nothing on Python 2 and fixes test on Python 3.