### PR TITLE
Upgrade flask & friends

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -19,7 +19,7 @@ cffi==1.14.6
 chardet==3.0.4
 charset-normalizer==2.0.7; python_version >= '3.5'
 ciso8601==2.2.0
-click==2.4
+click==7.1.2
 colorama==0.3.9
 colorlog==5.0.1
 configparser==4.0.2
@@ -35,7 +35,7 @@ flake8==2.1.0
 flake8-pep3101==0.6
 git+https://github.com/closeio/flanker-new.git@fa272d95345d45e8bb1f9bc32bc2c074bf52a484#egg=flanker
 tld==0.12.6
-Flask==0.12.5
+Flask==1.1.4
 Flask-RESTful==0.3.9
 freezegun==0.3.15
 funcsigs==1.0.2
@@ -127,7 +127,7 @@ urllib3==1.26.7
 vobject==0.9.1
 wcwidth==0.2.5
 WebOb==1.7.4
-Werkzeug==0.16.1
+Werkzeug==1.0.1
 wrapt==1.10.11
 zipp==1.2.0
 zope.event==4.5.0


### PR DESCRIPTION
This is the second step of upgrading Flask. These are the last versions that work on Python 2.

Click upgrade affects commandline parsing and I tested all the entry points we use manually.

Flask changelog

```

1.1.4

-------------
  
  Released 2021-05-13
  
  -   Update ``static_folder`` to use ``_compat.fspath`` instead of
  ``os.fspath`` to continue supporting Python < 3.6 :issue:`4050`

1.1.3

-------------
  
  Released 2021-05-13
  
  -   Set maximum versions of Werkzeug, Jinja, Click, and ItsDangerous.
  :issue:`4043`
  -   Re-add support for passing a ``pathlib.Path`` for ``static_folder``.
  :pr:`3579`

1.1.2

-------------
  
  Released 2020-04-03
  
  -   Work around an issue when running the ``flask`` command with an
  external debugger on Windows. :issue:`3297`
  -   The static route will not catch all URLs if the ``Flask``
  ``static_folder`` argument ends with a slash. :issue:`3452`

1.1.1

-------------
  
  Released 2019-07-08
  
  -   The ``flask.json_available`` flag was added back for compatibility
  with some extensions. It will raise a deprecation warning when used,
  and will be removed in version 2.0.0. :issue:`3288`

1.1.0

-------------
  
  Released 2019-07-04
  
  -   Bump minimum Werkzeug version to >= 0.15.
  -   Drop support for Python 3.4.
  -   Error handlers for ``InternalServerError`` or ``500`` will always be
  passed an instance of ``InternalServerError``. If they are invoked
  due to an unhandled exception, that original exception is now
  available as ``e.original_exception`` rather than being passed
  directly to the handler. The same is true if the handler is for the
  base ``HTTPException``. This makes error handler behavior more
  consistent. :pr:`3266`
  
  -   :meth:`Flask.finalize_request` is called for all unhandled
  exceptions even if there is no ``500`` error handler.
  
  -   :attr:`Flask.logger` takes the same name as
  :attr:`Flask.name` (the value passed as
  ``Flask(import_name)``. This reverts 1.0's behavior of always
  logging to ``"flask.app"``, in order to support multiple apps in the
  same process. A warning will be shown if old configuration is
  detected that needs to be moved. :issue:`2866`
  -   :meth:`flask.RequestContext.copy` includes the current session
  object in the request context copy. This prevents ``session``
  pointing to an out-of-date object. :issue:`2935`
  -   Using built-in RequestContext, unprintable Unicode characters in
  Host header will result in a HTTP 400 response and not HTTP 500 as
  previously. :pr:`2994`
  -   :func:`send_file` supports :class:`~os.PathLike` objects as
  described in PEP 0519, to support :mod:`pathlib` in Python 3.
  :pr:`3059`
  -   :func:`send_file` supports :class:`~io.BytesIO` partial content.
  :issue:`2957`
  -   :func:`open_resource` accepts the "rt" file mode. This still does
  the same thing as "r". :issue:`3163`
  -   The :attr:`MethodView.methods` attribute set in a base class is used
  by subclasses. :issue:`3138`
  -   :attr:`Flask.jinja_options` is a ``dict`` instead of an
  ``ImmutableDict`` to allow easier configuration. Changes must still
  be made before creating the environment. :pr:`3190`
  -   Flask's ``JSONMixin`` for the request and response wrappers was
  moved into Werkzeug. Use Werkzeug's version with Flask-specific
  support. This bumps the Werkzeug dependency to >= 0.15.
  :issue:`3125`
  -   The ``flask`` command entry point is simplified to take advantage
  of Werkzeug 0.15's better reloader support. This bumps the Werkzeug
  dependency to >= 0.15. :issue:`3022`
  -   Support ``static_url_path`` that ends with a forward slash.
  :issue:`3134`
  -   Support empty ``static_folder`` without requiring setting an empty
  ``static_url_path`` as well. :pr:`3124`
  -   :meth:`jsonify` supports :class:`dataclasses.dataclass` objects.
  :pr:`3195`
  -   Allow customizing the :attr:`Flask.url_map_class` used for routing.
  :pr:`3069`
  -   The development server port can be set to 0, which tells the OS to
  pick an available port. :issue:`2926`
  -   The return value from :meth:`cli.load_dotenv` is more consistent
  with the documentation. It will return ``False`` if python-dotenv is
  not installed, or if the given path isn't a file. :issue:`2937`
  -   Signaling support has a stub for the ``connect_via`` method when
  the Blinker library is not installed. :pr:`3208`
  -   Add an ``--extra-files`` option to the ``flask run`` CLI command to
  specify extra files that will trigger the reloader on change.
  :issue:`2897`
  -   Allow returning a dictionary from a view function. Similar to how
  returning a string will produce a ``text/html`` response, returning
  a dict will call ``jsonify`` to produce a ``application/json``
  response. :pr:`3111`
  -   Blueprints have a ``cli`` Click group like ``app.cli``. CLI commands
  registered with a blueprint will be available as a group under the
  ``flask`` command. :issue:`1357`.
  -   When using the test client as a context manager (``with client:``),
  all preserved request contexts are popped when the block exits,
  ensuring nested contexts are cleaned up correctly. :pr:`3157`
  -   Show a better error message when the view return type is not
  supported. :issue:`3214`
  -   ``flask.testing.make_test_environ_builder()`` has been deprecated in
  favour of a new class ``flask.testing.EnvironBuilder``. :pr:`3232`
  -   The ``flask run`` command no longer fails if Python is not built
  with SSL support. Using the ``--cert`` option will show an
  appropriate error message. :issue:`3211`
  -   URL matching now occurs after the request context is pushed, rather
  than when it's created. This allows custom URL converters to access
  the app and request contexts, such as to query a database for an id.
  :issue:`3088`

1.0.4

-------------
  
  Released 2019-07-04
  
  -   The key information for ``BadRequestKeyError`` is no longer cleared
  outside debug mode, so error handlers can still access it. This
  requires upgrading to Werkzeug 0.15.5. :issue:`3249`
  -   ``send_file`` url quotes the ":" and "/" characters for more
  compatible UTF-8 filename support in some browsers. :issue:`3074`
  -   Fixes for PEP451 import loaders and pytest 5.x. :issue:`3275`
  -   Show message about dotenv on stderr instead of stdout. :issue:`3285`

1.0.3

-------------
  
  Released 2019-05-17
  
  -   :func:`send_file` encodes filenames as ASCII instead of Latin-1
  (ISO-8859-1). This fixes compatibility with Gunicorn, which is
  stricter about header encodings than PEP 3333. :issue:`2766`
  -   Allow custom CLIs using ``FlaskGroup`` to set the debug flag without
  it always being overwritten based on environment variables.
  :pr:`2765`
  -   ``flask --version`` outputs Werkzeug's version and simplifies the
  Python version. :pr:`2825`
  -   :func:`send_file` handles an ``attachment_filename`` that is a
  native Python 2 string (bytes) with UTF-8 coded bytes. :issue:`2933`
  -   A catch-all error handler registered for ``HTTPException`` will not
  handle ``RoutingException``, which is used internally during
  routing. This fixes the unexpected behavior that had been introduced
  in 1.0. :pr:`2986`
  -   Passing the ``json`` argument to ``app.test_client`` does not
  push/pop an extra app context. :issue:`2900`

1.0.2

-------------
  
  Released 2018-05-02
  
  -   Fix more backwards compatibility issues with merging slashes between
  a blueprint prefix and route. :pr:`2748`
  -   Fix error with ``flask routes`` command when there are no routes.
  :issue:`2751`

1.0.1

-------------
  
  Released 2018-04-29
  
  -   Fix registering partials (with no ``__name__``) as view functions.
  :pr:`2730`
  -   Don't treat lists returned from view functions the same as tuples.
  Only tuples are interpreted as response data. :issue:`2736`
  -   Extra slashes between a blueprint's ``url_prefix`` and a route URL
  are merged. This fixes some backwards compatibility issues with the
  change in 1.0. :issue:`2731`, :issue:`2742`
  -   Only trap ``BadRequestKeyError`` errors in debug mode, not all
  ``BadRequest`` errors. This allows ``abort(400)`` to continue
  working as expected. :issue:`2735`
  -   The ``FLASK_SKIP_DOTENV`` environment variable can be set to ``1``
  to skip automatically loading dotenv files. :issue:`2722`

1.0

-----------
  
  Released 2018-04-26
  
  -   Python 2.6 and 3.3 are no longer supported.
  -   Bump minimum dependency versions to the latest stable versions:
  Werkzeug >= 0.14, Jinja >= 2.10, itsdangerous >= 0.24, Click >= 5.1.
  :issue:`2586`
  -   Skip :meth:`app.run <Flask.run>` when a Flask application is run
  from the command line. This avoids some behavior that was confusing
  to debug.
  -   Change the default for :data:`JSONIFY_PRETTYPRINT_REGULAR` to
  ``False``. :func:`~json.jsonify` returns a compact format by
  default, and an indented format in debug mode. :pr:`2193`
  -   :meth:`Flask.__init__ <Flask>` accepts the ``host_matching``
  argument and sets it on :attr:`~Flask.url_map`. :issue:`1559`
  -   :meth:`Flask.__init__ <Flask>` accepts the ``static_host`` argument
  and passes it as the ``host`` argument when defining the static
  route. :issue:`1559`
  -   :func:`send_file` supports Unicode in ``attachment_filename``.
  :pr:`2223`
  -   Pass ``_scheme`` argument from :func:`url_for` to
  :meth:`~Flask.handle_url_build_error`. :pr:`2017`
  -   :meth:`~Flask.add_url_rule` accepts the
  ``provide_automatic_options`` argument to disable adding the
  ``OPTIONS`` method. :pr:`1489`
  -   :class:`~views.MethodView` subclasses inherit method handlers from
  base classes. :pr:`1936`
  -   Errors caused while opening the session at the beginning of the
  request are handled by the app's error handlers. :pr:`2254`
  -   Blueprints gained :attr:`~Blueprint.json_encoder` and
  :attr:`~Blueprint.json_decoder` attributes to override the app's
  encoder and decoder. :pr:`1898`
  -   :meth:`Flask.make_response` raises ``TypeError`` instead of
  ``ValueError`` for bad response types. The error messages have been
  improved to describe why the type is invalid. :pr:`2256`
  -   Add ``routes`` CLI command to output routes registered on the
  application. :pr:`2259`
  -   Show warning when session cookie domain is a bare hostname or an IP
  address, as these may not behave properly in some browsers, such as
  Chrome. :pr:`2282`
  -   Allow IP address as exact session cookie domain. :pr:`2282`
  -   ``SESSION_COOKIE_DOMAIN`` is set if it is detected through
  ``SERVER_NAME``. :pr:`2282`
  -   Auto-detect zero-argument app factory called ``create_app`` or
  ``make_app`` from ``FLASK_APP``. :pr:`2297`
  -   Factory functions are not required to take a ``script_info``
  parameter to work with the ``flask`` command. If they take a single
  parameter or a parameter named ``script_info``, the
  :class:`~cli.ScriptInfo` object will be passed. :pr:`2319`
  -   ``FLASK_APP`` can be set to an app factory, with arguments if
  needed, for example ``FLASK_APP=myproject.app:create_app('dev')``.
  :pr:`2326`
  -   ``FLASK_APP`` can point to local packages that are not installed in
  editable mode, although ``pip install -e`` is still preferred.
  :pr:`2414`
  -   The :class:`~views.View` class attribute
  :attr:`~views.View.provide_automatic_options` is set in
  :meth:`~views.View.as_view`, to be detected by
  :meth:`~Flask.add_url_rule`. :pr:`2316`
  -   Error handling will try handlers registered for ``blueprint, code``,
  ``app, code``, ``blueprint, exception``, ``app, exception``.
  :pr:`2314`
  -   ``Cookie`` is added to the response's ``Vary`` header if the session
  is accessed at all during the request (and not deleted). :pr:`2288`
  -   :meth:`~Flask.test_request_context` accepts ``subdomain`` and
  ``url_scheme`` arguments for use when building the base URL.
  :pr:`1621`
  -   Set :data:`APPLICATION_ROOT` to ``'/'`` by default. This was already
  the implicit default when it was set to ``None``.
  -   :data:`TRAP_BAD_REQUEST_ERRORS` is enabled by default in debug mode.
  ``BadRequestKeyError`` has a message with the bad key in debug mode
  instead of the generic bad request message. :pr:`2348`
  -   Allow registering new tags with
  :class:`~json.tag.TaggedJSONSerializer` to support storing other
  types in the session cookie. :pr:`2352`
  -   Only open the session if the request has not been pushed onto the
  context stack yet. This allows :func:`~stream_with_context`
  generators to access the same session that the containing view uses.
  :pr:`2354`
  -   Add ``json`` keyword argument for the test client request methods.
  This will dump the given object as JSON and set the appropriate
  content type. :pr:`2358`
  -   Extract JSON handling to a mixin applied to both the
  :class:`Request` and :class:`Response` classes. This adds the
  :meth:`~Response.is_json` and :meth:`~Response.get_json` methods to
  the response to make testing JSON response much easier. :pr:`2358`
  -   Removed error handler caching because it caused unexpected results
  for some exception inheritance hierarchies. Register handlers
  explicitly for each exception if you want to avoid traversing the
  MRO. :pr:`2362`
  -   Fix incorrect JSON encoding of aware, non-UTC datetimes. :pr:`2374`
  -   Template auto reloading will honor debug mode even even if
  :attr:`~Flask.jinja_env` was already accessed. :pr:`2373`
  -   The following old deprecated code was removed. :issue:`2385`
  
  -   ``flask.ext`` - import extensions directly by their name instead
  of through the ``flask.ext`` namespace. For example,
  ``import flask.ext.sqlalchemy`` becomes
  ``import flask_sqlalchemy``.
  -   ``Flask.init_jinja_globals`` - extend
  :meth:`Flask.create_jinja_environment` instead.
  -   ``Flask.error_handlers`` - tracked by
  :attr:`Flask.error_handler_spec`, use :meth:`Flask.errorhandler`
  to register handlers.
  -   ``Flask.request_globals_class`` - use
  :attr:`Flask.app_ctx_globals_class` instead.
  -   ``Flask.static_path`` - use :attr:`Flask.static_url_path`
  instead.
  -   ``Request.module`` - use :attr:`Request.blueprint` instead.
  
  -   The :attr:`Request.json` property is no longer deprecated.
  :issue:`1421`
  -   Support passing a :class:`~werkzeug.test.EnvironBuilder` or ``dict``
  to :meth:`test_client.open <werkzeug.test.Client.open>`. :pr:`2412`
  -   The ``flask`` command and :meth:`Flask.run` will load environment
  variables from ``.env`` and ``.flaskenv`` files if python-dotenv is
  installed. :pr:`2416`
  -   When passing a full URL to the test client, the scheme in the URL is
  used instead of :data:`PREFERRED_URL_SCHEME`. :pr:`2430`
  -   :attr:`Flask.logger` has been simplified. ``LOGGER_NAME`` and
  ``LOGGER_HANDLER_POLICY`` config was removed. The logger is always
  named ``flask.app``. The level is only set on first access, it
  doesn't check :attr:`Flask.debug` each time. Only one format is
  used, not different ones depending on :attr:`Flask.debug`. No
  handlers are removed, and a handler is only added if no handlers are
  already configured. :pr:`2436`
  -   Blueprint view function names may not contain dots. :pr:`2450`
  -   Fix a ``ValueError`` caused by invalid ``Range`` requests in some
  cases. :issue:`2526`
  -   The development server uses threads by default. :pr:`2529`
  -   Loading config files with ``silent=True`` will ignore
  :data:`~errno.ENOTDIR` errors. :pr:`2581`
  -   Pass ``--cert`` and ``--key`` options to ``flask run`` to run the
  development server over HTTPS. :pr:`2606`
  -   Added :data:`SESSION_COOKIE_SAMESITE` to control the ``SameSite``
  attribute on the session cookie. :pr:`2607`
  -   Added :meth:`~flask.Flask.test_cli_runner` to create a Click runner
  that can invoke Flask CLI commands for testing. :pr:`2636`
  -   Subdomain matching is disabled by default and setting
  :data:`SERVER_NAME` does not implicitly enable it. It can be enabled
  by passing ``subdomain_matching=True`` to the ``Flask`` constructor.
  :pr:`2635`
  -   A single trailing slash is stripped from the blueprint
  ``url_prefix`` when it is registered with the app. :pr:`2629`
  -   :meth:`Request.get_json` doesn't cache the result if parsing fails
  when ``silent`` is true. :issue:`2651`
  -   :func:`Request.get_json` no longer accepts arbitrary encodings.
  Incoming JSON should be encoded using UTF-8 per :rfc:`8259`, but
  Flask will autodetect UTF-8, -16, or -32. :pr:`2691`
  -   Added :data:`MAX_COOKIE_SIZE` and :attr:`Response.max_cookie_size`
  to control when Werkzeug warns about large cookies that browsers may
  ignore. :pr:`2693`
  -   Updated documentation theme to make docs look better in small
  windows. :pr:`2709`
  -   Rewrote the tutorial docs and example project to take a more
  structured approach to help new users avoid common pitfalls.
  :pr:`2676`


```

werkzeug changelog

```

1.0.1

-------------
  
  Released 2020-03-31
  
  -   Make the argument to ``RequestRedirect.get_response`` optional.
  :issue:`1718`
  -   Only allow a single access control allow origin value. :pr:`1723`
  -   Fix crash when trying to parse a non-existent Content Security
  Policy header. :pr:`1731`
  -   ``http_date`` zero fills years < 1000 to always output four digits.
  :issue:`1739`
  -   Fix missing local variables in interactive debugger console.
  :issue:`1746`
  -   Fix passing file-like objects like ``io.BytesIO`` to
  ``FileStorage.save``. :issue:`1733`

1.0.0

-------------
  
  Released 2020-02-06
  
  -   Drop support for Python 3.4. (:issue:`1478`)
  -   Remove code that issued deprecation warnings in version 0.15.
  (:issue:`1477`)
  -   Remove most top-level attributes provided by the ``werkzeug``
  module in favor of direct imports. For example, instead of
  ``import werkzeug; werkzeug.url_quote``, do
  ``from werkzeug.urls import url_quote``. Install version 0.16 first
  to see deprecation warnings while upgrading. :issue:`2`, :pr:`1640`
  -   Added ``utils.invalidate_cached_property()`` to invalidate cached
  properties. (:pr:`1474`)
  -   Directive keys for the ``Set-Cookie`` response header are not
  ignored when parsing the ``Cookie`` request header. This allows
  cookies with names such as "expires" and "version". (:issue:`1495`)
  -   Request cookies are parsed into a ``MultiDict`` to capture all
  values for cookies with the same key. ``cookies[key]`` returns the
  first value rather than the last. Use ``cookies.getlist(key)`` to
  get all values. ``parse_cookie`` also defaults to a ``MultiDict``.
  :issue:`1562`, :pr:`1458`
  -   Add ``charset=utf-8`` to an HTTP exception response's
  ``CONTENT_TYPE`` header. (:pr:`1526`)
  -   The interactive debugger handles outer variables in nested scopes
  such as lambdas and comprehensions. :issue:`913`, :issue:`1037`,
  :pr:`1532`
  -   The user agent for Opera 60 on Mac is correctly reported as
  "opera" instead of "chrome". :issue:`1556`
  -   The platform for Crosswalk on Android is correctly reported as
  "android" instead of "chromeos". (:pr:`1572`)
  -   Issue a warning when the current server name does not match the
  configured server name. :issue:`760`
  -   A configured server name with the default port for a scheme will
  match the current server name without the port if the current scheme
  matches. :pr:`1584`
  -   :exc:`~exceptions.InternalServerError` has a ``original_exception``
  attribute that frameworks can use to track the original cause of the
  error. :pr:`1590`
  -   Headers are tested for equality independent of the header key case,
  such that ``X-Foo`` is the same as ``x-foo``. :pr:`1605`
  -   :meth:`http.dump_cookie` accepts ``'None'`` as a value for
  ``samesite``. :issue:`1549`
  -   :meth:`~test.Client.set_cookie` accepts a ``samesite`` argument.
  :pr:`1705`
  -   Support the Content Security Policy header through the
  `Response.content_security_policy` data structure. :pr:`1617`
  -   ``LanguageAccept`` will fall back to matching "en" for "en-US" or
  "en-US" for "en" to better support clients or translations that
  only match at the primary language tag. :issue:`450`, :pr:`1507`
  -   ``MIMEAccept`` uses MIME parameters for specificity when matching.
  :issue:`458`, :pr:`1574`
  -   If the development server is started with an ``SSLContext``
  configured to verify client certificates, the certificate in PEM
  format will be available as ``environ["SSL_CLIENT_CERT"]``.
  :pr:`1469`
  -   ``is_resource_modified`` will run for methods other than ``GET`` and
  ``HEAD``, rather than always returning ``False``. :issue:`409`
  -   ``SharedDataMiddleware`` returns 404 rather than 500 when trying to
  access a directory instead of a file with the package loader. The
  dependency on setuptools and pkg_resources is removed.
  :issue:`1599`
  -   Add a ``response.cache_control.immutable`` flag. Keep in mind that
  browser support for this ``Cache-Control`` header option is still
  experimental and may not be implemented. :issue:`1185`
  -   Optional request log highlighting with the development server is
  handled by Click instead of termcolor. :issue:`1235`
  -   Optional ad-hoc TLS support for the development server is handled
  by cryptography instead of pyOpenSSL. :pr:`1555`
  -   ``FileStorage.save()`` supports ``pathlib`` and :pep:`519`
  ``PathLike`` objects. :issue:`1653`
  -   The debugger security pin is unique in containers managed by Podman.
  :issue:`1661`
  -   Building a URL when ``host_matching`` is enabled takes into account
  the current host when there are duplicate endpoints with different
  hosts. :issue:`488`
  -   The ``429 TooManyRequests`` and ``503 ServiceUnavailable`` HTTP
  exceptions takes a ``retry_after`` parameter to set the
  ``Retry-After`` header. :issue:`1657`
  -   ``Map`` and ``Rule`` have a ``merge_slashes`` option to collapse
  multiple slashes into one, similar to how many HTTP servers behave.
  This is enabled by default. :pr:`1286, 1694`
  -   Add HTTP 103, 208, 306, 425, 506, 508, and 511 to the list of status
  codes. :pr:`1678`
  -   Add ``update``, ``setlist``, and ``setlistdefault`` methods to the
  ``Headers`` data structure. ``extend`` method can take ``MultiDict``
  and kwargs. :pr:`1687, 1697`
  -   The development server accepts paths that start with two slashes,
  rather than stripping off the first path segment. :issue:`491`
  -   Add access control (Cross Origin Request Sharing, CORS) header
  properties to the ``Request`` and ``Response`` wrappers. :pr:`1699`
  -   ``Accept`` values are no longer ordered alphabetically for equal
  quality tags. Instead the initial order is preserved. :issue:`1686`
  -   Added ``Map.lock_class`` attribute for alternative
  implementations. :pr:`1702`
  -   Support matching and building WebSocket rules in the routing system,
  for use by async frameworks. :pr:`1709`
  -   Range requests that span an entire file respond with 206 instead of
  200, to be more compliant with :rfc:`7233`. This may help serving
  media to older browsers. :issue:`410, 1704`
  -   The :class:`~middleware.shared_data.SharedDataMiddleware` default
  ``fallback_mimetype`` is ``application/octet-stream``. If a filename
  looks like a text mimetype, the ``utf-8`` charset is added to it.
  This matches the behavior of :class:`~wrappers.BaseResponse` and
  Flask's ``send_file()``. :issue:`1689`


```
click changelog
```

7.1.2

-------------
  
  Released 2020-04-27
  
  -   Revert applying shell quoting to commands for ``echo_with_pager``
  and ``edit``. This was intended to allows spaces in commands, but
  caused issues if the string was actually a command and arguments, or
  on Windows. Instead, the string must be quoted manually as it should
  appear on the command line. :issue:`1514`

7.1.1

-------------
  
  Released 2020-03-09
  
  -   Fix ``ClickException`` output going to stdout instead of stderr.
  :issue:`1495`

7.1

-----------
  
  Released 2020-03-09
  
  -   Fix PyPI package name, "click" is lowercase again.
  -   Fix link in ``unicode_literals`` error message. :pr:`1151`
  -   Add support for colored output on UNIX Jupyter notebooks.
  :issue:`1185`
  -   Operations that strip ANSI controls will strip the cursor hide/show
  sequences. :issue:`1216`
  -   Remove unused compat shim for ``bytes``. :pr:`1195`
  -   Expand testing around termui, especially getchar on Windows.
  :issue:`1116`
  -   Fix output on Windows Python 2.7 built with MSVC 14. :pr:`1342`
  -   Fix ``OSError`` when running in MSYS2. :issue:`1338`
  -   Fix ``OSError`` when redirecting to ``NUL`` stream on Windows.
  :issue:`1065`
  -   Fix memory leak when parsing Unicode arguments on Windows.
  :issue:`1136`
  -   Fix error in new AppEngine environments. :issue:`1462`
  -   Always return one of the passed choices for ``click.Choice``
  :issue:`1277`, :pr:`1318`
  -   Add ``no_args_is_help`` option to ``click.Command``, defaults to
  False :pr:`1167`
  -   Add ``show_default`` parameter to ``Context`` to enable showing
  defaults globally. :issue:`1018`
  -   Handle ``env MYPATH=''`` as though the option were not passed.
  :issue:`1196`
  -   It is once again possible to call ``next(bar)`` on an active
  progress bar instance. :issue:`1125`
  -   ``open_file`` with ``atomic=True`` retains permissions of existing
  files and respects the current umask for new files. :issue:`1376`
  -   When using the test ``CliRunner`` with ``mix_stderr=False``, if
  ``result.stderr`` is empty it will not raise a ``ValueError``.
  :issue:`1193`
  -   Remove the unused ``mix_stderr`` parameter from
  ``CliRunner.invoke``. :issue:`1435`
  -   Fix ``TypeError`` raised when using bool flags and specifying
  ``type=bool``. :issue:`1287`
  -   Newlines in option help text are replaced with spaces before
  re-wrapping to avoid uneven line breaks. :issue:`834`
  -   ``MissingParameter`` exceptions are printable in the Python
  interpreter. :issue:`1139`
  -   Fix how default values for file-type options are shown during
  prompts. :issue:`914`
  -   Fix environment variable automatic generation for commands
  containing ``-``. :issue:`1253`
  -   Option help text replaces newlines with spaces when rewrapping, but
  preserves paragraph breaks, fixing multiline formatting.
  :issue:`834, 1066, 1397`
  -   Option help text that is wrapped adds an extra newline at the end to
  distinguish it from the next option. :issue:`1075`
  -   Consider ``sensible-editor`` when determining the editor to use for
  ``click.edit()``. :pr:`1469`
  -   Arguments to system calls such as the executable path passed to
  ``click.edit`` can contains spaces. :pr:`1470`
  -   Add ZSH completion autoloading and error handling. :issue:`1348`
  -   Add a repr to ``Command``, ``Group``, ``Option``, and ``Argument``,
  showing the name for friendlier debugging. :issue:`1267`
  -   Completion doesn't consider option names if a value starts with
  ``-`` after the ``--`` separator. :issue:`1247`
  -   ZSH completion escapes special characters in values. :pr:`1418`
  -   Add completion support for Fish shell. :pr:`1423`
  -   Decoding bytes option values falls back to UTF-8 in more cases.
  :pr:`1468`
  -   Make the warning about old 2-arg parameter callbacks a deprecation
  warning, to be removed in 8.0. This has been a warning since Click
  2.0. :pr:`1492`
  -   Adjust error messages to standardize the types of quotes used so
  they match error messages from Python.

7.0

-----------
  
  Released 2018-09-25
  
  -   Drop support for Python 2.6 and 3.3. :pr:`967, 976`
  -   Wrap ``click.Choice``'s missing message. :issue:`202`, :pr:`1000`
  -   Add native ZSH autocompletion support. :issue:`323`, :pr:`865`
  -   Document that ANSI color info isn't parsed from bytearrays in Python
  2. :issue:`334`
  -   Document byte-stripping behavior of ``CliRunner``. :issue:`334`,
  :pr:`1010`
  -   Usage errors now hint at the ``--help`` option. :issue:`393`,
  :pr:`557`
  -   Implement streaming pager. :issue:`409`, :pr:`889`
  -   Extract bar formatting to its own method. :pr:`414`
  -   Add ``DateTime`` type for converting input in given date time
  formats. :pr:`423`
  -   ``secho``'s first argument can now be ``None``, like in ``echo``.
  :pr:`424`
  -   Fixes a ``ZeroDivisionError`` in ``ProgressBar.make_step``, when the
  arg passed to the first call of ``ProgressBar.update`` is 0.
  :issue:`447`, :pr:`1012`
  -   Show progressbar only if total execution time is visible. :pr:`487`
  -   Added the ability to hide commands and options from help. :pr:`500`
  -   Document that options can be ``required=True``. :issue:`514`,
  :pr:`1022`
  -   Non-standalone calls to ``Context.exit`` return the exit code,
  rather than calling ``sys.exit``. :issue:`667`, :pr:`533, 1098`
  -   ``click.getchar()`` returns Unicode in Python 3 on Windows,
  consistent with other platforms. :issue:`537, 821, 822, 1088`,
  :pr:`1108`
  -   Added ``FloatRange`` type. :pr:`538, 553`
  -   Added support for bash completion of ``type=click.Choice`` for
  ``Options`` and ``Arguments``. :issue:`535`, :pr:`681`
  -   Only allow one positional arg for ``Argument`` parameter
  declaration. :issue:`568, 574`, :pr:`1014`
  -   Add ``case_sensitive=False`` as an option to Choice. :issue:`569`
  -   ``click.getchar()`` correctly raises ``KeyboardInterrupt`` on "^C"
  and ``EOFError`` on "^D" on Linux. :issue:`583`, :pr:`1115`
  -   Fix encoding issue with ``click.getchar(echo=True)`` on Linux.
  :pr:`1115`
  -   ``param_hint`` in errors now derived from param itself.
  :issue:`598, 704`, :pr:`709`
  -   Add a test that ensures that when an argument is formatted into a
  usage error, its metavar is used, not its name. :pr:`612`
  -   Allow setting ``prog_name`` as extra in ``CliRunner.invoke``.
  :issue:`616`, :pr:`999`
  -   Help text taken from docstrings truncates at the ``\f`` form feed
  character, useful for hiding Sphinx-style parameter documentation.
  :pr:`629, 1091`
  -   ``launch`` now works properly under Cygwin. :pr:`650`
  -   Update progress after iteration. :issue:`651`, :pr:`706`
  -   ``CliRunner.invoke`` now may receive ``args`` as a string
  representing a Unix shell command. :pr:`664`
  -   Make ``Argument.make_metavar()`` default to type metavar. :pr:`675`
  -   Add documentation for ``ignore_unknown_options``. :pr:`684`
  -   Add bright colors support for ``click.style`` and fix the reset
  option for parameters ``fg`` and ``bg``. :issue:`703`, :pr:`809`
  -   Add ``show_envvar`` for showing environment variables in help.
  :pr:`710`
  -   Avoid ``BrokenPipeError`` during interpreter shutdown when stdout or
  stderr is a closed pipe. :issue:`712`, :pr:`1106`
  -   Document customizing option names. :issue:`725`, :pr:`1016`
  -   Disable ``sys._getframes()`` on Python interpreters that don't
  support it. :pr:`728`
  -   Fix bug in test runner when calling ``sys.exit`` with ``None``.
  :pr:`739`
  -   Clarify documentation on command line options. :issue:`741`,
  :pr:`1003`
  -   Fix crash on Windows console. :issue:`744`
  -   Fix bug that caused bash completion to give improper completions on
  chained commands. :issue:`754`, :pr:`774`
  -   Added support for dynamic bash completion from a user-supplied
  callback. :pr:`755`
  -   Added support for bash completions containing spaces. :pr:`773`
  -   Allow autocompletion function to determine whether or not to return
  completions that start with the incomplete argument. :issue:`790`,
  :pr:`806`
  -   Fix option naming routine to match documentation and be
  deterministic. :issue:`793`, :pr:`794`
  -   Fix path validation bug. :issue:`795`, :pr:`1020`
  -   Add test and documentation for ``Option`` naming: functionality.
  :pr:`799`
  -   Update doc to match arg name for ``path_type``. :pr:`801`
  -   Raw strings added so correct escaping occurs. :pr:`807`
  -   Fix 16k character limit of ``click.echo`` on Windows. :issue:`816`,
  :pr:`819`
  -   Overcome 64k character limit when writing to binary stream on
  Windows 7. :issue:`825`, :pr:`830`
  -   Add bool conversion for "t" and "f". :pr:`842`
  -   ``NoSuchOption`` errors take ``ctx`` so that ``--help`` hint gets
  printed in error output. :pr:`860`
  -   Fixed the behavior of Click error messages with regards to Unicode
  on 2.x and 3.x. Message is now always Unicode and the str and
  Unicode special methods work as you expect on that platform.
  :issue:`862`
  -   Progress bar now uses stderr by default. :pr:`863`
  -   Add support for auto-completion documentation. :issue:`866`,
  :pr:`869`
  -   Allow ``CliRunner`` to separate stdout and stderr. :pr:`868`
  -   Fix variable precedence. :issue:`873`, :pr:`874`
  -   Fix invalid escape sequences. :pr:`877`
  -   Fix ``ResourceWarning`` that occurs during some tests. :pr:`878`
  -   When detecting a misconfigured locale, don't fail if the ``locale``
  command fails. :pr:`880`
  -   Add ``case_sensitive=False`` as an option to ``Choice`` types.
  :pr:`887`
  -   Force stdout/stderr writable. This works around issues with badly
  patched standard streams like those from Jupyter. :pr:`918`
  -   Fix completion of subcommand options after last argument
  :issue:`919`, :pr:`930`
  -   ``_AtomicFile`` now uses the ``realpath`` of the original filename
  so that changing the working directory does not affect it. :pr:`920`
  -   Fix incorrect completions when defaults are present :issue:`925`,
  :pr:`930`
  -   Add copy option attrs so that custom classes can be re-used.
  :issue:`926`, :pr:`994`
  -   "x" and "a" file modes now use stdout when file is ``"-"``.
  :pr:`929`
  -   Fix missing comma in ``__all__`` list. :pr:`935`
  -   Clarify how parameters are named. :issue:`949`, :pr:`1009`
  -   Stdout is now automatically set to non blocking. :pr:`954`
  -   Do not set options twice. :pr:`962`
  -   Move ``fcntl`` import. :pr:`965`
  -   Fix Google App Engine ``ImportError``. :pr:`995`
  -   Better handling of help text for dynamic default option values.
  :pr:`996`
  -   Fix ``get_winter_size()`` so it correctly returns ``(0,0)``.
  :pr:`997`
  -   Add test case checking for custom param type. :pr:`1001`
  -   Allow short width to address cmd formatting. :pr:`1002`
  -   Add details about Python version support. :pr:`1004`
  -   Added deprecation flag to commands. :pr:`1005`
  -   Fixed issues where ``fd`` was undefined. :pr:`1007`
  -   Fix formatting for short help. :pr:`1008`
  -   Document how ``auto_envvar_prefix`` works with command groups.
  :pr:`1011`
  -   Don't add newlines by default for progress bars. :pr:`1013`
  -   Use Python sorting order for ZSH completions. :issue:`1047`,
  :pr:`1059`
  -   Document that parameter names are converted to lowercase by default.
  :pr:`1055`
  -   Subcommands that are named by the function now automatically have
  the underscore replaced with a dash. If you register a function
  named ``my_command`` it becomes ``my-command`` in the command line
  interface.
  -   Hide hidden commands and options from completion. :issue:`1058`,
  :pr:`1061`
  -   Fix absolute import blocking Click from being vendored into a
  project on Windows. :issue:`1068`, :pr:`1069`
  -   Fix issue where a lowercase ``auto_envvar_prefix`` would not be
  converted to uppercase. :pr:`1105`

6.7

-----------
  
  Released 2017-01-06
  
  -   Make ``click.progressbar`` work with ``codecs.open`` files.
  :pr:`637`
  -   Fix bug in bash completion with nested subcommands. :pr:`639`
  -   Fix test runner not saving caller env correctly. :pr:`644`
  -   Fix handling of SIGPIPE. :pr:`62`
  -   Deal with broken Windows environments such as Google App Engine's.
  :issue:`711`

6.6

-----------
  
  Released 2016-04-04
  
  -   Fix bug in ``click.Path`` where it would crash when passed a ``-``.
  :issue:`551`

6.4

-----------
  
  Released 2016-03-24
  
  -   Fix bug in bash completion where click would discard one or more
  trailing arguments. :issue:`471`

6.3

-----------
  
  Released 2016-02-22
  
  -   Fix argument checks for interpreter invoke with ``-m`` and ``-c`` on
  Windows.
  -   Fixed a bug that cased locale detection to error out on Python 3.

6.2

-----------
  
  Released 2015-11-27
  
  -   Correct fix for hidden progress bars.

6.1

-----------
  
  Released 2015-11-27
  
  -   Resolved an issue with invisible progress bars no longer rendering.
  -   Disable chain commands with subcommands as they were inherently
  broken.
  -   Fix ``MissingParameter`` not working without parameters passed.

6.0

-----------
  
  Released 2015-11-24, codename "pow pow"
  
  -   Optimized the progressbar rendering to not render when it did not
  actually change.
  -   Explicitly disallow ``nargs=-1`` with a set default.
  -   The context is now closed before it's popped from the stack.
  -   Added support for short aliases for the false flag on toggles.
  -   Click will now attempt to aid you with debugging locale errors
  better by listing with the help of the OS what locales are
  available.
  -   Click used to return byte strings on Python 2 in some unit-testing
  situations. This has been fixed to correctly return unicode strings
  now.
  -   For Windows users on Python 2, Click will now handle Unicode more
  correctly handle Unicode coming in from the system. This also has
  the disappointing side effect that filenames will now be always
  unicode by default in the ``Path`` type which means that this can
  introduce small bugs for code not aware of this.
  -   Added a ``type`` parameter to ``Path`` to force a specific string
  type on the value.
  -   For users running Python on Windows the ``echo`` and ``prompt``
  functions now work with full unicode functionality in the Python
  windows console by emulating an output stream. This also applies to
  getting the virtual output and input streams via
  ``click.get_text_stream(...)``.
  -   Unittests now always force a certain virtual terminal width.
  -   Added support for allowing dashes to indicate standard streams to
  the ``Path`` type.
  -   Multi commands in chain mode no longer propagate arguments left over
  from parsing to the callbacks. It's also now disallowed through an
  exception when optional arguments are attached to multi commands if
  chain mode is enabled.
  -   Relaxed restriction that disallowed chained commands to have other
  chained commands as child commands.
  -   Arguments with positive nargs can now have defaults implemented.
  Previously this configuration would often result in slightly
  unexpected values be returned.

5.1

-----------
  
  Released 2015-08-17
  
  -   Fix a bug in ``pass_obj`` that would accidentally pass the context
  too.

5.0

-----------
  
  Released 2015-08-16, codename "tok tok"
  
  -   Removed various deprecated functionality.
  -   Atomic files now only accept the ``w`` mode.
  -   Change the usage part of help output for very long commands to wrap
  their arguments onto the next line, indented by 4 spaces.
  -   Fix a bug where return code and error messages were incorrect when
  using ``CliRunner``.
  -   Added ``get_current_context``.
  -   Added a ``meta`` dictionary to the context which is shared across
  the linked list of contexts to allow click utilities to place state
  there.
  -   Introduced ``Context.scope``.
  -   The ``echo`` function is now threadsafe: It calls the ``write``
  method of the underlying object only once.
  -   ``prompt(hide_input=True)`` now prints a newline on ``^C``.
  -   Click will now warn if users are using ``unicode_literals``.
  -   Click will now ignore the ``PAGER`` environment variable if it is
  empty or contains only whitespace.
  -   The ``click-contrib`` GitHub organization was created.

4.1

-----------
  
  Released 2015-07-14
  
  -   Fix a bug where error messages would include a trailing ``None``
  string.
  -   Fix a bug where Click would crash on docstrings with trailing
  newlines.
  -   Support streams with encoding set to ``None`` on Python 3 by barfing
  with a better error.
  -   Handle ^C in less-pager properly.
  -   Handle return value of ``None`` from ``sys.getfilesystemencoding``
  -   Fix crash when writing to unicode files with ``click.echo``.
  -   Fix type inference with multiple options.

4.0

-----------
  
  Released 2015-03-31, codename "zoom zoom"
  
  -   Added ``color`` parameters to lots of interfaces that directly or
  indirectly call into echoing. This previously was always
  autodetection (with the exception of the ``echo_via_pager``
  function). Now you can forcefully enable or disable it, overriding
  the auto detection of Click.
  -   Added an ``UNPROCESSED`` type which does not perform any type
  changes which simplifies text handling on 2.x / 3.x in some special
  advanced usecases.
  -   Added ``NoSuchOption`` and ``BadOptionUsage`` exceptions for more
  generic handling of errors.
  -   Added support for handling of unprocessed options which can be
  useful in situations where arguments are forwarded to underlying
  tools.
  -   Added ``max_content_width`` parameter to the context which can be
  used to change the maximum width of help output. By default Click
  will not format content for more than 80 characters width.
  -   Added support for writing prompts to stderr.
  -   Fix a bug when showing the default for multiple arguments.
  -   Added support for custom subclasses to ``option`` and ``argument``.
  -   Fix bug in ``clear()`` on Windows when colorama is installed.
  -   Reject ``nargs=-1`` for options properly. Options cannot be
  variadic.
  -   Fixed an issue with bash completion not working properly for
  commands with non ASCII characters or dashes.
  -   Added a way to manually update the progressbar.
  -   Changed the formatting of missing arguments. Previously the internal
  argument name was shown in error messages, now the metavar is shown
  if passed. In case an automated metavar is selected, it's stripped
  of extra formatting first.

3.3

-----------
  
  Released 2014-09-08
  
  -   Fixed an issue with error reporting on Python 3 for invalid
  forwarding of commands.

3.2

-----------
  
  Released 2014-08-22
  
  -   Added missing ``err`` parameter forwarding to the ``secho``
  function.
  -   Fixed default parameters not being handled properly by the context
  invoke method. This is a backwards incompatible change if the
  function was used improperly. See :ref:`upgrade-to-3.2` for more
  information.
  -   Removed the ``invoked_subcommands`` attribute largely. It is not
  possible to provide it to work error free due to how the parsing
  works so this API has been deprecated. See :ref:`upgrade-to-3.2` for
  more information.
  -   Restored the functionality of ``invoked_subcommand`` which was
  broken as a regression in 3.1.

3.1

-----------
  
  Released 2014-08-13
  
  -   Fixed a regression that caused contexts of subcommands to be created
  before the parent command was invoked which was a regression from
  earlier Click versions.

3.0

-----------
  
  Released 2014-08-12, codename "clonk clonk"
  
  -   Formatter now no longer attempts to accommodate for terminals
  smaller than 50 characters. If that happens it just assumes a
  minimal width.
  -   Added a way to not swallow exceptions in the test system.
  -   Added better support for colors with pagers and ways to override the
  autodetection.
  -   The CLI runner's result object now has a traceback attached.
  -   Improved automatic short help detection to work better with dots
  that do not terminate sentences.
  -   When defining options without actual valid option strings now,
  Click will give an error message instead of silently passing. This
  should catch situations where users wanted to created arguments
  instead of options.
  -   Restructured Click internally to support vendoring.
  -   Added support for multi command chaining.
  -   Added support for defaults on options with ``multiple`` and options
  and arguments with ``nargs != 1``.
  -   Label passed to ``progressbar`` is no longer rendered with
  whitespace stripped.
  -   Added a way to disable the standalone mode of the ``main`` method on
  a Click command to be able to handle errors better.
  -   Added support for returning values from command callbacks.
  -   Added simplifications for printing to stderr from ``echo``.
  -   Added result callbacks for groups.
  -   Entering a context multiple times defers the cleanup until the last
  exit occurs.
  -   Added ``open_file``.


```