### PR TITLE
SQLAlchemy cache_ok

### DIFF
--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -74,6 +74,8 @@ def time_parse(x):
 class FlexibleDateTime(TypeDecorator):
     """Coerce arrow times to naive datetimes before handing to the database."""
 
+    cache_ok = True
+
     impl = DateTime
 
     def process_bind_param(self, value, dialect):

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -117,6 +117,7 @@ class StringWithTransform(TypeDecorator):
 
 # http://docs.sqlalchemy.org/en/rel_0_9/core/types.html#marshal-json-strings
 class JSON(TypeDecorator):
+    cache_ok = True
     impl = Text
 
     def process_bind_param(self, value, dialect):

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -118,6 +118,7 @@ class StringWithTransform(TypeDecorator):
 # http://docs.sqlalchemy.org/en/rel_0_9/core/types.html#marshal-json-strings
 class JSON(TypeDecorator):
     cache_ok = True
+
     impl = Text
 
     def process_bind_param(self, value, dialect):

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -94,6 +94,8 @@ class StringWithTransform(TypeDecorator):
     setter or a @validates decorator
     """
 
+    cache_ok = True
+
     impl = String
 
     def __init__(self, string_transform, *args, **kwargs):
@@ -151,6 +153,8 @@ class BigJSON(JSON):
 
 
 class Base36UID(TypeDecorator):
+    cache_ok = True
+
     impl = BINARY(16)  # 128 bit unsigned integer
 
     def process_bind_param(self, value, dialect):


### PR DESCRIPTION
This marks type decorators as ready for SQLAlchemy query caching mechanism.