### PR TITLE
Upgrade MarkupSafe

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -65,7 +65,7 @@ lazy-object-proxy==1.3.1
 limitlion==0.10.0
 lxml==4.6.4
 Mako==1.0.7
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 mock==1.3.0
 mockredispy==2.9.3


### PR DESCRIPTION
MarkupSafe is part of Flask.


Changelog

```

1.1.1

-------------
  
  Released 2019-02-23
  
  -   Fix segfault when ``__html__`` method raises an exception when using
  the C speedups. The exception is now propagated correctly. :pr:`109`

1.1.0

-------------
  
  Released 2018-11-05
  
  -   Drop support for Python 2.6 and 3.3.
  -   Build wheels for Linux, Mac, and Windows, allowing systems without
  a compiler to take advantage of the C extension speedups. :pr:`104`
  -   Use newer CPython API on Python 3, resulting in a 1.5x speedup.
  :pr`64`
  -   ``escape`` wraps ``__html__`` result in ``Markup``, consistent with
  documented behavior. :pr:`69`


```