### PR TITLE
BaseException.message does not exist on Python 3

### DIFF
--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -249,16 +249,17 @@ class OAuthRequestsWrapper(requests.auth.AuthBase):
 
 
 def _process_imap_exception(exc):
-    if "Lookup failed" in exc.message:
+    message = exc.args[0] if exc.args else ""
+    if "Lookup failed" in message:
         # Gmail is disabled for this apps account
         return ImapSupportDisabledError("gmail_disabled_for_domain")
-    elif "IMAP access is disabled for your domain." in exc.message:
+    elif "IMAP access is disabled for your domain." in message:
         # IMAP is disabled for this domain
         return ImapSupportDisabledError("imap_disabled_for_domain")
-    elif exc.message.startswith("[AUTHENTICATIONFAILED] Invalid credentials (Failure)"):
+    elif message.startswith("[AUTHENTICATIONFAILED] Invalid credentials (Failure)"):
         # Google
         return ImapSupportDisabledError("authentication_failed")
-    elif exc.message.startswith("AUTHENTICATE failed."):
+    elif message.startswith("AUTHENTICATE failed."):
         # Microsoft
         return ImapSupportDisabledError("authentication_failed")
     else:


### PR DESCRIPTION
As written, on 3 one needs to look in args and if it's empty Python 2 would return `""` in message.