### PR TITLE
Simplify ABCMixin

### DIFF
--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -70,14 +70,6 @@ def before_commit(conn):
         )
 
 
-# class SQLAlchemyCompatibleAbstractMetaClass(DeclarativeMeta, abc.ABCMeta):
-#     """Declarative model classes that *also* inherit from an abstract base
-#     class need a metaclass like this one, in order to prevent metaclass
-#     conflict errors."""
-
-#     pass
-
-
 class ABCMixin(object):
     """Use this if you want a mixin class which is actually an abstract base
     class, for example in order to enforce that concrete subclasses define

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -70,15 +70,15 @@ def before_commit(conn):
         )
 
 
-class SQLAlchemyCompatibleAbstractMetaClass(DeclarativeMeta, abc.ABCMeta):
-    """Declarative model classes that *also* inherit from an abstract base
-    class need a metaclass like this one, in order to prevent metaclass
-    conflict errors."""
+# class SQLAlchemyCompatibleAbstractMetaClass(DeclarativeMeta, abc.ABCMeta):
+#     """Declarative model classes that *also* inherit from an abstract base
+#     class need a metaclass like this one, in order to prevent metaclass
+#     conflict errors."""
 
-    pass
+#     pass
 
 
-class ABCMixin(with_metaclass(SQLAlchemyCompatibleAbstractMetaClass, object)):
+class ABCMixin(object):
     """Use this if you want a mixin class which is actually an abstract base
     class, for example in order to enforce that concrete subclasses define
     particular methods or properties."""

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -15,7 +15,6 @@ json_util.EPOCH_AWARE = EPOCH_NAIVE
 from sqlalchemy import String, Text, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext import baked
-from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import operators


### PR DESCRIPTION
This is one of the small changes I need to start updating SQLAlchemy. That extra inheritance level from abc.ABCMeta adds not much value, but more importantly it breaks later versions of SQLAlchemy.

I was tempted to remove this abstract mixin all together but SQLAlchemy didn't like it. I might attempt it later after updating SQLAlchemy.
