### PR TITLE
Gmail labels containing asterisks search fix

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -1390,64 +1390,60 @@ class GmailCrispinClient(CrispinClient):
     def search_uids(self, criteria):
         # type: (List[str]) -> List[int]
         """
-        Find UIDs in this folder matching the criteria. See
-        http://tools.ietf.org/html/rfc3501.html#section-6.4.4 for valid
-        criteria.
+        Handle Gmail label search oddities.
+        https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels.
+
+        UTF-7 encodes label names and also quotes it to prevent errors when the label contains
+        asterisks (*). imapclient's search method sends label names containing asterisks unquoted which
+        upsets Gmail IMAP server.
         """
-        if len(criteria) == 2 and criteria[0] == "X-GM-LABELS":
-            response = gmail_label_search(self.conn, criteria[1])
-            return sorted([long(uid) for uid in response])
+        if len(criteria) != 2:
+            return super(GmailCrispinClient, self).search_uids(criteria)
 
-        return super(GmailCrispinClient, self).search_uids(criteria)
+        if criteria[0] != "X-GM-LABELS":
+            return super(GmailCrispinClient, self).search_uids(criteria)
 
+        # First UTF-7 encode the label name
+        label_name = criteria[1]
+        encoded_label_name = imapclient.imap_utf7.encode(label_name)  # type: bytes
 
-def gmail_label_search(connection, label_name):
-    # type: (Any, str) -> List[int]
-    """
-    Handle Gmail label search oddities.
-    https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels.
+        # If label contained only ASCII characters and does not contain asterisks
+        # we don't need to do anything special
+        if encoded_label_name.decode("ascii") == label_name and "*" not in label_name:
+            return super(GmailCrispinClient, self).search_uids(criteria)
 
-    It UTF-7 encodes label names and also always quotes it to prevent errors when the label contains
-    asterisks (*). imapclient's search method sends label names containing asterisks unquoted which
-    upsets Gmail IMAP server.
-    """
-    criteria = ["X-GM-LABELS", label_name]
+        # At this point quote Gmail label name since it could contain asterisks.
+        # Sending unquotted label name containg asterisks upsets Gmail IMAP server
+        # and triggers imapclient.exceptions.InvalidCriteriaError: b'Could not parse command'
+        # based off: https://github.com/mjs/imapclient/blob/0279592557495d4ddf7619b17ed9e73b21161bdf/imapclient/imapclient.py#L1826
+        encoded_label_name = encoded_label_name.replace(b"\\", b"\\\\")
+        encoded_label_name = encoded_label_name.replace(b'"', b'\\"')
+        encoded_label_name = b'"' + encoded_label_name + b'"'
 
-    # First UTF-7 encode the label name
-    encoded_label_name = imapclient.imap_utf7.encode(label_name)  # type: bytes
-
-    # Always quote Gmail label names since they can contain asterisks.
-    # Sending unquotted label name containg asterisks upsets Gmail IMAP server
-    # and triggers imapclient.exceptions.InvalidCriteriaError: b'Could not parse command'
-    # based off: https://github.com/mjs/imapclient/blob/0279592557495d4ddf7619b17ed9e73b21161bdf/imapclient/imapclient.py#L1826
-    encoded_label_name = encoded_label_name.replace(b"\\", b"\\\\")
-    encoded_label_name = encoded_label_name.replace(b'"', b'\\"')
-    encoded_label_name = b'"' + encoded_label_name + b'"'
-
-    # Now actually perform the search the Goole way skipping imapclient's public API which does it differently
-    # based off: https://github.com/mjs/imapclient/blob/master/imapclient/imapclient.py#L1123-L1145
-    try:
-        data = connection._raw_command_untagged(
-            b"SEARCH", [b"X-GM-LABELS", encoded_label_name]
-        )
-    except imaplib.IMAP4.error as e:
-        # Make BAD IMAP responses easier to understand to the user, with a link to the docs
-        m = re.match(r"SEARCH command error: BAD \[(.+)\]", str(e))
-        if m:
-            raise imapclient.exceptions.InvalidCriteriaError(
-                "{original_msg}\n\n"
-                "This error may have been caused by a syntax error in the criteria: "
-                "{criteria}\nPlease refer to the documentation for more information "
-                "about search criteria syntax..\n"
-                "https://imapclient.readthedocs.io/en/master/#imapclient.IMAPClient.search".format(
-                    original_msg=m.group(1),
-                    criteria='"%s"' % criteria
-                    if not isinstance(criteria, list)
-                    else criteria,
-                )
+        # Now actually perform the search skipping imapclient's public API which does quoting differently
+        # based off: https://github.com/mjs/imapclient/blob/master/imapclient/imapclient.py#L1123-L1145
+        try:
+            data = self.conn._raw_command_untagged(
+                b"SEARCH", [b"X-GM-LABELS", encoded_label_name]
             )
+        except imaplib.IMAP4.error as e:
+            # Make BAD IMAP responses easier to understand to the user, with a link to the docs
+            m = re.match(r"SEARCH command error: BAD \[(.+)\]", str(e))
+            if m:
+                raise imapclient.exceptions.InvalidCriteriaError(
+                    "{original_msg}\n\n"
+                    "This error may have been caused by a syntax error in the criteria: "
+                    "{criteria}\nPlease refer to the documentation for more information "
+                    "about search criteria syntax..\n"
+                    "https://imapclient.readthedocs.io/en/master/#imapclient.IMAPClient.search".format(
+                        original_msg=m.group(1),
+                        criteria='"%s"' % criteria
+                        if not isinstance(criteria, list)
+                        else criteria,
+                    )
+                )
 
-        # If the exception is not from a BAD IMAP response, re-raise as-is
-        raise
+            # If the exception is not from a BAD IMAP response, re-raise as-is
+            raise
 
-    return imapclient.response_parser.parse_message_list(data)
+        return imapclient.response_parser.parse_message_list(data)

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -1446,4 +1446,5 @@ class GmailCrispinClient(CrispinClient):
             # If the exception is not from a BAD IMAP response, re-raise as-is
             raise
 
-        return imapclient.response_parser.parse_message_list(data)
+        response = imapclient.response_parser.parse_message_list(data)
+        return sorted([long(uid) for uid in response])

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -5,9 +5,12 @@ import re
 import sys
 import time
 from builtins import range
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple
+from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple, Union
 
 import imapclient
+import imapclient.exceptions
+import imapclient.imap_utf7
+import imapclient.response_parser
 from future.utils import iteritems
 from past.builtins import long
 
@@ -716,6 +719,7 @@ class CrispinClient(object):
         return b"IDLE" in self.conn.capabilities()
 
     def search_uids(self, criteria):
+        # type: (List[str]) -> List[int]
         """
         Find UIDs in this folder matching the criteria. See
         http://tools.ietf.org/html/rfc3501.html#section-6.4.4 for valid
@@ -1382,3 +1386,68 @@ class GmailCrispinClient(CrispinClient):
         self.conn.select_folder(trash_folder_name)
         self._delete_message(message_id_header, delete_multiple)
         return True
+
+    def search_uids(self, criteria):
+        # type: (List[str]) -> List[int]
+        """
+        Find UIDs in this folder matching the criteria. See
+        http://tools.ietf.org/html/rfc3501.html#section-6.4.4 for valid
+        criteria.
+        """
+        if len(criteria) == 2 and criteria[0] == "X-GM-LABELS":
+            response = gmail_label_search(self.conn, criteria[1])
+            return sorted([long(uid) for uid in response])
+
+        return super(GmailCrispinClient, self).search_uids(criteria)
+
+
+def gmail_label_search(connection, label_name):
+    # type: (Any, str) -> List[int]
+    """
+    Handle Gmail label search oddities.
+    https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels.
+
+    It UTF-7 encodes label names and also always quotes it to prevent errors when the label contains
+    asterisks (*). imapclient's search method sends label names containing asterisks unquoted which
+    upsets Gmail IMAP server.
+    """
+    criteria = ["X-GM-LABELS", label_name]
+
+    # First UTF-7 encode the label name
+    encoded_label_name = imapclient.imap_utf7.encode(label_name)  # type: bytes
+
+    # Always quote Gmail label names since they can contain asterisks.
+    # Sending unquotted label name containg asterisks upsets Gmail IMAP server
+    # and triggers imapclient.exceptions.InvalidCriteriaError: b'Could not parse command'
+    # based off: https://github.com/mjs/imapclient/blob/0279592557495d4ddf7619b17ed9e73b21161bdf/imapclient/imapclient.py#L1826
+    encoded_label_name = encoded_label_name.replace(b"\\", b"\\\\")
+    encoded_label_name = encoded_label_name.replace(b'"', b'\\"')
+    encoded_label_name = b'"' + encoded_label_name + b'"'
+
+    # Now actually perform the search the Goole way skipping imapclient's public API which does it differently
+    # based off: https://github.com/mjs/imapclient/blob/master/imapclient/imapclient.py#L1123-L1145
+    try:
+        data = connection._raw_command_untagged(
+            b"SEARCH", [b"X-GM-LABELS", encoded_label_name]
+        )
+    except imaplib.IMAP4.error as e:
+        # Make BAD IMAP responses easier to understand to the user, with a link to the docs
+        m = re.match(r"SEARCH command error: BAD \[(.+)\]", str(e))
+        if m:
+            raise imapclient.exceptions.InvalidCriteriaError(
+                "{original_msg}\n\n"
+                "This error may have been caused by a syntax error in the criteria: "
+                "{criteria}\nPlease refer to the documentation for more information "
+                "about search criteria syntax..\n"
+                "https://imapclient.readthedocs.io/en/master/#imapclient.IMAPClient.search".format(
+                    original_msg=m.group(1),
+                    criteria='"%s"' % criteria
+                    if not isinstance(criteria, list)
+                    else criteria,
+                )
+            )
+
+        # If the exception is not from a BAD IMAP response, re-raise as-is
+        raise
+
+    return imapclient.response_parser.parse_message_list(data)

--- a/inbox/mailsync/gc.py
+++ b/inbox/mailsync/gc.py
@@ -4,7 +4,6 @@ standard_library.install_aliases()
 import datetime
 
 import gevent
-from imapclient.imap_utf7 import encode as utf7_encode
 from sqlalchemy import func
 from sqlalchemy.orm import load_only
 
@@ -233,7 +232,7 @@ class LabelRenameHandler(gevent.Greenlet):
                     crispin_client.select_folder(folder_name, uidvalidity_cb)
 
                     found_uids = crispin_client.search_uids(
-                        ["X-GM-LABELS", utf7_encode(self.label_name)]
+                        ["X-GM-LABELS", self.label_name]
                     )
 
                     for chnk in chunk(found_uids, 200):


### PR DESCRIPTION
Not related to Python 3 porting, just a problem we had before.

We are sporadically hitting errors when customers have labels in their Gmail inbox containing asterisks. Such us:

```
InvalidCriteriaError: b'Could not parse command'
``` 

For an IMAP search criteria like `["X-GM-LABELS", "*Asterisk"]`

This is an extension to IMAP by Google and we are using it. It also works differently than the rest of IMAP as implemented by `imapclient` library, specifically:
* the label has to be utf-7 encoded (https://en.wikipedia.org/wiki/UTF-7). This is documented here: https://developers.google.com/gmail/imap/imap-extensions 
* if the label contains asterisk it has to be quoted

We were already doing the first thing already but in the wrong place architecture-wise. 
About quoting ,`imapclient` only quotes values containing `"` and `\` characters and leaves everything else unquoted. This requirement to quote labels containing `*` character is not documented anywhere, I have found out it has to be done by experimenting. I don't think IMAP RFC mandates this, although `*` has special meaning in some contexts/positions but here it would not be ambiguous. This is most probably Gmail quirk, whilst `imapclient` follows the RFC.

I've also confirmed this works by creating a Gmail label containing *Asterisk in my Gmail inbox and then used the code from this pull request. It would fail loudly before.

Quoting labels not containing `*` is not necessary, but quoting them always does not hurt either. This is a little bit hacky because `imapclient`s default logic has to be skipped.