### PR TITLE
Fix SMTP host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,6 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN \
-  --mount=type=cache,target=/home/sync-engine/.cache,uid=5000,gid=5000  \
   python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==44.0.0 pip==20.3.4 && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements_frozen.txt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN \
+  --mount=type=cache,target=/home/sync-engine/.cache,uid=5000,gid=5000  \
   python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==44.0.0 pip==20.3.4 && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements_frozen.txt && \

--- a/inbox/sendmail/smtp/postel.py
+++ b/inbox/sendmail/smtp/postel.py
@@ -167,14 +167,14 @@ class SMTPConnection(object):
         if port in (SMTP_OVER_SSL_PORT, SMTP_OVER_SSL_TEST_PORT):
             self.connection = (
                 SMTP_SSL(timeout=SMTP_TIMEOUT)
-                if sys.version < (3,)
+                if sys.version_info < (3,)
                 else SMTP_SSL(host, timeout=SMTP_TIMEOUT)
             )
             self._connect(host, port)
         else:
             self.connection = (
                 SMTP(timeout=SMTP_TIMEOUT)
-                if sys.version < (3,)
+                if sys.version_info < (3,)
                 else SMTP(host, timeout=SMTP_TIMEOUT)
             )
             self._connect(host, port)

--- a/inbox/sendmail/smtp/postel.py
+++ b/inbox/sendmail/smtp/postel.py
@@ -6,6 +6,7 @@ import re
 import smtplib
 import socket
 import ssl
+import sys
 from builtins import range
 
 from inbox.logging import get_logger
@@ -164,10 +165,18 @@ class SMTPConnection(object):
     def setup(self):
         host, port = self.smtp_endpoint
         if port in (SMTP_OVER_SSL_PORT, SMTP_OVER_SSL_TEST_PORT):
-            self.connection = SMTP_SSL(host, timeout=SMTP_TIMEOUT)
+            self.connection = (
+                SMTP_SSL(timeout=SMTP_TIMEOUT)
+                if sys.version < (3,)
+                else SMTP_SSL(host, timeout=SMTP_TIMEOUT)
+            )
             self._connect(host, port)
         else:
-            self.connection = SMTP(host, timeout=SMTP_TIMEOUT)
+            self.connection = (
+                SMTP(timeout=SMTP_TIMEOUT)
+                if sys.version < (3,)
+                else SMTP(host, timeout=SMTP_TIMEOUT)
+            )
             self._connect(host, port)
             self._upgrade_connection()
 

--- a/inbox/sendmail/smtp/postel.py
+++ b/inbox/sendmail/smtp/postel.py
@@ -164,10 +164,10 @@ class SMTPConnection(object):
     def setup(self):
         host, port = self.smtp_endpoint
         if port in (SMTP_OVER_SSL_PORT, SMTP_OVER_SSL_TEST_PORT):
-            self.connection = SMTP_SSL(timeout=SMTP_TIMEOUT)
+            self.connection = SMTP_SSL(host, timeout=SMTP_TIMEOUT)
             self._connect(host, port)
         else:
-            self.connection = SMTP(timeout=SMTP_TIMEOUT)
+            self.connection = SMTP(host, timeout=SMTP_TIMEOUT)
             self._connect(host, port)
             self._upgrade_connection()
 


### PR DESCRIPTION
Newer versions of Python verify that the host we are conecting to matches the cert, one needs to provide host to the constructor, otherwise it wil fail.

We don't use this part of code (sending) but it was easy to fix anyway.