### PR TITLE
Disable JSON_SORT_KEYS

### DIFF
--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import sys
+
 from flask import Flask, g, jsonify, make_response, request
 from flask_restful import reqparse
 from sqlalchemy.orm.exc import NoResultFound
@@ -31,6 +33,8 @@ from .metrics_api import app as metrics_api
 from .ns_api import DEFAULT_LIMIT, app as ns_api
 
 app = Flask(__name__)
+if (3, 6) <= sys.version_info < (3, 7):
+    app.config["JSON_SORT_KEYS"] = False
 # Handle both /endpoint and /endpoint/ without redirecting.
 # Note that we need to set this *before* registering the blueprint.
 app.url_map.strict_slashes = False

--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import sys
-
 from flask import Flask, g, jsonify, make_response, request
 from flask_restful import reqparse
 from sqlalchemy.orm.exc import NoResultFound
@@ -33,8 +31,7 @@ from .metrics_api import app as metrics_api
 from .ns_api import DEFAULT_LIMIT, app as ns_api
 
 app = Flask(__name__)
-if (3, 6) <= sys.version_info < (3, 7):
-    app.config["JSON_SORT_KEYS"] = False
+app.config["JSON_SORT_KEYS"] = False
 # Handle both /endpoint and /endpoint/ without redirecting.
 # Note that we need to set this *before* registering the blueprint.
 app.url_map.strict_slashes = False

--- a/inbox/mailsync/frontend.py
+++ b/inbox/mailsync/frontend.py
@@ -1,3 +1,5 @@
+import sys
+
 import gevent
 import gevent._threading  # This is a clone of the *real* threading module
 from flask import Flask, jsonify, request
@@ -23,6 +25,8 @@ class HTTPFrontend(object):
 
     def _create_app(self):
         app = Flask(__name__)
+        if (3, 6) <= sys.version_info < (3, 7):
+            app.config["JSON_SORT_KEYS"] = False
         self._create_app_impl(app)
         return app
 

--- a/inbox/mailsync/frontend.py
+++ b/inbox/mailsync/frontend.py
@@ -1,5 +1,3 @@
-import sys
-
 import gevent
 import gevent._threading  # This is a clone of the *real* threading module
 from flask import Flask, jsonify, request
@@ -25,8 +23,7 @@ class HTTPFrontend(object):
 
     def _create_app(self):
         app = Flask(__name__)
-        if (3, 6) <= sys.version_info < (3, 7):
-            app.config["JSON_SORT_KEYS"] = False
+        app.config["JSON_SORT_KEYS"] = False
         self._create_app_impl(app)
         return app
 


### PR DESCRIPTION
I've stumbled on mysterious

`TypeError: '<' not supported between instances of 'NoneType' and 'str'`

in `json.dumps` when manually testing things on Python 3.6.

It turns out Python 3.6 has a bug when one passes `sort_keys=True` into `json.dumps` and dictionaries have `None` keys and at least syncback uses such dictionaries. We don't pass it ourselves but we are using it indirectly with Flask's `jsonify`. I had to disable it on 3.6. We are going for 3.8 anyway so I think this is acceptable intermediate step.

See also: https://github.com/humanprotocol/hmt-escrow/issues/32