### PR TITLE
Upgrade WebOb

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -125,7 +125,7 @@ typing==3.10.0.0; python_version < '3.5'
 urllib3==1.26.7
 vobject==0.9.1
 wcwidth==0.2.5
-WebOb==1.7.4
+WebOb==1.8.7
 Werkzeug==1.0.1
 wrapt==1.10.11
 zipp==1.2.0


### PR DESCRIPTION
> WebOb provides objects for HTTP requests and responses.

WebOb is a dependency of flanker. This is the last version of WebOb and it still supports Python 2.7.

```
pipdeptree --reverse --packages WebOb
WebOb==1.8.7
  - flanker==0.9.11 [requires: WebOb>=0.9.8]
```

WebOb only publishes changelog entries for minor releases, no micro releases changelogs

```

1.8.0

------------------
  
  Feature
  ~~~~~~~
  
  - ``request.POST`` now supports any requests with the appropriate
  Content-Type. Allowing any HTTP method to access form encoded content,
  including DELETE, PUT, and others. See
  https://github.com/Pylons/webob/pull/352
  
  Compatibility
  ~~~~~~~~~~~~~
  
  - WebOb is no longer officially supported on Python 3.3 which was EOL'ed on
  2017-09-29.
  
  Backwards Incompatibilities
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
  - Many changes have been made to the way WebOb does Accept handling, not just
  for the Accept header itself, but also for Accept-Charset, Accept-Encoding
  and Accept-Language. This was a `Google Summer of Code
  <https://summerofcode.withgoogle.com/>`_ project completed by
  Whiteroses (https://github.com/whiteroses). Many thanks to Google for running
  GSoC, the Python Software Foundation for organising and a huge thanks to Ira
  for completing the work. See https://github.com/Pylons/webob/pull/338 and
  https://github.com/Pylons/webob/pull/335. Documentation is available at
  https://docs.pylonsproject.org/projects/webob/en/master/api/webob.html
  
  - When calling a ``wsgify`` decorated function, the default arguments passed
  to ``wsgify`` are now used when called with the request, and not as a
  `start_response`
  
  .. code::
  
  def hello(req, name):
  return "Hello, %s!" % name
  app = wsgify(hello, args=("Fred",))
  
  req = Request.blank('/')
  resp = req.get_response(app)   => "Hello, Fred"
  resp2 = app(req)  => "Hello, Fred"
  
  Previously the ``resp2`` line would have failed with a ``TypeError``. With
  this change there is no way to override the default arguments with no
  arguments. See https://github.com/Pylons/webob/pull/203
  
  - When setting ``app_iter`` on a ``Response`` object the ``content_md5`` header
  is no longer cleared. This behaviour is odd and disallows setting the
  ``content_md5`` and then returning an iterator for chunked content encoded
  responses. See https://github.com/Pylons/webob/issues/86
  
  Experimental Features
  ~~~~~~~~~~~~~~~~~~~~~
  
  These features are experimental and may change at any point in the future.
  
  - The cookie APIs now have the ability to set the SameSite attribute on a
  cookie in both ``webob.cookies.make_cookie`` and
  ``webob.cookies.CookieProfile``. See https://github.com/Pylons/webob/pull/255
  
  Bugfix
  ~~~~~~
  
  - Exceptions now use string.Template.safe_substitute rather than
  string.Template.substitute. The latter would raise for missing mappings, the
  former will simply not substitute the missing variable. This is safer in case
  the WSGI environ does not contain the keys necessary for the body template.
  See https://github.com/Pylons/webob/issues/345.
  
  - Request.host_url, Request.host_port, Request.domain correctly parse IPv6 Host
  headers as provided by a browser. See
  https://github.com/Pylons/webob/pull/332
  
  - Request.authorization would raise ValueError for unusual or malformed header
  values. See https://github.com/Pylons/webob/issues/231
  
  - Allow unnamed fields in form data to be properly transcoded when calling
  request.decode with an alternate encoding. See
  https://github.com/Pylons/webob/pull/309
  
  - ``Response.__init__`` would discard ``app_iter`` when a ``Response`` had no
  body, this would cause issues when ``app_iter`` was an object that was tied
  to the life-cycle of a web application and had to be properly closed.
  ``app_iter`` is more advanced API for ``Response`` and thus even if it
  contains a body and is thus against the HTTP RFC's, we should let the users
  shoot themselves by returning a body. See
  https://github.com/Pylons/webob/issues/305
```