### PR TITLE
Upgrade icalendar

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -51,7 +51,7 @@ guppy3==3.1.2; python_version >= '3.0'
 hiredis==1.1.0
 html2text==2019.8.11
 hypothesis==4.57.1
-icalendar==3.9.1
+icalendar==4.0.9
 idna==2.9
 git+https://github.com/closeio/imapclient.git@aca1b9b3624f28dca8fdf5e140704c8b7d57820f#egg=imapclient
 importlib-metadata==2.1.1


### PR DESCRIPTION
Sync-engine uses icalendar to create ical files. This is the latest version of icalendar and it still works on Python 2. We don't use this feature.

icalendar changelog:

```
4.0.9 (2021-10-16)

Bug fixes:

    Fix vCategories for correct en/de coding. [thet]
    vDuration property value: Fix changing duration sign after multiple to_ical calls. Ref: #320 Fixes: #319 [barlik]

4.0.8 (2021-10-07)

Bug fixes:

    Support added for Python 3.9 and 3.10 (no code changes needed).
    Replace bare 'except:' with 'except Exception:' (#281)

4.0.7 (2020-09-07)

Bug fixes:

    fixed rrule handling, re-enabled test_create_america_new_york()

4.0.6 (2020-05-06)

Bug fixes:

    Use vText as default type, when convert recurrence definition to ical string. [kam193]

4.0.5 (2020-03-21)

Bug fixes:

    Fixed a docs issue related to building on Read the Docs [davidfischer]

4.0.4 (2019-11-25)

Bug fixes:

    Reduce Hypothesis iterations to speed up testing, allowing PRs to pass [UniversalSuperBox]

4.0.3 (2018-10-10)

Bug fixes:

    Categories are comma separated not 1 per line #265. [cleder]
    mark test with mixed timezoneaware and naive datetimes as an expected failure. [cleder]

4.0.2 (2018-06-20)

Bug fixes:

    Update all pypi.python.org URLs to pypi.org [jon.dufresne]

4.0.1 (2018-02-11)

    Added rudimentary command line interface. [jfjlaros]
    Readme, setup and travis updates. [jdufresne, PabloCastellano]

4.0.0 (2017-11-08)

Breaking changes:

    Drop support for Python 2.6 and 3.3.

3.12 (2017-11-07)

New features:

    Accept Windows timezone identifiers as valid. #242 [geier]

Bug fixes:

    Fix ResourceWarnings in setup.py when Python warnings are enabled. #244 [jdufresne]
    Fix invalid escape sequences in string and bytes literals. #245 [jdufresne]
    Include license file in the generated wheel package. #243 [jdufresne]
    Fix non-ASCII TZID and TZNAME parameter handling. #238 [clivest]
    Docs: update install instructions. #240 [Ekran]

3.11.7 (2017-08-27)

New features:

    added vUTCOffset.ignore_exceptions to allow surpressing of failed TZOFFSET parsing (for now this ignores the check for offsets > 24h) [geier]

3.11.6 (2017-08-04)

Bug fixes:

    Fix VTIMEZONEs including RDATEs #234. [geier]

3.11.5 (2017-07-03)

Bug fixes:

    added an assertion that VTIMEZONE sub-components' DTSTART must be of type DATETIME [geier]
    Fix handling of VTIMEZONEs with subcomponents with the same DTSTARTs and OFFSETs but which are of different types [geier]

3.11.4 (2017-05-10)

Bug fixes:

    Don't break on parameter values which contain equal signs, e.g. base64 encoded binary data [geier]
    Fix handling of VTIMEZONEs with subcomponents with the same DTSTARTs. [geier]

3.11.3 (2017-02-15)

Bug fixes:

    Removed setuptools as a dependency as it was only required by setup.py and not by the package.
    Don't split content lines on the unicode LINE SEPARATOR character \u2028 but only on CRLF or LF.

3.11.2 (2017-01-12)

Bug fixes:

    Run tests with python 3.5 and 3.6. [geier]
    Allow tests failing with pypy3 on travis.ci. [geier]

3.11.1 (2016-12-19)

Bug fixes:

    Encode error message before adding it to the stack of collected error messages.

3.11 (2016-11-18)

Fixes:

    Successfully test with pypy and pypy3. [gforcada]
    Minor documentation update. [tpltnt]

3.10 (2016-05-26)

New:

    Updated components description to better comply with RFC 5545. Refs #183. [stlaz]
    Added PERIOD value type to date types. Also fixes incompatibilities described in #184. Refs #189. [stlaz]

Fixes:

    Fix testsuite for use with dateutil>=2.5. Refs #195. [untitaker]
    Reintroduce cal.Component.is_broken that was removed with 3.9.2. Refs #185. [geier]

3.9.2 (2016-02-05)

New:

    Defined test_suite in setup.py. Now tests can be run via python setup.py test. [geier]

Fixes:

    Fixed cal.Component.from_ical() representing an unknown component as one of the known. [stlaz]
    Fixed possible IndexError exception during parsing of an ical string. [stlaz]
    When doing a boolean test on icalendar.cal.Component, always return True. Before it was returning False due to CaselessDict, if it didn't contain any items. [stlaz]
    Fixed date-time being recognized as date or time during parsing. Added better error handling to parsing from ical strings. [stlaz]
    Added __version__ attribute to init.py. [TomTry]
    Documentation fixes. [TomTry]
    Pep 8, UTF 8 headers, dict/list calls to literals. [thet]


```