### PR TITLE
Upgrade pymongo

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -92,7 +92,7 @@ pygments==2.5.2
 pyinstrument==3.2.0
 pyinstrument-cext==0.2.2
 pylint==1.5.1
-pymongo==2.5.2  # For json_util in bson
+pymongo==2.9.5  # For json_util in bson
 Pympler==0.9
 PyNaCl==1.4.0
 pyOpenSSL==17.5.0


### PR DESCRIPTION
This is the last version of 2.x series and one of the first versions explicitly tested on Python 3.6.

sync-engine does not use MongoDB but...
sync-engine uses `bson.json_utils` and monkeypatches it to do serializing and deserializing of JSON that is stored in the database.

I did not discover why they are doing it but I guess it's safer that assume they had a reason. I might try to remove it altogether later when I am sure that it would not cause any problems.

Changelog

```

Changes in Version 2.9.5

Version 2.9.5 works around ssl module deprecations in Python 3.6, and expected future ssl module deprecations. It also fixes bugs found since the release of 2.9.4.

    Use ssl.SSLContext and ssl.PROTOCOL_TLS_CLIENT when available.
    Fixed a C extensions build issue when the interpreter was built with -std=c99
    Fixed various build issues with MinGW32.
    Fixed a write concern bug in add_user() and remove_user() when connected to MongoDB 3.2+
    Fixed various test failures related to changes in gevent, MongoDB, and our CI test environment.

Issues Resolved

See the PyMongo 2.9.5 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.9.4

Version 2.9.4 fixes issues reported since the release of 2.9.3.

    Fixed __repr__ for closed instances of MongoClient.
    Fixed MongoReplicaSetClient handling of uuidRepresentation.
    Fixed building and testing the documentation with python 3.x.
    New documentation for TLS/SSL and PyMongo and Using PyMongo with MongoDB Atlas.

Issues Resolved

See the PyMongo 2.9.4 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.9.3

Version 2.9.3 fixes a few issues reported since the release of 2.9.2 including thread safety issues in ensure_index(), drop_index(), and drop_indexes().
Issues Resolved

See the PyMongo 2.9.3 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.9.2

Version 2.9.2 restores Python 3.1 support, which was broken in PyMongo 2.8. It improves an error message when decoding BSON as well as fixes a couple other issues including aggregate() ignoring codec_options and command() raising a superfluous DeprecationWarning.
Issues Resolved

See the PyMongo 2.9.2 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.9.1

Version 2.9.1 fixes two interrupt handling issues in the C extensions and adapts a test case for a behavior change in MongoDB 3.2.
Issues Resolved

See the PyMongo 2.9.1 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.9

Version 2.9 provides an upgrade path to PyMongo 3.x. Most of the API changes from PyMongo 3.0 have been backported in a backward compatible way, allowing applications to be written against PyMongo >= 2.9, rather then PyMongo 2.x or PyMongo 3.x. See the PyMongo 3 Migration Guide for detailed examples.

Note

There are a number of new deprecations in this release for features that were removed in PyMongo 3.0.

MongoClient:

        host
        port
        use_greenlets
        document_class
        tz_aware
        secondary_acceptable_latency_ms
        tag_sets
        uuid_subtype
        disconnect()
        alive()

MongoReplicaSetClient:

        use_greenlets
        document_class
        tz_aware
        secondary_acceptable_latency_ms
        tag_sets
        uuid_subtype
        alive()

Database:

        secondary_acceptable_latency_ms
        tag_sets
        uuid_subtype

Collection:

        secondary_acceptable_latency_ms
        tag_sets
        uuid_subtype

Warning

In previous versions of PyMongo, changing the value of document_class changed the behavior of all existing instances of Collection:

>>> coll = client.test.test
>>> coll.find_one()
{u'_id': ObjectId('5579dc7cfba5220cc14d9a18')}
>>> from bson.son import SON
>>> client.document_class = SON
>>> coll.find_one()
SON([(u'_id', ObjectId('5579dc7cfba5220cc14d9a18'))])

The document_class setting is now configurable at the client, database, collection, and per-operation level. This required breaking the existing behavior. To change the document class per operation in a forward compatible way use with_options():

>>> coll.find_one()
{u'_id': ObjectId('5579dc7cfba5220cc14d9a18')}
>>> from bson.codec_options import CodecOptions
>>> coll.with_options(CodecOptions(SON)).find_one()
SON([(u'_id', ObjectId('5579dc7cfba5220cc14d9a18'))])

Issues Resolved

See the PyMongo 2.9 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.8.1

Version 2.8.1 fixes a number of issues reported since the release of PyMongo 2.8. It is a recommended upgrade for all users of PyMongo 2.x.
Issues Resolved

See the PyMongo 2.8.1 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.8

Version 2.8 is a major release that provides full support for MongoDB 3.0 and fixes a number of bugs.

Special thanks to Don Mitchell, Ximing, Can Zhang, Sergey Azovskov, and Heewa Barfchin for their contributions to this release.

Highlights include:

    Support for the SCRAM-SHA-1 authentication mechanism (new in MongoDB 3.0).
    JSON decoder support for the new $numberLong and $undefined types.
    JSON decoder support for the $date type as an ISO-8601 string.
    Support passing an index name to hint().
    The count() method will use a hint if one has been provided through hint().
    A new socketKeepAlive option for the connection pool.
    New generator based BSON decode functions, decode_iter() and decode_file_iter().
    Internal changes to support alternative storage engines like wiredtiger.

Note

There are a number of deprecations in this release for features that will be removed in PyMongo 3.0. These include:

    start_request()
    in_request()
    end_request()
    copy_database()
    error()
    last_status()
    previous_error()
    reset_error_history()
    MasterSlaveConnection

The JSON format for Timestamp has changed from ‘{“t”: <int>, “i”: <int>}’ to ‘{“$timestamp”: {“t”: <int>, “i”: <int>}}’. This new format will be decoded to an instance of Timestamp. The old format will continue to be decoded to a python dict as before. Encoding to the old format is no longer supported as it was never correct and loses type information.
Issues Resolved

See the PyMongo 2.8 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.7.2

Version 2.7.2 includes fixes for upsert reporting in the bulk API for MongoDB versions previous to 2.6, a regression in how son manipulators are applied in insert(), a few obscure connection pool semaphore leaks, and a few other minor issues. See the list of issues resolved for full details.
Issues Resolved

See the PyMongo 2.7.2 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.7.1

Version 2.7.1 fixes a number of issues reported since the release of 2.7, most importantly a fix for creating indexes and manipulating users through mongos versions older than 2.4.0.
Issues Resolved

See the PyMongo 2.7.1 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.7

PyMongo 2.7 is a major release with a large number of new features and bug fixes. Highlights include:

    Full support for MongoDB 2.6.
    A new bulk write operations API.
    Support for server side query timeouts using max_time_ms().
    Support for writing aggregate() output to a collection.
    A new parallel_scan() helper.
    OperationFailure and its subclasses now include a details attribute with complete error details from the server.
    A new GridFS find() method that returns a GridOutCursor.
    Greatly improved support for mod_wsgi when using PyMongo’s C extensions. Read Jesse’s blog post for details.
    Improved C extension support for ARM little endian.

Breaking changes

Version 2.7 drops support for replica sets running MongoDB versions older than 1.6.2.
Issues Resolved

See the PyMongo 2.7 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.6.3

Version 2.6.3 fixes issues reported since the release of 2.6.2, most importantly a semaphore leak when a connection to the server fails.
Issues Resolved

See the PyMongo 2.6.3 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.6.2

Version 2.6.2 fixes a TypeError problem when max_pool_size=None is used in Python 3.
Issues Resolved

See the PyMongo 2.6.2 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.6.1

Version 2.6.1 fixes a reference leak in the insert() method.
Issues Resolved

See the PyMongo 2.6.1 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.6

Version 2.6 includes some frequently requested improvements and adds support for some early MongoDB 2.6 features.

Special thanks go to Justin Patrin for his work on the connection pool in this release.

Important new features:

    The max_pool_size option for MongoClient and MongoReplicaSetClient now actually caps the number of sockets the pool will open concurrently. Once the pool has reached max_pool_size operations will block waiting for a socket to become available. If waitQueueTimeoutMS is set, an operation that blocks waiting for a socket will raise ConnectionFailure after the timeout. By default waitQueueTimeoutMS is not set. See Can PyMongo help me load the results of my query as a Pandas DataFrame? for more information.
    The insert() method automatically splits large batches of documents into multiple insert messages based on max_message_size
    Support for the exhaust cursor flag. See find() for details and caveats.
    Support for the PLAIN and MONGODB-X509 authentication mechanisms. See the authentication docs for more information.
    Support aggregation output as a Cursor. See aggregate() for details.

Warning

SIGNIFICANT BEHAVIOR CHANGE in 2.6. Previously, max_pool_size would limit only the idle sockets the pool would hold onto, not the number of open sockets. The default has also changed, from 10 to 100. If you pass a value for max_pool_size make sure it is large enough for the expected load. (Sockets are only opened when needed, so there is no cost to having a max_pool_size larger than necessary. Err towards a larger value.) If your application accepts the default, continue to do so.

See Can PyMongo help me load the results of my query as a Pandas DataFrame? for more information.
Issues Resolved

See the PyMongo 2.6 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.5.2

Version 2.5.2 fixes a NULL pointer dereference issue when decoding an invalid DBRef.
Issues Resolved

See the PyMongo 2.5.2 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.5.1

Version 2.5.1 is a minor release that fixes issues discovered after the release of 2.5. Most importantly, this release addresses some race conditions in replica set monitoring.
Issues Resolved

See the PyMongo 2.5.1 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.5

Version 2.5 includes changes to support new features in MongoDB 2.4.

Important new features:

    Support for GSSAPI (Kerberos) authentication.
    Support for SSL certificate validation with hostname matching.
    Support for delegated and role based authentication.
    New GEOSPHERE (2dsphere) and HASHED index constants.

Note

authenticate() now raises a subclass of PyMongoError if authentication fails due to invalid credentials or configuration issues.
Issues Resolved

See the PyMongo 2.5 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.4.2

Version 2.4.2 is a minor release that fixes issues discovered after the release of 2.4.1. Most importantly, PyMongo will no longer select a replica set member for read operations that is not in primary or secondary state.
Issues Resolved

See the PyMongo 2.4.2 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.4.1

Version 2.4.1 is a minor release that fixes issues discovered after the release of 2.4. Most importantly, this release fixes a regression using aggregate(), and possibly other commands, with mongos.
Issues Resolved

See the PyMongo 2.4.1 release notes in JIRA for the list of resolved issues in this release.
Changes in Version 2.4

Version 2.4 includes a few important new features and a large number of bug fixes.

Important new features:

    New MongoClient and MongoReplicaSetClient classes - these connection classes do acknowledged write operations (previously referred to as ‘safe’ writes) by default. Connection and ReplicaSetConnection are deprecated but still support the old default fire-and-forget behavior.
    A new write concern API implemented as a write_concern attribute on the connection, Database, or Collection classes.
    MongoClient (and Connection) now support Unix Domain Sockets.
    Cursor can be copied with functions from the copy module.
    The set_profiling_level() method now supports a slow_ms option.
    The replica set monitor task (used by MongoReplicaSetClient and ReplicaSetConnection) is a daemon thread once again, meaning you won’t have to call close() before exiting the python interactive shell.


```