### PR TITLE
Skip test_smtp_ssl_verification_bad_cert

### DIFF
--- a/tests/security/test_smtp_ssl.py
+++ b/tests/security/test_smtp_ssl.py
@@ -103,6 +103,9 @@ def example_draft(db, default_account):
     }
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 8), reason="asyncore and smtpd are deprecated"
+)
 def test_smtp_ssl_verification_bad_cert(
     db,
     bad_cert_smtp_server,
@@ -122,5 +125,5 @@ def test_smtp_ssl_verification_bad_cert(
 
 
 if __name__ == "__main__":
-    server = BadCertSMTPServer((SMTP_SERVER_HOST, SMTP_SERVER_PORT), (None, None))
+    server = BadCertSMTPServer((SMTP_SERVER_HOST, 0), (None, None))
     asyncore.loop()


### PR DESCRIPTION
This test stopped working on Python 3.8. This is due to asyncore (https://docs.python.org/3/library/asyncore.html) and smtpd (https://docs.python.org/3/library/smtpd.html) being deprecated.

This test relies on asyncore and smtpd to start a dummy SMTP server with self signed certificate. One is supposed to rewrite it using asyncio and aiosmtpd (https://github.com/aio-libs/aiosmtpd) on latest Python versions. Given that we don't use email sending and will most probably get rid off e-mail sending from sync-engine it's not worth the effort right now.