### PR TITLE
Upgrade cchardet

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -12,7 +12,8 @@ boto==2.49.0
 boto3==1.17.112
 botocore==1.20.112
 bumpversion==0.5.3
-cchardet==2.1.7
+cchardet==2.1.1; python_version < '3.0'
+cchardet==2.1.7; python_version >= '3.0'
 certifi==2020.4.5.1
 cffi==1.14.6
 chardet==3.0.4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -12,7 +12,7 @@ boto==2.49.0
 boto3==1.17.112
 botocore==1.20.112
 bumpversion==0.5.3
-cchardet==2.1.1
+cchardet==2.1.7
 certifi==2020.4.5.1
 cffi==1.14.6
 chardet==3.0.4


### PR DESCRIPTION
Upgrades to version tested on Python 3.8. It's also the last version. That needs to be conditional since it does not support Python 2.

Changelog

```

2.1.7

------------------
  
  - support Python 3.9
  - drop support for Python 3.5

2.1.6

------------------
  
  - drop support for Python 2.7
  - support Github Actions
  - update dev-dependencies

2.1.5

------------------
  
  - update language models (uchardet)
  - add iso8859-2 test but disabled it
  - support Python 3.8
  - drop support for Python 3.4

2.1.4

------------------
  
  - disable LTO because become poor performance

2.1.3

------------------
  
  - support Python 3.7

2.1.2

------------------
  
  - enable `LTO`_ for wheel builds
  - update Cython
  
  .. _LTO: https://gcc.gnu.org/wiki/LinkTimeOptimization


```