### PR TITLE
Ubuntu Bionic Beaver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM ubuntu:xenial-20210804
+FROM ubuntu:bionic-20210930
 ARG PYTHON_VERSION=2.7
 
 RUN groupadd -g 5000 sync-engine \
   && useradd -d /home/sync-engine -m -u 5000 -g 5000 sync-engine
 
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get dist-upgrade -y && apt-get install -y \
+ENV TZ="Etc/GMT"
+RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get dist-upgrade -y && \
+  apt-get install -y tzdata && \
+  apt-get install -y \
   build-essential \
   curl \
   dnsutils \
@@ -26,17 +29,16 @@ RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get dist-upgrade -y 
   net-tools \
   shared-mime-info \
   telnet \
-  tzdata \
   vim \
   libffi-dev \
   software-properties-common \
   && rm -rf /var/lib/apt/lists/*
 
-RUN if [ "${PYTHON_VERSION}" != "2.7" ] ; \
+RUN if [ "${PYTHON_VERSION}" != "3.6" ] ; \
   then \
     add-apt-repository ppa:deadsnakes/ppa; \
-    DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y python"${PYTHON_VERSION}" python"${PYTHON_VERSION}"-dev; \
   fi; \
+  DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y python"${PYTHON_VERSION}"-dev; \
   if [ "${PYTHON_VERSION}" = "3.8" ] ; then DEBIAN_FRONTEND=noninteractive apt-get install -y python"${PYTHON_VERSION}"-distutils; fi; \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This upgrades the base image from unsupported Ubuntu 16.04.7 LTS (Xenial Xerus) to Ubuntu 18.04.6 LTS (Bionic Beaver).

The default Python version on this image is Python 3.6.

I'm tracking 20.04 (Focal Fossa on a separate branch).