### PR TITLE
Upgrade imapclient

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -53,7 +53,7 @@ html2text==2019.8.11
 hypothesis==4.57.1
 icalendar==3.9.1
 idna==2.9
-git+https://github.com/closeio/imapclient.git@aca1b9b3624f28dca8fdf5e140704c8b7d57820f#egg=imapclient
+imapclient==2.2.0
 importlib-metadata==2.1.1
 ipaddress==1.0.19
 ipython==5.8.0


### PR DESCRIPTION
This is the same version of imapclient we use in another project of ours.

The fixes we've made have been independently implemented upstream and are included in the latest release.
I've run manual email syncing tests with this version of imapclient.