### PR TITLE
Upgrade flask & friends

### DIFF
--- a/inbox/api/validation.py
+++ b/inbox/api/validation.py
@@ -26,7 +26,7 @@ MAX_LIMIT = 1000
 
 
 class ValidatableArgument(reqparse.Argument):
-    def handle_validation_error(self, error):
+    def handle_validation_error(self, error, bundle_errors):
         raise InputError(str(error))
 
 

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -35,8 +35,8 @@ flake8==2.1.0
 flake8-pep3101==0.6
 git+https://github.com/closeio/flanker-new.git@fa272d95345d45e8bb1f9bc32bc2c074bf52a484#egg=flanker
 tld==0.12.6
-Flask==0.10.1
-Flask-RESTful==0.3.2
+Flask==0.12.5
+Flask-RESTful==0.3.9
 freezegun==0.3.15
 funcsigs==1.0.2
 future==0.18.2
@@ -58,8 +58,8 @@ importlib-metadata==2.1.1
 ipaddress==1.0.19
 ipython==5.8.0
 ipython_genutils==0.2.0
-itsdangerous==0.24
-Jinja2==2.10
+itsdangerous==1.1.0
+Jinja2==2.11.3
 jmespath==0.9.3
 lazy-object-proxy==1.3.1
 limitlion==0.9.2
@@ -127,7 +127,7 @@ urllib3==1.26.7
 vobject==0.9.1
 wcwidth==0.2.5
 WebOb==1.7.4
-Werkzeug==0.14.1
+Werkzeug==0.16.1
 wrapt==1.10.11
 zipp==1.2.0
 zope.event==4.5.0


### PR DESCRIPTION
This upgrades Flask & the dependencies to the latest versions that do not have too many breaking changes. This version of Flask is from February 2020 just before 1.0 happened. I will try to update past 1.0 on a separate PR in the future.

Flask-Restful was updated to the latest version.

Flask Changelog

```

Version 0.12.5

Released 2020-02-10

    Pin Werkzeug to < 1.0.0. #3497

Version 0.12.4

Released 2018-04-29

    Repackage 0.12.3 to fix package layout issue. #2728

Version 0.12.3

Released 2018-04-26

    Request.get_json() no longer accepts arbitrary encodings. Incoming JSON should be encoded using UTF-8 per RFC 8259, but Flask will autodetect UTF-8, -16, or -32. #2692

    Fix a Python warning about imports when using python -m flask. #2666

    Fix a ValueError caused by invalid Range requests in some cases.

Version 0.12.2

Released 2017-05-16

    Fix a bug in safe_join on Windows.

Version 0.12.1

Released 2017-03-31

    Prevent flask run from showing a NoAppException when an ImportError occurs within the imported application module.

    Fix encoding behavior of app.config.from_pyfile for Python 3. #2118

    Use the SERVER_NAME config if it is present as default values for app.run. #2109, #2152

    Call ctx.auto_pop with the exception object instead of None, in the event that a BaseException such as KeyboardInterrupt is raised in a request handler.

Version 0.12

Released 2016-12-21, codename Punsch

    The cli command now responds to --version.

    Mimetype guessing and ETag generation for file-like objects in send_file has been removed. #104, :pr`1849`

    Mimetype guessing in send_file now fails loudly and doesn’t fall back to application/octet-stream. #1988

    Make flask.safe_join able to join multiple paths like os.path.join #1730

    Revert a behavior change that made the dev server crash instead of returning an Internal Server Error. #2006

    Correctly invoke response handlers for both regular request dispatching as well as error handlers.

    Disable logger propagation by default for the app logger.

    Add support for range requests in send_file.

    app.test_client includes preset default environment, which can now be directly set, instead of per client.get.

    Fix crash when running under PyPy3. #1814


Version 0.11.1

Released 2016-06-07

    Fixed a bug that prevented FLASK_APP=foobar/__init__.py from working. #1872

Version 0.11

Released 2016-05-29, codename Absinthe

    Added support to serializing top-level arrays to flask.jsonify(). This introduces a security risk in ancient browsers.

    Added before_render_template signal.

    Added **kwargs to flask.Test.test_client() to support passing additional keyword arguments to the constructor of flask.Flask.test_client_class.

    Added SESSION_REFRESH_EACH_REQUEST config key that controls the set-cookie behavior. If set to True a permanent session will be refreshed each request and get their lifetime extended, if set to False it will only be modified if the session actually modifies. Non permanent sessions are not affected by this and will always expire if the browser window closes.

    Made Flask support custom JSON mimetypes for incoming data.

    Added support for returning tuples in the form (response, headers) from a view function.

    Added flask.Config.from_json().

    Added flask.Flask.config_class.

    Added flask.Config.get_namespace().

    Templates are no longer automatically reloaded outside of debug mode. This can be configured with the new TEMPLATES_AUTO_RELOAD config key.

    Added a workaround for a limitation in Python 3.3’s namespace loader.

    Added support for explicit root paths when using Python 3.3’s namespace packages.

    Added flask and the flask.cli module to start the local debug server through the click CLI system. This is recommended over the old flask.run() method as it works faster and more reliable due to a different design and also replaces Flask-Script.

    Error handlers that match specific classes are now checked first, thereby allowing catching exceptions that are subclasses of HTTP exceptions (in werkzeug.exceptions). This makes it possible for an extension author to create exceptions that will by default result in the HTTP error of their choosing, but may be caught with a custom error handler if desired.

    Added flask.Config.from_mapping().

    Flask will now log by default even if debug is disabled. The log format is now hardcoded but the default log handling can be disabled through the LOGGER_HANDLER_POLICY configuration key.

    Removed deprecated module functionality.

    Added the EXPLAIN_TEMPLATE_LOADING config flag which when enabled will instruct Flask to explain how it locates templates. This should help users debug when the wrong templates are loaded.

    Enforce blueprint handling in the order they were registered for template loading.

    Ported test suite to py.test.

    Deprecated request.json in favour of request.get_json().

    Add “pretty” and “compressed” separators definitions in jsonify() method. Reduces JSON response size when JSONIFY_PRETTYPRINT_REGULAR=False by removing unnecessary white space included by default after separators.

    JSON responses are now terminated with a newline character, because it is a convention that UNIX text files end with a newline and some clients don’t deal well when this newline is missing. This came up originally as a part of https://github.com/postmanlabs/httpbin/issues/168. #1262

    The automatically provided OPTIONS method is now correctly disabled if the user registered an overriding rule with the lowercase-version options. #1288

    flask.json.jsonify now supports the datetime.date type. #1326

    Don’t leak exception info of already caught exceptions to context teardown handlers. #1393

    Allow custom Jinja environment subclasses. #1422

    Updated extension dev guidelines.

    flask.g now has pop() and setdefault methods.

    Turn on autoescape for flask.templating.render_template_string by default. #1515

    flask.ext is now deprecated. #1484

    send_from_directory now raises BadRequest if the filename is invalid on the server OS. #1763

    Added the JSONIFY_MIMETYPE configuration variable. #1728

    Exceptions during teardown handling will no longer leave bad application contexts lingering around.

    Fixed broken test_appcontext_signals() test case.

    Raise an AttributeError in flask.helpers.find_package() with a useful message explaining why it is raised when a PEP 302 import hook is used without an is_package() method.

    Fixed an issue causing exceptions raised before entering a request or app context to be passed to teardown handlers.

    Fixed an issue with query parameters getting removed from requests in the test client when absolute URLs were requested.

    Made @before_first_request into a decorator as intended.

    Fixed an etags bug when sending a file streams with a name.

    Fixed send_from_directory not expanding to the application root path correctly.

    Changed logic of before first request handlers to flip the flag after invoking. This will allow some uses that are potentially dangerous but should probably be permitted.

    Fixed Python 3 bug when a handler from app.url_build_error_handlers reraises the BuildError.

```

Werkzeug changelog:

```

Version 0.16.1

Released 2020-01-27

    Fix import location in deprecation messages for subpackages. #1663

    Fix an SSL error on Python 3.5 when the dev server responds with no content. #1659

Version 0.16.0

Released 2019-09-19

    Deprecate most top-level attributes provided by the werkzeug module in favor of direct imports. The deprecated imports will be removed in version 1.0.

    For example, instead of import werkzeug; werkzeug.url_quote, do from werkzeug.urls import url_quote. A deprecation warning will show the correct import to use. werkzeug.exceptions and werkzeug.routing should also be imported instead of accessed, but for technical reasons can’t show a warning.

    #2, #1640

Version 0.15.6

Released 2019-09-04

    Work around a bug in pip that caused the reloader to fail on Windows when the script was an entry point. This fixes the issue with Flask’s flask run command failing with “No module named Scriptsflask”. #1614

    ProxyFix trusts the X-Forwarded-Proto header by default. #1630

    The deprecated num_proxies argument to ProxyFix sets x_for, x_proto, and x_host to match 0.14 behavior. This is intended to make intermediate upgrades less disruptive, but the argument will still be removed in 1.0. #1630

Version 0.15.5

Released 2019-07-17

    Fix a TypeError due to changes to ast.Module in Python 3.8. #1551

    Fix a C assertion failure in debug builds of some Python 2.7 releases. #1553

    BadRequestKeyError adds the KeyError message to the description if e.show_exception is set to True. This is a more secure default than the original 0.15.0 behavior and makes it easier to control without losing information. #1592

    Upgrade the debugger to jQuery 3.4.1. #1581

    Work around an issue in some external debuggers that caused the reloader to fail. #1607

    Work around an issue where the reloader couldn’t introspect a setuptools script installed as an egg. #1600

    The reloader will use sys.executable even if the script is marked executable, reverting a behavior intended for NixOS introduced in 0.15. The reloader should no longer cause OSError: [Errno 8] Exec format error. #1482, #1580

    SharedDataMiddleware safely handles paths with Windows drive names. #1589

Version 0.15.4

Released 2019-05-14

    Fix a SyntaxError on Python 2.7.5. (#1544)

Version 0.15.3

Released 2019-05-14

    Properly handle multi-line header folding in development server in Python 2.7. (#1080)

    Restore the response argument to Unauthorized. (#1527)

    Unauthorized doesn’t add the WWW-Authenticate header if www_authenticate is not given. (#1516)

    The default URL converter correctly encodes bytes to string rather than representing them with b''. (#1502)

    Fix the filename format string in ProfilerMiddleware to correctly handle float values. (#1511)

    Update LintMiddleware to work on Python 3. (#1510)

    The debugger detects cycles in chained exceptions and does not time out in that case. (#1536)

    When running the development server in Docker, the debugger security pin is now unique per container.

Version 0.15.2

Released 2019-04-02

    Rule code generation uses a filename that coverage will ignore. The previous value, “generated”, was causing coverage to fail. (#1487)

    The test client removes the cookie header if there are no persisted cookies. This fixes an issue introduced in 0.15.0 where the cookies from the original request were used for redirects, causing functions such as logout to fail. (#1491)

    The test client copies the environ before passing it to the app, to prevent in-place modifications from affecting redirect requests. (#1498)

    The "werkzeug" logger only adds a handler if there is no handler configured for its level in the logging chain. This avoids double logging if other code configures logging first. (#1492)

Version 0.15.1

Released 2019-03-21

    Unauthorized takes description as the first argument, restoring previous behavior. The new www_authenticate argument is listed second. (#1483)

Version 0.15.0

Released 2019-03-19

    Building URLs is ~7x faster. Each Rule compiles an optimized function for building itself. (#1281)

    MapAdapter.build() can be passed a MultiDict to represent multiple values for a key. It already did this when passing a dict with a list value. (#724)

    path_info defaults to '/' for Map.bind(). (#740, #768, #1316)

    Change RequestRedirect code from 301 to 308, preserving the verb and request body (form data) during redirect. (#1342)

    int and float converters in URL rules will handle negative values if passed the signed=True parameter. For example, /jump/<int(signed=True):count>. (#1355)

    Location autocorrection in Response.get_wsgi_headers() is relative to the current path rather than the root path. (#693, #718, #1315)

    412 responses once again include entity headers and an error message in the body. They were originally omitted when implementing If-Match (#1233), but the spec doesn’t seem to disallow it. (#1231, #1255)

    The Content-Length header is removed for 1xx and 204 responses. This fixes a previous change where no body would be sent, but the header would still be present. The new behavior matches RFC 7230. (#1294)

    Unauthorized takes a www_authenticate parameter to set the WWW-Authenticate header for the response, which is technically required for a valid 401 response. (#772, #795)

    Add support for status code 424 FailedDependency. (#1358)

    http.parse_cookie() ignores empty segments rather than producing a cookie with no key or value. (#1245, #1301)

    parse_authorization_header() (and Authorization, authorization) treats the authorization header as UTF-8. On Python 2, basic auth username and password are unicode. (#1325)

    parse_options_header() understands RFC 2231 parameter continuations. (#1417)

    uri_to_iri() does not unquote ASCII characters in the unreserved class, such as space, and leaves invalid bytes quoted when decoding. iri_to_uri() does not quote reserved characters. See RFC 3987 for these character classes. (#1433)

    get_content_type appends a charset for any mimetype that ends with +xml, not just those that start with application/. Known text types such as application/javascript are also given charsets. (#1439)

    Clean up werkzeug.security module, remove outdated hashlib support. (#1282)

    In generate_password_hash(), PBKDF2 uses 150000 iterations by default, increased from 50000. (#1377)

    ClosingIterator calls close on the wrapped iterable, not the internal iterator. This doesn’t affect objects where __iter__ returned self. For other objects, the method was not called before. (#1259, #1260)

    Bytes may be used as keys in Headers, they will be decoded as Latin-1 like values are. (#1346)

    Range validates that list of range tuples passed to it would produce a valid Range header. (#1412)

    FileStorage looks up attributes on stream._file if they don’t exist on stream, working around an issue where tempfile.SpooledTemporaryFile() didn’t implement all of io.IOBase. See https://github.com/python/cpython/pull/3249. (#1409)

    CombinedMultiDict.copy() returns a shallow mutable copy as a MultiDict. The copy no longer reflects changes to the combined dicts, but is more generally useful. (#1420)

    The version of jQuery used by the debugger is updated to 3.3.1. (#1390)

    The debugger correctly renders long markupsafe.Markup instances. (#1393)

    The debugger can serve resources when Werkzeug is installed as a zip file. DebuggedApplication.get_resource uses pkgutil.get_data. (#1401)

    The debugger and server log support Python 3’s chained exceptions. (#1396)

    The interactive debugger highlights frames that come from user code to make them easy to pick out in a long stack trace. Note that if an env was created with virtualenv instead of venv, the debugger may incorrectly classify some frames. (#1421)

    Clicking the error message at the top of the interactive debugger will jump down to the bottom of the traceback. (#1422)

    When generating a PIN, the debugger will ignore a KeyError raised when the current UID doesn’t have an associated username, which can happen in Docker. (#1471)

    BadRequestKeyError adds the KeyError message to the description, making it clearer what caused the 400 error. Frameworks like Flask can omit this information in production by setting e.args = (). (#1395)

    If a nested ImportError occurs from import_string() the traceback mentions the nested import. Removes an untested code path for handling “modules not yet set up by the parent.” (#735)

    Triggering a reload while using a tool such as PDB no longer hides input. (#1318)

    The reloader will not prepend the Python executable to the command line if the Python file is marked executable. This allows the reloader to work on NixOS. (#1242)

    Fix an issue where sys.path would change between reloads when running with python -m app. The reloader can detect that a module was run with “-m” and reconstructs that instead of the file path in sys.argv when reloading. (#1416)

    The dev server can bind to a Unix socket by passing a hostname like unix://app.socket. (#209, #1019)

    Server uses IPPROTO_TCP constant instead of SOL_TCP for Jython compatibility. (#1375)

    When using an adhoc SSL cert with run_simple(), the cert is shown as self-signed rather than signed by an invalid authority. (#1430)

    The development server logs the unquoted IRI rather than the raw request line, to make it easier to work with Unicode in request paths during development. (#1115)

    The development server recognizes ConnectionError on Python 3 to silence client disconnects, and does not silence other OSErrors that may have been raised inside the application. (#1418)

    The environ keys REQUEST_URI and RAW_URI contain the raw path before it was percent-decoded. This is non-standard, but many WSGI servers add them. Middleware could replace PATH_INFO with this to route based on the raw value. (#1419)

    EnvironBuilder doesn’t set CONTENT_TYPE or CONTENT_LENGTH in the environ if they aren’t set. Previously these used default values if they weren’t set. Now it’s possible to distinguish between empty and unset values. (#1308)

    The test client raises a ValueError if a query string argument would overwrite a query string in the path. (#1338)

    test.EnvironBuilder and test.Client take a json argument instead of manually passing data and content_type. This is serialized using the test.EnvironBuilder.json_dumps() method. (#1404)

    test.Client redirect handling is rewritten. (#1402)

        The redirect environ is copied from the initial request environ.

        Script root and path are correctly distinguished when redirecting to a path under the root.

        The HEAD method is not changed to GET.

        307 and 308 codes preserve the method and body. All others ignore the body and related headers.

        Headers are passed to the new request for all codes, following what browsers do.

        test.EnvironBuilder sets the content type and length headers in addition to the WSGI keys when detecting them from the data.

        Intermediate response bodies are iterated over even when buffered=False to ensure iterator middleware can run cleanup code safely. Only the last response is not buffered. (#988)

    EnvironBuilder, FileStorage, and wsgi.get_input_stream() no longer share a global _empty_stream instance. This improves test isolation by preventing cases where closing the stream in one request would affect other usages. (#1340)

    The default SecureCookie.serialization_method will change from pickle to json in 1.0. To upgrade existing tokens, override unquote() to try pickle if json fails. (#1413)

    CGIRootFix no longer modifies PATH_INFO for very old versions of Lighttpd. LighttpdCGIRootFix was renamed to CGIRootFix in 0.9. Both are deprecated and will be removed in version 1.0. (#1141)

    werkzeug.wrappers.json.JSONMixin has been replaced with Flask’s implementation. Check the docs for the full API. (#1445)

    The contrib modules are deprecated and will either be moved into werkzeug core or removed completely in version 1.0. Some modules that already issued deprecation warnings have been removed. Be sure to run or test your code with python -W default::DeprecationWarning to catch any deprecated code you’re using. (#4)

        LintMiddleware has moved to werkzeug.middleware.lint.

        ProfilerMiddleware has moved to werkzeug.middleware.profiler.

        ProxyFix has moved to werkzeug.middleware.proxy_fix.

        JSONRequestMixin has moved to werkzeug.wrappers.json.

        cache has been extracted into a separate project, cachelib. The version in Werkzeug is deprecated.

        securecookie and sessions have been extracted into a separate project, secure-cookie. The version in Werkzeug is deprecated.

        Everything in fixers, except ProxyFix, is deprecated.

        Everything in wrappers, except JSONMixin, is deprecated.

        atom is deprecated. This did not fit in with the rest of Werkzeug, and is better served by a dedicated library in the community.

        jsrouting is removed. Set URLs when rendering templates or JSON responses instead.

        limiter is removed. Its specific use is handled by Werkzeug directly, but stream limiting is better handled by the WSGI server in general.

        testtools is removed. It did not offer significant benefit over the default test client.

        iterio is deprecated.

    wsgi.get_host() no longer looks at X-Forwarded-For. Use ProxyFix to handle that. (#609, #1303)

    ProxyFix is refactored to support more headers, multiple values, and more secure configuration.

        Each header supports multiple values. The trusted number of proxies is configured separately for each header. The num_proxies argument is deprecated. (#1314)

        Sets SERVER_NAME and SERVER_PORT based on X-Forwarded-Host. (#1314)

        Sets SERVER_PORT and modifies HTTP_HOST based on X-Forwarded-Port. (#1023, #1304)

        Sets SCRIPT_NAME based on X-Forwarded-Prefix. (#1237)

        The original WSGI environment values are stored in the werkzeug.proxy_fix.orig key, a dict. The individual keys werkzeug.proxy_fix.orig_remote_addr, werkzeug.proxy_fix.orig_wsgi_url_scheme, and werkzeug.proxy_fix.orig_http_host are deprecated.

    Middleware from werkzeug.wsgi has moved to separate modules under werkzeug.middleware, along with the middleware moved from werkzeug.contrib. The old werkzeug.wsgi imports are deprecated and will be removed in version 1.0. (#1452)

        werkzeug.wsgi.DispatcherMiddleware has moved to werkzeug.middleware.dispatcher.DispatcherMiddleware.

        werkzeug.wsgi.ProxyMiddleware as moved to werkzeug.middleware.http_proxy.ProxyMiddleware.

        werkzeug.wsgi.SharedDataMiddleware has moved to werkzeug.middleware.shared_data.SharedDataMiddleware.

    ProxyMiddleware proxies the query string. (#1252)

    The filenames generated by ProfilerMiddleware can be customized. (#1283)

    The werkzeug.wrappers module has been converted to a package, and its various classes have been organized into separate modules. Any previously documented classes, understood to be the existing public API, are still importable from werkzeug.wrappers, or may be imported from their specific modules. (#1456)


```

itsdangerous changelog

```
Version 1.1.0

Released 2018-10-26

    Change default signing algorithm back to SHA-1. :pr:`113`
    Added a default SHA-512 fallback for users who used the yanked 1.0.0 release which defaulted to SHA-512. :pr:`114`
    Add support for fallback algorithms during deserialization to support changing the default in the future without breaking existing signatures. :pr:`113`
    Changed capitalization of packages back to lowercase as the change in capitalization broke some tooling. :pr:`113`

Version 1.0.0

Released 2018-10-18

YANKED

Note: This release was yanked from PyPI because it changed the default algorithm to SHA-512. This decision was reverted in 1.1.0 and it remains at SHA1.

    Drop support for Python 2.6 and 3.3.

    Refactor code from a single module to a package. Any object in the API docs is still importable from the top-level itsdangerous name, but other imports will need to be changed. A future release will remove many of these compatibility imports. :pr:`107`

    Optimize how timestamps are serialized and deserialized. :pr:`13`

    base64_decode raises BadData when it is passed invalid data. :pr:`27`

    Ensure value is bytes when signing to avoid a TypeError on Python 3. :issue:`29`

    Add a serializer_kwargs argument to Serializer, which is passed to dumps during dump_payload. :pr:`36`

    More compact JSON dumps for unicode strings. :issue:`38`

    Use the full timestamp rather than an offset, allowing dates before 2011. :issue:`46`

    To retain compatibility with signers from previous versions, consider using this shim when unsigning.

    Detect a sep character that may show up in the signature itself and raise a ValueError. :issue:`62`

    Use a consistent signature for keyword arguments for Serializer.load_payload in subclasses. :issue:`74`, :pr:`75`

    Change default intermediate hash from SHA-1 to SHA-512. :pr:`80`

    Convert JWS exp header to an int when loading. :pr:`99`

```

Jinja2 changelog (we don't use it but it's a dependency of Flask)

```

Version 2.11.3

Released 2021-01-31

    Improve the speed of the urlize filter by reducing regex backtracking. Email matching requires a word character at the start of the domain part, and only word characters in the TLD. #1343

Version 2.11.2

Released 2020-04-13

    Fix a bug that caused callable objects with __getattr__, like Mock to be treated as a contextfunction(). #1145

    Update wordcount filter to trigger Undefined methods by wrapping the input in soft_unicode(). #1160

    Fix a hang when displaying tracebacks on Python 32-bit. #1162

    Showing an undefined error for an object that raises AttributeError on access doesn’t cause a recursion error. #1177

    Revert changes to PackageLoader from 2.10 which removed the dependency on setuptools and pkg_resources, and added limited support for namespace packages. The changes caused issues when using Pytest. Due to the difficulty in supporting Python 2 and PEP 451 simultaneously, the changes are reverted until 3.0. #1182

    Fix line numbers in error messages when newlines are stripped. #1178

    The special namespace() assignment object in templates works in async environments. #1180

    Fix whitespace being removed before tags in the middle of lines when lstrip_blocks is enabled. #1138

    NativeEnvironment doesn’t evaluate intermediate strings during rendering. This prevents early evaluation which could change the value of an expression. #1186

Version 2.11.1

Released 2020-01-30

    Fix a bug that prevented looking up a key after an attribute ({{ data.items[1:] }}) in an async template. #1141

Version 2.11.0

Released 2020-01-27

    Drop support for Python 2.6, 3.3, and 3.4. This will be the last version to support Python 2.7 and 3.5.

    Added a new ChainableUndefined class to support getitem and getattr on an undefined object. #977

    Allow {%+ syntax (with NOP behavior) when lstrip_blocks is disabled. #748

    Added a default parameter for the map filter. #557

    Exclude environment globals from meta.find_undeclared_variables(). #931

    Float literals can be written with scientific notation, like 2.56e-3. #912, #922

    Int and float literals can be written with the ‘_’ separator for legibility, like 12_345. #923

    Fix a bug causing deadlocks in LRUCache.setdefault. #1000

    The trim filter takes an optional string of characters to trim. #828

    A new jinja2.ext.debug extension adds a {% debug %} tag to quickly dump the current context and available filters and tests. #174, #798, #983

    Lexing templates with large amounts of whitespace is much faster. #857, #858

    Parentheses around comparisons are preserved, so {{ 2 * (3 < 5) }} outputs “2” instead of “False”. #755, #938

    Add new boolean, false, true, integer and float tests. #824

    The environment’s finalize function is only applied to the output of expressions (constant or not), not static template data. #63

    When providing multiple paths to FileSystemLoader, a template can have the same name as a directory. #821

    Always return Undefined when omitting the else clause in a {{ 'foo' if bar }} expression, regardless of the environment’s undefined class. Omitting the else clause is a valid shortcut and should not raise an error when using StrictUndefined. #710, #1079

    Fix behavior of loop control variables such as length and revindex0 when looping over a generator. #459, #751, #794, #993

    Async support is only loaded the first time an environment enables it, in order to avoid a slow initial import. #765

    In async environments, the |map filter will await the filter call if needed. #913

    In for loops that access loop attributes, the iterator is not advanced ahead of the current iteration unless length, revindex, nextitem, or last are accessed. This makes it less likely to break groupby results. #555, #1101

    In async environments, the loop attributes length and revindex work for async iterators. #1101

    In async environments, values from attribute/property access will be awaited if needed. #1101

    PackageLoader doesn’t depend on setuptools or pkg_resources. #970

    PackageLoader has limited support for PEP 420 namespace packages. #1097

    Support os.PathLike objects in FileSystemLoader and ModuleLoader. #870

    NativeTemplate correctly handles quotes between expressions. "'{{ a }}', '{{ b }}'" renders as the tuple ('1', '2') rather than the string '1, 2'. #1020

    Creating a NativeTemplate directly creates a NativeEnvironment instead of a default Environment. #1091

    After calling LRUCache.copy(), the copy’s queue methods point to the correct queue. #843

    Compiling templates always writes UTF-8 instead of defaulting to the system encoding. #889

    |wordwrap filter treats existing newlines as separate paragraphs to be wrapped individually, rather than creating short intermediate lines. #175

    Add break_on_hyphens parameter to |wordwrap filter. #550

    Cython compiled functions decorated as context functions will be passed the context. #1108

    When chained comparisons of constants are evaluated at compile time, the result follows Python’s behavior of returning False if any comparison returns False, rather than only the last one. #1102

    Tracebacks for exceptions in templates show the correct line numbers and source for Python >= 3.7. #1104

    Tracebacks for template syntax errors in Python 3 no longer show internal compiler frames. #763

    Add a DerivedContextReference node that can be used by extensions to get the current context and local variables such as loop. #860

    Constant folding during compilation is applied to some node types that were previously overlooked. #733

    TemplateSyntaxError.source is not empty when raised from an included template. #457

    Passing an Undefined value to get_template (such as through extends, import, or include), raises an UndefinedError consistently. select_template will show the undefined message in the list of attempts rather than the empty string. #1037

    TemplateSyntaxError can be pickled. #1117

Version 2.10.3

Released 2019-10-04

    Fix a typo in Babel entry point in setup.py that was preventing installation.

Version 2.10.2

Released 2019-10-04

    Fix Python 3.7 deprecation warnings.

    Using range in the sandboxed environment uses xrange on Python 2 to avoid memory use. #933

    Use Python 3.7’s better traceback support to avoid a core dump when using debug builds of Python 3.7. #1050

Version 2.10.1

Released 2019-04-06

    SandboxedEnvironment securely handles str.format_map in order to prevent code execution through untrusted format strings. The sandbox already handled str.format.




```

Flask-RESTful changelog

```
Version 0.3.9

    Compatibility with Flask 2.0

Version 0.3.8

Released February 06, 2020

    Add Python 3.8 support (#835)
    Fix wrongly parsed Decimal fields (#855)
    Fix overridden response when calling abort with Response (#817)
    Various small fixes and updates to documentation

Version 0.3.7

Released December 18, 2018

    Fix error handling in python3 (#696)
    Fix arguments with type=list (#705)
    Return code for parse_args() is now configurable (#722)
    Removed flask_restful.paging module.
    Removed misleading help_on_404 functionality (#722)
    JSON keys are no longer sorted by default in debug mode in python3 (#680)
    Various small fixes and updates to documentation

Version 0.3.6

Released May 31, 2017

    Argument.help now supports unicode strings (#564)
    Flags can now be passed to inputs.regex (#621)
    Fix behavior of action='append' in conjunction with location='json' (#645)
    method_decorators can be a dict to apply decorator behavior for only specific HTTP methods (#532)
    JSON keys are no longer sorted by default in debug mode in python3 (#680)
    Various small fixes and updates to documentation

Version 0.3.5

Released December 9, 2015

    Add nullable option to request parser to allow/disallow null values for arguments (#538)
    Use Flask's exception log method in handle_error(e) method instead of directly logging the exception notice. (#496)
    Argument.help now allows more flexible message formatting using the {error_msg} string interpolation token. (#518)
    Prevent representation from being chosen at random when Accept: */* (#524)
    Headers from HTTPExceptions are now returned in the response instead of being discarded (#523)
    Marshalling now checks for a __marshallable__ method first before defaulting back to __getitem__ ()
    Flask 1.0 compatability fixes (#506)

Version 0.3.4

Released July 20, 2015

    Fixed issue where abort() and raise Exception were not equivalent (#205)
    Fixed RequestParser settings not being copied properly (#483)
    Add ability to configure json serializer settings from application config (#458)
    Project metadata, tests, and examples are now included in source distributions (#475)
    Various documentation improvements

Version 0.3.3

Released May 22, 2015

    Disable challenge on 401 by default (THIS IS A BREAKING CHANGE, albeit a very small one with behavior that probably no one depended upon. You can easily change this back to the old way).
    Doc fixes (#404, #406, #436, misc. other commits)
    Fix truncation of microseconds in iso8601 datetime output (#368)
    null arguments from JSON no longer cast to string (#390)
    Made list fields work with classes (#409)
    Fix url_for() when used with Blueprints (#410)
    Add CORS "Access-Control-Expose-Headers" support (#412)
    Fix class references in RequestParser (#414)
    Allow any callables to be used as lazy attributes (#417)
    Fix references to flask.ext.* (#420)
    Trim support with fixes (#428)
    Added ability to pass-in parameters into Resource constructors (#444)
    Fix custom type docs on "Intermediate usage" and docstring (#434)
    Fixed problem with RequestParser.copy (#435)
    Feature/error bundling (#431)
    Explicitly check the class type for propagate_exceptions (#445)
    Remove min. year limit 1900 in inputs.date (#446)


```