### PR TITLE
Skip contact test relying on gdata

### DIFF
--- a/tests/contacts/test_remote_sync.py
+++ b/tests/contacts/test_remote_sync.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from inbox.models import Contact
@@ -84,6 +86,9 @@ def test_deletes(contacts_provider, contact_sync, db):
     assert num_current_contacts == num_original_contacts
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3,), reason="gdata library does not work on Python 3"
+)
 def test_auth_error_handling(contact_sync, default_account, db):
     """Test that the contact sync greenlet stops if account credentials are
     invalid."""


### PR DESCRIPTION
gdata (https://pypi.org/project/gdata/) is not available on Python 3. This is the only test that fails because of it. Skip it for now.

We will most probably remove contact sync feature alltogether later. For the time being just skip it, as we don't use this code.