### PR TITLE
CONDSTORE related bytes/str changes

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -753,7 +753,9 @@ class FolderSyncEngine(Greenlet):
     def condstore_refresh_flags(self, crispin_client):
         new_highestmodseq = crispin_client.conn.folder_status(
             self.folder_name, ["HIGHESTMODSEQ"]
-        )[b"HIGHESTMODSEQ"]
+        )[
+            b"HIGHESTMODSEQ"
+        ]  # type: int
         # Ensure that we have an initial highestmodseq value stored before we
         # begin polling for changes.
         if self.highestmodseq is None:

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -218,12 +218,12 @@ class MockIMAPClient(object):
                 m = re.match("CHANGEDSINCE (?P<modseq>[0-9]+)", modifiers[0])
                 if m:
                     modseq = int(m.group("modseq"))
-                    items = {u for u in items if uid_dict[u]["MODSEQ"][0] > modseq}
+                    items = {u for u in items if uid_dict[u][b"MODSEQ"][0] > modseq}
         data = [d.encode() for d in data]
         for u in items:
             if u in uid_dict:
                 resp[u] = {
-                    k: v for k, v in uid_dict[u].items() if k in data or k == "MODSEQ"
+                    k: v for k, v in uid_dict[u].items() if k in data or k == b"MODSEQ"
                 }
         return resp
 
@@ -257,7 +257,10 @@ class MockIMAPClient(object):
         lastuid = max(folder_data) if folder_data else 0
         resp = {b"UIDNEXT": lastuid + 1, b"UIDVALIDITY": self.uidvalidity}
         if data and "HIGHESTMODSEQ" in data:
-            resp[b"HIGHESTMODSEQ"] = max(v[b"MODSEQ"] for v in folder_data.values())
+            resp[b"HIGHESTMODSEQ"] = max(
+                v[b"MODSEQ"][0] if isinstance(v[b"MODSEQ"], tuple) else v[b"MODSEQ"]
+                for v in folder_data.values()
+            )
         return resp
 
     def delete_messages(self, uids, silent=False):

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -257,10 +257,7 @@ class MockIMAPClient(object):
         lastuid = max(folder_data) if folder_data else 0
         resp = {b"UIDNEXT": lastuid + 1, b"UIDVALIDITY": self.uidvalidity}
         if data and "HIGHESTMODSEQ" in data:
-            resp[b"HIGHESTMODSEQ"] = max(
-                v[b"MODSEQ"][0] if isinstance(v[b"MODSEQ"], tuple) else v[b"MODSEQ"]
-                for v in folder_data.values()
-            )
+            resp[b"HIGHESTMODSEQ"] = max(v[b"MODSEQ"][0] for v in folder_data.values())
         return resp
 
     def delete_messages(self, uids, silent=False):

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -39,7 +39,7 @@ def build_uid_data(internaldate, flags, body, g_labels, g_msgid, modseq):
         b"X-GM-LABELS": g_labels,
         b"X-GM-MSGID": g_msgid,
         b"X-GM-THRID": g_msgid,  # For simplicity
-        b"MODSEQ": modseq,
+        b"MODSEQ": (modseq,),
     }
 
 

--- a/tests/imap/test_delete_handling.py
+++ b/tests/imap/test_delete_handling.py
@@ -301,9 +301,9 @@ def test_renamed_label_refresh(
 
     new_flags = {
         msg_uid: {
-            "FLAGS": ("\\Seen",),
-            "X-GM-LABELS": ("new label",),
-            "MODSEQ": ("23",),
+            b"FLAGS": (b"\\Seen",),
+            b"X-GM-LABELS": (b"new label",),
+            b"MODSEQ": (23,),
         }
     }
     mock_imapclient._data["[Gmail]/All mail"] = new_flags

--- a/tests/imap/test_folder_sync.py
+++ b/tests/imap/test_folder_sync.py
@@ -127,6 +127,9 @@ def test_condstore_flags_refresh(
         v[b"X-GM-LABELS"] = (b"newlabel",)
         v[b"MODSEQ"] = (k,)
 
+    with folder_sync_engine.conn_pool.get() as crispin_client:
+        assert crispin_client.condstore_supported()
+
     folder_sync_engine.highestmodseq = 0
     # Don't sleep at the end of poll_impl before returning.
     folder_sync_engine.poll_frequency = 0
@@ -138,7 +141,7 @@ def test_condstore_flags_refresh(
     assert (
         folder_sync_engine.highestmodseq
         == mock_imapclient.folder_status(all_mail_folder.name, ["HIGHESTMODSEQ"])[
-            "HIGHESTMODSEQ"
+            b"HIGHESTMODSEQ"
         ]
     )
 


### PR DESCRIPTION
This is a couple of str/bytes changes around the code that uses `CONDSTORE`.

`CONDSTORE` is a capability that allows the server to ask what messages changed in given folder since given `MODSEQ` (modification sequence). At least gmail supports it.

Modification sequences are monotonically increasing integers that server assigns to each message on change. If you ask the server for a `HIGESTMODSEQ` (highest modification sequence) in given folder, then sleep for a while, then `FETCH` messages since that highest modification sequence, you can implement efficient way to sync incremental changes, without `FETCH`ing all the messages from scratch.