### PR TITLE
Remove baked query

### DIFF
--- a/inbox/models/account.py
+++ b/inbox/models/account.py
@@ -34,7 +34,7 @@ from inbox.models.mixins import (
 )
 from inbox.providers import provider_info
 from inbox.scheduling.event_queue import EventQueue
-from inbox.sqlalchemy_ext.util import JSON, MutableDict, bakery
+from inbox.sqlalchemy_ext.util import JSON, MutableDict
 
 log = get_logger()
 
@@ -313,9 +313,9 @@ class Account(
 
     @classmethod
     def get(cls, id_, session):
-        q = bakery(lambda session: session.query(cls))
-        q += lambda q: q.filter(cls.id == bindparam("id_"))
-        return q(session).params(id_=id_).first()
+        q = session.query(cls)
+        q = q.filter(cls.id == bindparam("id_"))
+        return q.params(id_=id_).first()
 
     @property
     def is_killed(self):

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -8,7 +8,6 @@ from inbox.models.base import MailSyncBase
 from inbox.models.category import Category, CategoryNameString, sanitize_name
 from inbox.models.constants import MAX_INDEXABLE_LENGTH
 from inbox.models.mixins import DeletedAtMixin, UpdatedAtMixin
-from inbox.sqlalchemy_ext.util import bakery
 
 log = get_logger()
 
@@ -111,8 +110,8 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     @classmethod
     def get(cls, id_, session):
-        q = bakery(lambda session: session.query(cls))
-        q += lambda q: q.filter(cls.id == bindparam("id_"))
-        return q(session).params(id_=id_).first()
+        q = session.query(cls)
+        q = q.filter(cls.id == bindparam("id_"))
+        return q.params(id_=id_).first()
 
     __table_args__ = (UniqueConstraint("account_id", "name", "canonical_name"),)

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -45,12 +45,7 @@ from inbox.models.mixins import (
     UpdatedAtMixin,
 )
 from inbox.security.blobstorage import decode_blob, encode_blob
-from inbox.sqlalchemy_ext.util import (
-    JSON,
-    MAX_MYSQL_INTEGER,
-    bakery,
-    json_field_too_long,
-)
+from inbox.sqlalchemy_ext.util import JSON, MAX_MYSQL_INTEGER, json_field_too_long
 from inbox.util.addr import parse_mimepart_address_header
 from inbox.util.blockstore import save_to_blockstore
 from inbox.util.encoding import unicode_safe_truncate
@@ -699,20 +694,18 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
     @classmethod
     def from_public_id(cls, public_id, namespace_id, db_session):
         # type: (str, int, Any) -> Message
-        q = bakery(lambda s: s.query(cls))
-        q += lambda q: q.filter(
+        q = db_session.query(cls)
+        q = q.filter(
             Message.public_id == bindparam("public_id"),
             Message.namespace_id == bindparam("namespace_id"),
         )
-        q += lambda q: q.options(
+        q = q.options(
             joinedload(Message.thread).load_only("discriminator", "public_id"),
             joinedload(Message.messagecategories).joinedload(MessageCategory.category),
             joinedload(Message.parts).joinedload("block"),
             joinedload(Message.events),
         )
-        return (
-            q(db_session).params(public_id=public_id, namespace_id=namespace_id).one()
-        )
+        return q.params(public_id=public_id, namespace_id=namespace_id).one()
 
     @classmethod
     def api_loading_options(cls, expand=False):

--- a/inbox/models/namespace.py
+++ b/inbox/models/namespace.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm import backref, relationship
 
 from inbox.models.base import MailSyncBase
 from inbox.models.mixins import DeletedAtMixin, HasPublicID, UpdatedAtMixin
-from inbox.sqlalchemy_ext.util import bakery
 
 
 class Namespace(MailSyncBase, HasPublicID, UpdatedAtMixin, DeletedAtMixin):
@@ -36,12 +35,12 @@ class Namespace(MailSyncBase, HasPublicID, UpdatedAtMixin, DeletedAtMixin):
 
     @classmethod
     def get(cls, id_, session):
-        q = bakery(lambda session: session.query(cls))
-        q += lambda q: q.filter(cls.id == bindparam("id_"))
-        return q(session).params(id_=id_).first()
+        q = session.query(cls)
+        q = q.filter(cls.id == bindparam("id_"))
+        return q.params(id_=id_).first()
 
     @classmethod
     def from_public_id(cls, public_id, db_session):
-        q = bakery(lambda session: session.query(Namespace))
-        q += lambda q: q.filter(Namespace.public_id == bindparam("public_id"))
-        return q(db_session).params(public_id=public_id).one()
+        q = db_session.query(Namespace)
+        q = q.filter(Namespace.public_id == bindparam("public_id"))
+        return q.params(public_id=public_id).one()

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -14,7 +14,6 @@ json_util.EPOCH_AWARE = EPOCH_NAIVE
 
 from sqlalchemy import String, Text, event
 from sqlalchemy.engine import Engine
-from sqlalchemy.ext import baked
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.pool import QueuePool
 from sqlalchemy.sql import operators
@@ -31,8 +30,6 @@ MAX_TEXT_BYTES = 65535
 MAX_BYTES_PER_CHAR = 4  # For collation of utf8mb4
 MAX_TEXT_CHARS = int(MAX_TEXT_BYTES / float(MAX_BYTES_PER_CHAR))
 MAX_MYSQL_INTEGER = 2147483647
-
-bakery = baked.bakery()
 
 
 query_counts = weakref.WeakKeyDictionary()


### PR DESCRIPTION
The baked query extension is deprecated since 1.4:

https://docs.sqlalchemy.org/en/14/orm/extensions/baked.html

> Deprecated since version 1.4: SQLAlchemy 1.4 and 2.0 feature an all-new direct query caching system that removes the need for the BakedQuery system. Caching is now transparently active for all Core and ORM queries with no action taken by the user, using the system described at SQL Compilation Caching.

Since we will be updating to 1.4 we can get rid off it altogether.