### PR TITLE
Fix multipart attachment encoding test on Python 3

### DIFF
--- a/tests/general/test_message_parsing.py
+++ b/tests/general/test_message_parsing.py
@@ -3,6 +3,7 @@
 """Sanity-check our construction of a Message object from raw synced data."""
 import datetime
 import pkgutil
+import sys
 
 import pytest
 from flanker import mime
@@ -435,9 +436,13 @@ def test_parse_body_on_bad_attachment(default_account, raw_message_with_bad_atta
         received_date,
         raw_message_with_bad_attachment,
     )
-    assert m.decode_error
+    if sys.version_info < (3,):
+        assert m.decode_error
     assert "dingy blue carpet" in m.body
-    assert len(m.parts) == 0
+    assert len(m.parts) == 0 if sys.version_info < (3,) else 1
+    if sys.version_info >= (3,):
+        assert m.parts[0].is_attachment
+        assert m.parts[0].block.data.decode() == "EMPTY 😊\n"
 
 
 def test_calculate_snippet():


### PR DESCRIPTION
This one is funny. Flanker on Python 3 is better at guessing a charset so we can properly save an attachment in the mime used for this test. Given it contains emoji and emojis have a very special pattern that can be used reliability to guess encodings I am not surprised.

The multipart in question is:

```
From: Ben Bitdiddle <ben@example.com>
To: Helena Handbasket <helena@example.com>
Subject: The Monsters of MIME
Date: Thu, 30 Apr 2015 16:55:12 +0000
Content-Type: multipart/related; boundary="_004_143041291414210227nylascom_";
  type="multipart/alternative"
MIME-Version: 1.0

--_004_143041291414210227nylascom_
Content-Disposition: attachment

EMPTY 😊

--_004_143041291414210227nylascom_
Content-Type: multipart/alternative;
  boundary="_000_143041291414210227nylascom_"

--_000_143041291414210227nylascom_
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: base64

Cgo+IGxvb2sKCllvdSBhcmUgaW4gYSByb29tIHdpdGggdGFsbCBjZWlsaW5ncywgYSBkaW5neSBi
bHVlIGNhcnBldCB3aXRoIHN0YWlucywKYW5kIGFuIGltcHJlc3NpdmUgc2V0IG9mIGJyaWdodGx5
IHBhaW50ZWQgcmVkIHNpZWdlIGRvb3JzLiBTdW5saWdodApzdHJlYW1zIHRocm91Z2ggdGhlIGNv
cGlvdXMgd2luZG93cyBvbnRvIHNvbWUgY291Y2hlcyBpbiB0aGUgY29ybmVyLgpTb21lIGVtcHR5
IHdoaXRlIGRlc2tzIG9uIHRoZSBvdGhlciBzaWRlIG9mIHRoZSByb29tIGFyZSBjb3ZlcmVkIGlu
CnBlbnMsIHBhcGVycywgc3RpY2tlcnMsIG11Z3MsIGhlYWRwaG9uZXMsIGFuZCB2YXJpb3VzIG90
aGVyIG9kZHMgYW5kCmVuZHMuCg==

--_000_143041291414210227nylascom_
Content-Type: text/html; charset="utf-8"
Content-Transfer-Encoding: base64

PHA+CiZndDsgbG9vawo8L3A+CjxwPllvdSBhcmUgaW4gYSByb29tIHdpdGggdGFsbCBjZWlsaW5n
cywgYSBkaW5neSBibHVlIGNhcnBldCB3aXRoIHN0YWlucywKYW5kIGFuIGltcHJlc3NpdmUgc2V0
IG9mIGJyaWdodGx5IHBhaW50ZWQgcmVkIHNpZWdlIGRvb3JzLiBTdW5saWdodApzdHJlYW1zIHRo
cm91Z2ggdGhlIGNvcGlvdXMgd2luZG93cyBvbnRvIHNvbWUgY291Y2hlcyBpbiB0aGUgY29ybmVy
LgpTb21lIGVtcHR5IHdoaXRlIGRlc2tzIG9uIHRoZSBvdGhlciBzaWRlIG9mIHRoZSByb29tIGFy
ZSBjb3ZlcmVkIGluCnBlbnMsIHBhcGVycywgc3RpY2tlcnMsIG11Z3MsIGhlYWRwaG9uZXMsIGFu
ZCB2YXJpb3VzIG90aGVyIG9kZHMgYW5kCmVuZHMuCjwvcD4K

--_000_143041291414210227nylascom_--

--_004_143041291414210227nylascom_--

```

The attachment in question is:

```
(Pdb) mimepart.to_string()
'Content-Disposition: attachment\n\nEMPTY \xf0\x9f\x98\x8a\n'
```

On Python 2:

```
(Pdb) mimepart.body
*** DecodingError: Failed to guess encoding
```
On Python 3

```
(Pdb) mimepart.body
'EMPTY 😊\n'
```