### PR TITLE
Rollbar and chains on Python 3

### DIFF
--- a/inbox/error_handling.py
+++ b/inbox/error_handling.py
@@ -76,6 +76,10 @@ GROUP_EXCEPTION_CLASSES = [
 def payload_handler(message_filters, payload, **kw):
     title = payload["data"].get("title")
     exception = payload["data"].get("body", {}).get("trace", {}).get("exception", {})
+    # On Python 3 exceptions are organized in chains
+    if not exception:
+        trace_chain = payload["data"].get("body", {}).get("trace_chain")
+        exception = trace_chain[0].get("exception", {}) if trace_chain else {}
 
     exception_message = exception.get("message")
     exception_class = exception.get("class")


### PR DESCRIPTION
This is the logic we use to artificially decimate the number of rollbars we get in production. Each exception messages is assigned a threshold to only report a percentage of the occurances.

There is a change between Python 2 & 3 on how exception data is stored in rollbar data. As Python 3 supports exception chains the whole chain is stored now elsewhere. This ensures that it works consistently between Python 2 & 3.