### PR TITLE
refresh_token is str

### DIFF
--- a/inbox/models/backends/oauth.py
+++ b/inbox/models/backends/oauth.py
@@ -3,6 +3,7 @@ Generic OAuth class that provides abstraction for access and
 refresh tokens.
 """
 from datetime import datetime, timedelta
+from typing import Union
 
 from sqlalchemy import Column, ForeignKey
 from sqlalchemy.ext.declarative import declared_attr
@@ -55,15 +56,17 @@ class OAuthAccount(object):
 
     @property
     def refresh_token(self):
+        # type: () -> str
         if not self.secret:
             return None
         if self.secret.type == SecretType.Token.value:
-            return self.secret.secret
+            return self.secret.secret.decode("utf-8")
         else:
             raise ValueError("Invalid secret type.")
 
     @refresh_token.setter
     def refresh_token(self, value):
+        # type: (Union[str, bytes]) -> None
         # Must be a valid UTF-8 byte sequence without NULL bytes.
         if not isinstance(value, bytes):
             value = value.encode("utf-8")
@@ -79,6 +82,7 @@ class OAuthAccount(object):
         self.set_secret(SecretType.Token, value)
 
     def set_secret(self, secret_type, secret_value):
+        # type: (SecretType, bytes) -> None
         if not self.secret:
             self.secret = Secret()
 

--- a/inbox/models/secret.py
+++ b/inbox/models/secret.py
@@ -1,4 +1,5 @@
 import enum
+from typing import Union
 
 from sqlalchemy import Column, Enum, Integer
 from sqlalchemy.orm import validates
@@ -38,8 +39,9 @@ class Secret(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     @secret.setter
     def secret(self, plaintext):
+        # type: (Union[str, bytes]) -> None
         if not isinstance(plaintext, bytes):
-            plaintext = plaintext.encode("utf8")
+            plaintext = plaintext.encode("utf-8")
         if not isinstance(plaintext, bytes):
             raise TypeError("Invalid secret")
 

--- a/tests/security/test_secret.py
+++ b/tests/security/test_secret.py
@@ -1,7 +1,4 @@
 # -*- coding: UTF-8 -*-
-import builtins
-import sys
-
 import pytest
 
 from inbox.auth.google import GoogleAccountData, GoogleAuthHandler
@@ -85,10 +82,11 @@ def test_token(db, config, encrypt):
             "utf-8"
         ), "token encrypted when encryption disabled"
 
-    decrypted_secret = secret.secret
-    assert (
-        decrypted_secret == token.encode("utf-8")
-        and account.refresh_token == decrypted_secret
+    decrypted_secret = secret.secret  # type: bytes
+    assert decrypted_secret == token.encode(
+        "utf-8"
+    ) and account.refresh_token == decrypted_secret.decode(
+        "utf-8"
     ), "token not decrypted correctly"
 
     # db.session.delete(account.auth_credentials[0])
@@ -118,21 +116,15 @@ def test_token_inputs(db, config, encrypt, default_account):
     secret_id = default_account.refresh_token_id
     secret = db.session.query(Secret).get(secret_id)
 
-    assert not isinstance(
-        secret.secret, builtins.unicode if sys.version_info < (3,) else str
-    ), "secret cannot be unicode"
+    assert isinstance(secret.secret, bytes), "secret cannot be unicode"
     assert secret.secret == unicode_token.encode(
         "utf-8"
     ), "token not decrypted correctly"
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         default_account.refresh_token = invalid_token
 
-    assert e.typename == "ValueError", "token cannot be invalid UTF-8"
-
-    with pytest.raises(ValueError) as f:
+    with pytest.raises(ValueError):
         default_account.refresh_token = null_token
 
-    assert f.typename == "ValueError", "token cannot contain NULL byte"
-
-    assert default_account.refresh_token == unicode_token.encode("utf-8")
+    assert default_account.refresh_token == unicode_token


### PR DESCRIPTION
This is very analogical to: https://github.com/closeio/sync-engine/pull/183

Refresh tokens are stored in MySQL in binary BLOB fields.

The logic already accepts bytes and text, and if it receives text it will encode it UTF-8 before saving.

On Python 3 the getters will return bytes. This is fine on Python 2 where it is a synonym of string and silently coerces to unicode in comparisons. But Python 3 needs an extra .decode('utf-8').