### PR TITLE
Upgrade pytz

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -100,7 +100,7 @@ pytest==4.6.11
 pytest-timeout==1.4.2
 pytest-cov==2.12.1
 python-dateutil==2.8.2
-pytz==2017.3
+pytz==2021.3
 PyYAML==5.4.1
 redis==2.10.6
 regex==2018.1.10


### PR DESCRIPTION
This contains mostly civil date DST changes etc.

```
	release 2021c - 2021-10-01 14:21:49 -0700

  Briefly:
    Revert most 2021b changes to 'backward'.
    Fix 'zic -b fat' bug in pre-1970 32-bit data.
    Fix two Link line typos.
    Distribute SECURITY file.

    This release is intended as a bugfix release, to fix compatibility
    problems and typos reported since 2021b was released.

  Changes to Link directives

    Revert almost all of 2021b's changes to the 'backward' file,
    by moving Link directives back to where they were in 2021a.
    Although 'zic' doesn't care which source file contains a Link
    directive, some downstream uses ran into trouble with the move.
    (Problem reported by Stephen Colebourne for Joda-Time.)

    Fix typo that linked Atlantic/Jan_Mayen to the wrong location
    (problem reported by Chris Walton).

    Fix 'backzone' typo that linked America/Virgin to the wrong
    location (problem reported by Michael Deckers).

  Changes to code

    Fix a bug in 'zic -b fat' that caused old timestamps to be
    mishandled in 32-bit-only readers (problem reported by Daniel
    Fischer).

  Changes to documentation

    Distribute the SECURITY file (problem reported by Andreas Radke).


Release 2021b - 2021-09-24 16:23:00 -0700

  Briefly:
    Jordan now starts DST on February's last Thursday.
    Samoa no longer observes DST.
    Merge more location-based Zones whose timestamps agree since 1970.
    Move some backward-compatibility links to 'backward'.
    Rename Pacific/Enderbury to Pacific/Kanton.
    Correct many pre-1993 transitions in Malawi, Portugal, etc.
    zic now creates each output file or link atomically.
    zic -L no longer omits the POSIX TZ string in its output.
    zic fixes for truncation and leap second table expiration.
    zic now follows POSIX for TZ strings using all-year DST.
    Fix some localtime crashes and bugs in obscure cases.
    zdump -v now outputs more-useful boundary cases.
    tzfile.5 better matches a draft successor to RFC 8536.
    A new file SECURITY.

    This release is prompted by recent announcements by Jordan and Samoa.
    It incorporates many other changes that had accumulated since 2021a.
    However, it omits most proposed changes that merged all Zones
    agreeing since 1970, as concerns were raised about doing too many of
    these changes at once.  It does keeps some of these changes in the
    interest of making tzdb more equitable one step at a time; see
    "Merge more location-based Zones" below.

  Changes to future timestamps

    Jordan now starts DST on February's last Thursday.
    (Thanks to Steffen Thorsen.)

    Samoa no longer observes DST.  (Thanks to Geoffrey D. Bennett.)

  Changes to zone name

    Rename Pacific/Enderbury to Pacific/Kanton.  When we added
    Enderbury in 1993, we did not know that it is uninhabited and that
    Kanton (population two dozen) is the only inhabited location in
    that timezone.  The old name is now a backward-compatility link.

  Changes to past timestamps

    Correct many pre-1993 transitions, fixing entries originally
    derived from Shanks, Whitman, and Mundell.  The fixes include:
      - Barbados: standard time was introduced in 1911, not 1932; and
	DST was observed in 1942-1944
      - Cook Islands: In 1899 they switched from east to west of GMT,
	celebrating Christmas for two days.  They (and Niue) switched
	to standard time in 1952, not 1901.
      - Guyana: corrected LMT for Georgetown; the introduction of
	standard time in 1911, not 1915; and corrections to 1975 and
	1992 transitions
      - Kanton: uninhabited before 1937-08-31
      - Niue: only observed -11:20 from 1952 through 1964, then went to
        -11 instead of -11:30
      - Portugal: DST was observed in 1950
      - Tonga: corrected LMT; the introduction of standard time in 1945,
        not 1901; and corrections to the transition from +12:20 to +13
        in 1961, not 1941
    Additional fixes to entries in the 'backzone' file include:
      - Enderbury: inhabited only 1860/1885 and 1938-03-06/1942-02-09
      - The Gambia: 1933 and 1942 transitions
      - Malawi: several 1911 through 1925 transitions
      - Sierra Leone: several 1913 through 1941 transitions, and DST
	was NOT observed in 1957 through 1962
    (Thanks to P Chan, Michael Deckers, Alexander Krivenyshev and
    Alois Treindl.)

    Merge more location-based Zones whose timestamps agree since 1970,
    as pre-1970 timestamps are out of scope.  This is part of a
    process that has been ongoing since 2013.  This does not affect
    post-1970 timestamps, and timezone historians who build with 'make
    PACKRATDATA=backzone' should see no changes to pre-1970 timestamps.
    When merging, keep the most-populous location's data, and move
    data for other locations to 'backzone' with a backward
    link in 'backward'.  For example, move America/Creston data to
    'backzone' with a link in 'backward' from America/Phoenix because
    the two timezones' timestamps agree since 1970; this change
    affects some pre-1968 timestamps in America/Creston because
    Creston and Phoenix disagreed before 1968.  The affected Zones
    are Africa/Accra, America/Atikokan, America/Blanc-Sablon,
    America/Creston, America/Curacao, America/Nassau,
    America/Port_of_Spain, Antarctica/DumontDUrville, and
    Antarctica/Syowa.

  Changes to maintenance procedure

    The new file SECURITY covers how to report security-related bugs.

    Several backward-compatibility links have been moved to the
    'backward' file.  These links, which range from Africa/Addis_Ababa
    to Pacific/Saipan, are only for compatibility with now-obsolete
    guidelines suggesting an entry for every ISO 3166 code.
    The intercontinental convenience links Asia/Istanbul and
    Europe/Nicosia have also been moved to 'backward'.

  Changes to code

    zic now creates each output file or link atomically,
    possibly by creating a temporary file and then renaming it.
    This avoids races where a TZ setting would temporarily stop
    working while zic was installing a replacement file or link.

    zic -L no longer omits the POSIX TZ string in its output.
    Starting with 2020a, zic -L truncated its output according to the
    "Expires" directive or "#expires" comment in the leapseconds file.
    The resulting TZif files omitted daylight saving transitions after
    the leap second table expired, which led to far less-accurate
    predictions of times after the expiry.  Although future timestamps
    cannot be converted accurately in the presence of leap seconds, it
    is more accurate to convert near-future timestamps with a few
    seconds error than with an hour error, so zic -L no longer
    truncates output in this way.

    Instead, when zic -L is given the "Expires" directive, it now
    outputs the expiration by appending a no-change entry to the leap
    second table.  Although this should work well with most TZif
    readers, it does not conform to Internet RFC 8536 and some pickier
    clients (including tzdb 2017c through 2021a) reject it, so
    "Expires" directives are currently disabled by default.  To enable
    them, set the EXPIRES_LINE Makefile variable.  If a TZif file uses
    this new feature it is marked with a new TZif version number 4,
    a format intended to be documented in a successor to RFC 8536.

    zic -L LEAPFILE -r @LO no longer generates an invalid TZif file
    that omits leap second information for the range LO..B when LO
    falls between two leap seconds A and B.  Instead, it generates a
    TZif version 4 file that represents the previously-missing
    information.

    The TZif reader now allows the leap second table to begin with a
    correction other than -1 or +1, and to contain adjacent
    transitions with equal corrections.  This supports TZif version 4.

    The TZif reader now lets leap seconds occur less than 28 days
    apart.  This supports possible future TZif extensions.

    Fix bug that caused 'localtime' etc. to crash when TZ was
    set to a all-year DST string like "EST5EDT4,0/0,J365/25" that does
    not conform to POSIX but does conform to Internet RFC 8536.

    Fix another bug that caused 'localtime' etc. to crash when TZ was
    set to a POSIX-conforming but unusual TZ string like
    "EST5EDT4,0/0,J365/0", where almost all the year is DST.

    Fix yet another bug that caused 'localtime' etc. to mishandle slim
    TZif files containing leap seconds after the last explicit
    transition in the table, or when handling far-future timestamps
    in slim TZif files lacking leap seconds.

    Fix localtime misbehavior involving positive leap seconds.
    This change affects only behavior for "right" system time,
    which contains leap seconds, and only if the UT offset is
    not a multiple of 60 seconds when a positive leap second occurs.
    (No such timezone exists in tzdb, luckily.)  Without the fix,
    the timestamp was ambiguous during a positive leap second.
    With the fix, any seconds occurring after a positive leap second
    and within the same localtime minute are counted through 60, not
    through 59; their UT offset (tm_gmtoff) is the same as before.
    Here is how the fix affects timestamps in a timezone with UT
    offset +01:23:45 (5025 seconds) and with a positive leap second at
    1972-06-30 23:59:60 UTC (78796800):

	time_t    without the fix      with the fix
	78796800  1972-07-01 01:23:45  1972-07-01 01:23:45 (leap second)
	78796801  1972-07-01 01:23:45  1972-07-01 01:23:46
	...
	78796815  1972-07-01 01:23:59  1972-07-01 01:23:60
	78796816  1972-07-01 01:24:00  1972-07-01 01:24:00

    Fix an unlikely bug that caused 'localtime' etc. to misbehave if
    civil time changes a few seconds before time_t wraps around, when
    leap seconds are enabled.

    Fix bug in zic -r; in some cases, the dummy time type after the
    last time transition disagreed with the TZ string, contrary to
    Internet RFC 8563 section 3.3.

    Fix a bug with 'zic -r @X' when X is a negative leap second that
    has a nonnegative correction.  Without the fix, the output file
    was truncated so that X appeared to be a positive leap second.
    Fix a similar, even-less-likely bug when truncating at a positive
    leap second that has a nonpositive correction.

    zic -r now reports an error if given rolling leap seconds, as this
    usage has never generally worked and is evidently unused.

    zic now generates a POSIX-conforming TZ string for TZif files
    where all-year DST is predicted for the indefinite future.
    For example, for all-year Eastern Daylight Time, zic now generates
    "XXX3EDT4,0/0,J365/23" where it previously generated
    "EST5EDT,0/0,J365/25" or "".  (Thanks to Michael Deckers for
    noting the possibility of POSIX conformance.)

    zic.c no longer requires sys/wait.h (thanks to spazmodius for
    noting it wasn't needed).

    When reading slim TZif files, zdump no longer mishandles leap
    seconds on the rare platforms where time_t counts leap seconds,
    fixing a bug introduced in 2014g.

    zdump -v now outputs timestamps at boundaries of what localtime
    and gmtime can represent, instead of the less-useful timestamps
    one day after the minimum and one day before the maximum.
    (Thanks to Arthur David Olson for prototype code, and to Manuela
    Friedrich for debugging help.)

    zdump's -c and -t options are now consistently inclusive for the
    lower time bound and exclusive for the upper.  Formerly they were
    inconsistent.  (Confusion noted by Martin Burnicki.)

  Changes to build procedure

    You can now compile with -DHAVE_MALLOC_ERRNO=0 to port to
    non-POSIX hosts where malloc doesn't set errno.
    (Problem reported by Jan Engelhardt.)

  Changes to documentation

    tzfile.5 better matches a draft successor to RFC 8536
    <https://datatracker.ietf.org/doc/draft-murchison-rfc8536bis/01/>.


Release 2021a - 2021-01-24 10:54:57 -0800

  Changes to future timestamps

    South Sudan changes from +03 to +02 on 2021-02-01 at 00:00.
    (Thanks to Steffen Thorsen.)


Release 2020f - 2020-12-29 00:17:46 -0800

  Change to build procedure

    'make rearguard_tarballs' no longer generates a bad rearguard.zi,
    fixing a 2020e bug.  (Problem reported by Deborah Goldsmith.)


Release 2020e - 2020-12-22 15:14:34 -0800

  Briefly:
    Volgograd switches to Moscow time on 2020-12-27 at 02:00.

  Changes to future timestamps

    Volgograd changes time zone from +04 to +03 on 2020-12-27 at 02:00.
    (Thanks to Alexander Krivenyshev and Stepan Golosunov.)

  Changes to past timestamps

    Correct many pre-1986 transitions, fixing entries originally
    derived from Shanks.  The fixes include:
      - Australia: several 1917 through 1971 transitions
      - The Bahamas: several 1941 through 1945 transitions
      - Bermuda: several 1917 through 1956 transitions
      - Belize: several 1942 through 1968 transitions
      - Ghana: several 1915 through 1956 transitions
      - Israel and Palestine: several 1940 through 1985 transitions
      - Kenya and adjacent: several 1908 through 1960 transitions
      - Nigeria and adjacent: correcting LMT in Lagos, and several 1905
        through 1919 transitions
      - Seychelles: the introduction of standard time in 1907, not 1906
      - Vanuatu: DST in 1973-1974, and a corrected 1984 transition
    (Thanks to P Chan.)

    Because of the Australia change, Australia/Currie (King Island) is
    no longer needed, as it is identical to Australia/Hobart for all
    timestamps since 1970 and was therefore created by mistake.
    Australia/Currie has been moved to the 'backward' file and its
    corrected data moved to the 'backzone' file.

  Changes to past time zone abbreviations and DST flags

    To better match legislation in Turks and Caicos, the 2015 shift to
    year-round observance of -04 is now modeled as AST throughout before
    returning to Eastern Time with US DST in 2018, rather than as
    maintaining EDT until 2015-11-01.  (Thanks to P Chan.)

  Changes to documentation

    The zic man page now documents zic's coalescing of transitions
    when a zone falls back just before DST springs forward.


Release 2020d - 2020-10-21 11:24:13 -0700

  Briefly:
    Palestine ends DST earlier than predicted, on 2020-10-24.

  Changes to past and future timestamps

    Palestine ends DST on 2020-10-24 at 01:00, instead of 2020-10-31
    as previously predicted (thanks to Sharef Mustafa.)  Its
    2019-10-26 fall-back was at 00:00, not 01:00 (thanks to Steffen
    Thorsen.)  Its 2015-10-23 transition was at 01:00 not 00:00, and
    its spring 2020 transition was on March 28 at 00:00, not March 27
    (thanks to Pierre Cashon.)  This affects Asia/Gaza and
    Asia/Hebron.  Assume future spring and fall transitions will be on
    the Saturday preceding the last Sunday of March and October,
    respectively.


Release 2020c - 2020-10-16 11:15:53 -0700

  Briefly:
    Fiji starts DST later than usual, on 2020-12-20.

  Changes to future timestamps

    Fiji will start DST on 2020-12-20, instead of 2020-11-08 as
    previously predicted.  DST will still end on 2021-01-17.
    (Thanks to Raymond Kumar and Alan Mintz.)  Assume for now that
    the later-than-usual start date is a one-time departure from the
    recent pattern.

  Changes to build procedure

    Rearguard tarballs now contain an empty file pacificnew.
    Some older downstream software expects this file to exist.
    (Problem reported by Mike Cullinan.)


Release 2020b - 2020-10-06 18:35:04 -0700

  Briefly:
    Revised predictions for Morocco's changes starting in 2023.
    Canada's Yukon changes to -07 on 2020-11-01, not 2020-03-08.
    Macquarie Island has stayed in sync with Tasmania since 2011.
    Casey, Antarctica is at +08 in winter and +11 in summer.
    zic no longer supports -y, nor the TYPE field of Rules.

  Changes to future timestamps

    Morocco's spring-forward after Ramadan is now predicted to occur
    no sooner than two days after Ramadan, instead of one day.
    (Thanks to Milamber.)  The first altered prediction is for 2023,
    now predicted to spring-forward on April 30 instead of April 23.

  Changes to past and future timestamps

   Casey Station, Antarctica has been using +08 in winter and +11 in
   summer since 2018.  The most recent transition from +08 to +11 was
   2020-10-04 00:01.  Also, Macquarie Island has been staying in
   sync with Tasmania since 2011.  (Thanks to Steffen Thorsen.)

  Changes to past and future time zone abbreviations and DST flags

    Canada's Yukon, represented by America/Whitehorse and
    America/Dawson, changes its time zone rules from -08/-07 to
    permanent -07 on 2020-11-01, not on 2020-03-08 as 2020a had it.
    This change affects only the time zone abbreviation (MST vs PDT)
    and daylight saving flag for the period between the two dates.
    (Thanks to Andrew G. Smith.)

  Changes to past timestamps

    Correct several transitions for Hungary for 1918/1983.
    For example, the 1983-09-25 fall-back was at 01:00, not 03:00.
    (Thanks to Géza Nyáry.)  Also, the 1890 transition to standard
    time was on 11-01, not 10-01 (thanks to Michael Deckers).

    The 1891 French transition was on March 16, not March 15.  The
    1911-03-11 French transition was at midnight, not a minute later.
    Monaco's transitions were on 1892-06-01 and 1911-03-29, not
    1891-03-15 and 1911-03-11.  (Thanks to Michael Deckers.)

  Changes to code

    Support for zic's long-obsolete '-y YEARISTYPE' option has been
    removed and, with it, so has support for the TYPE field in Rule
    lines, which is now reserved for compatibility with earlier zic.
    These features were previously deprecated in release 2015f.
    (Thanks to Tim Parenti.)

    zic now defaults to '-b slim' instead of to '-b fat'.

    zic's new '-l -' and '-p -' options uninstall any existing
    localtime and posixrules files, respectively.

    The undocumented and ineffective tzsetwall function has been
    removed.

  Changes to build procedure

    The Makefile now defaults POSIXRULES to '-', so the posixrules
    feature (obsolete as of 2019b) is no longer installed by default.

  Changes to documentation and commentary

    The long-obsolete files pacificnew, systemv, and yearistype.sh have
    been removed from the distribution.  (Thanks to Tim Parenti.)


Release 2020a - 2020-04-23 16:03:47 -0700

  Briefly:
    Morocco springs forward on 2020-05-31, not 2020-05-24.
    Canada's Yukon advanced to -07 year-round on 2020-03-08.
    America/Nuuk renamed from America/Godthab.
    zic now supports expiration dates for leap second lists.

  Changes to future timestamps

    Morocco's second spring-forward transition in 2020 will be May 31,
    not May 24 as predicted earlier.  (Thanks to Semlali Naoufal.)
    Adjust future-year predictions to use the first Sunday after the
    day after Ramadan, not the first Sunday after Ramadan.

    Canada's Yukon, represented by America/Whitehorse and
    America/Dawson, advanced to -07 year-round, beginning with its
    spring-forward transition on 2020-03-08, and will not fall back on
    2020-11-01.  Although a government press release calls this
    "permanent Pacific Daylight Saving Time", we prefer MST for
    consistency with nearby Dawson Creek, Creston, and Fort Nelson.
    (Thanks to Tim Parenti.)

  Changes to past timestamps

    Shanghai observed DST in 1919.  (Thanks to Phake Nick.)

  Changes to timezone identifiers

    To reflect current usage in English better, America/Godthab has
    been renamed to America/Nuuk.  A backwards-compatibility link
    remains for the old name.

  Changes to code

    localtime.c no longer mishandles timestamps after the last
    transition in a TZif file with leap seconds and with daylight
    saving time transitions projected into the indefinite future.
    For example, with TZ='America/Los_Angeles' with leap seconds,
    zdump formerly reported a DST transition on 2038-03-14
    from 01:59:32.999... to 02:59:33 instead of the correct transition
    from 01:59:59.999... to 03:00:00.

    zic -L now supports an Expires line in the leapseconds file, and
    truncates the TZif output accordingly.  This propagates leap
    second expiration information into the TZif file, and avoids the
    abovementioned localtime.c bug as well as similar bugs present in
    many client implementations.  If no Expires line is present, zic
    -L instead truncates the TZif output based on the #expires comment
    present in leapseconds files distributed by tzdb 2018f and later;
    however, this usage is obsolescent.  For now, the distributed
    leapseconds file has an Expires line that is commented out, so
    that the file can be fed to older versions of zic which ignore the
    commented-out line.  Future tzdb distributions are planned to
    contain a leapseconds file with an Expires line.

    The configuration macros HAVE_TZNAME and USG_COMPAT should now be
    set to 1 if the system library supports the feature, and 2 if not.
    As before, these macros are nonzero if tzcode should support the
    feature, zero otherwise.

    The configuration macro ALTZONE now has the same values with the
    same meaning as HAVE_TZNAME and USG_COMPAT.

    The code's defense against CRLF in leap-seconds.list is now
    portable to POSIX awk.  (Problem reported by Deborah Goldsmith.)

    Although the undocumented tzsetwall function is not changed in
    this release, it is now deprecated in preparation for removal in
    future releases.  Due to POSIX requirements, tzsetwall has not
    worked for some time.  Any code that uses it should instead use
    tzalloc(NULL) or, if portability trumps thread-safety, should
    unset the TZ environment variable.

  Changes to commentary

    The Îles-de-la-Madeleine and the Listuguj reserve are noted as
    following America/Halifax, and comments about Yukon's "south" and
    "north" have been corrected to say "east" and "west".  (Thanks to
    Jeffery Nichols.)


Release 2019c - 2019-09-11 08:59:48 -0700

  Briefly:
    Fiji observes DST from 2019-11-10 to 2020-01-12.
    Norfolk Island starts observing Australian-style DST.

  Changes to future timestamps

    Fiji's next DST transitions will be 2019-11-10 and 2020-01-12
    instead of 2019-11-03 and 2020-01-19.  (Thanks to Raymond Kumar.)
    Adjust future guesses accordingly.

    Norfolk Island will observe Australian-style DST starting in
    spring 2019.  The first transition is on 2019-10-06.  (Thanks to
    Kyle Czech and Michael Deckers.)

  Changes to past timestamps

    Many corrections to time in Turkey from 1940 through 1985.
    (Thanks to Oya Vulaş via Alois Treindl, and to Kıvanç Yazan.)

    The Norfolk Island 1975-03-02 transition was at 02:00 standard
    time, not 02:00 DST.  (Thanks to Michael Deckers.)

    South Korea observed DST from 1948 through 1951.  Although this
    info was supposed to appear in release 2014j, a typo inadvertently
    suppressed the change.  (Thanks to Alois Treindl.)

    Detroit observed DST in 1967 and 1968 following the US DST rules,
    except that its 1967 DST began on June 14 at 00:01.  (Thanks to
    Alois Treindl for pointing out that the old data entries were
    probably wrong.)

    Fix several errors in pre-1970 transitions in Perry County, IN.
    (Thanks to Alois Triendl for pointing out the 1967/9 errors.)

    Edmonton did not observe DST in 1967 or 1969.  In 1946 Vancouver
    ended DST on 09-29 not 10-13, and Vienna ended DST on 10-07 not
    10-06.  In 1945 Königsberg (now Kaliningrad) switched from +01/+02
    to +02/+03 on 04-10 not 01-01, and its +02/+03 is abbreviated
    EET/EEST, not CET/CEST.  (Thanks to Alois Triendl.)  In 1946
    Königsberg switched to +03 on 04-07 not 01-01.

    In 1946 Louisville switched from CST to CDT on 04-28 at 00:01, not
    01-01 at 00:00.  (Thanks to Alois Treindl and Michael Deckers.)
    Also, it switched from CST to CDT on 1950-04-30, not 1947-04-27.

    The 1892-05-01 transition in Brussels was at 00:17:30, not at noon.
    (Thanks to Michael Deckers.)

  Changes to past time zone abbreviations and DST flags

    Hong Kong Winter Time, observed from 1941-10-01 to 1941-12-25,
    is now flagged as DST and is abbreviated HKWT not HKT.

  Changes to code

    leapseconds.awk now relies only on its input data, rather than
    also relying on its comments.  (Inspired by code from Dennis
    Ferguson and Chris Woodbury.)

    The code now defends against CRLFs in leap-seconds.list.
    (Thanks to Brian Inglis and Chris Woodbury.)

  Changes to documentation and commentary

    theory.html discusses leap seconds.  (Thanks to Steve Summit.)

    Nashville's newspapers dueled about the time of day in the 1950s.
    (Thanks to John Seigenthaler.)

    Liechtenstein observed Swiss DST in 1941/2.
    (Thanks to Alois Treindl.)


Release 2019b - 2019-07-01 00:09:53 -0700

  Briefly:
    Brazil no longer observes DST.
    'zic -b slim' outputs smaller TZif files; please try it out.
    Palestine's 2019 spring-forward transition was on 03-29, not 03-30.

  Changes to future timestamps

    Brazil has canceled DST and will stay on standard time indefinitely.
    (Thanks to Steffen Thorsen, Marcus Diniz, and Daniel Soares de
    Oliveira.)

    Predictions for Morocco now go through 2087 instead of 2037, to
    work around a problem on newlib when using TZif files output by
    zic 2019a or earlier.  (Problem reported by David Gauchard.)

  Changes to past and future timestamps

    Palestine's 2019 spring transition was 03-29 at 00:00, not 03-30
    at 01:00.  (Thanks to Sharef Mustafa and Even Scharning.)  Guess
    future transitions to be March's last Friday at 00:00.

  Changes to past timestamps

    Hong Kong's 1941-06-15 spring-forward transition was at 03:00, not
    03:30.  Its 1945 transition from JST to HKT was on 11-18 at 02:00,
    not 09-15 at 00:00.  In 1946 its spring-forward transition was on
    04-21 at 00:00, not the previous day at 03:30.  From 1946 through
    1952 its fall-back transitions occurred at 04:30, not at 03:30.
    In 1947 its fall-back transition was on 11-30, not 12-30.
    (Thanks to P Chan.)

  Changes to past time zone abbreviations

    Italy's 1866 transition to Rome Mean Time was on December 12, not
    September 22.  This affects only the time zone abbreviation for
    Europe/Rome between those dates.  (Thanks to Stephen Trainor and
    Luigi Rosa.)

  Changes affecting metadata only

    Add info about the Crimea situation in zone1970.tab and zone.tab.
    (Problem reported by Serhii Demediuk.)

  Changes to code

    zic's new -b option supports a way to control data bloat and to
    test for year-2038 bugs in software that reads TZif files.
    'zic -b fat' and 'zic -b slim' generate larger and smaller output;
    for example, changing from fat to slim shrinks the Europe/London
    file from 3648 to 1599 bytes, saving about 56%.  Fat and slim
    files represent the same set of timestamps and use the same TZif
    format as documented in tzfile(5) and in Internet RFC 8536.
    Fat format attempts to work around bugs or incompatibilities in
    older software, notably software that mishandles 64-bit TZif data
    or uses obsolete TZ strings like "EET-2EEST" that lack DST rules.
    Slim format is more efficient and does not work around 64-bit bugs
    or obsolete TZ strings.  Currently zic defaults to fat format
    unless you compile with -DZIC_BLOAT_DEFAULT=\"slim\"; this
    out-of-the-box default is intended to change in future releases
    as the buggy software often mishandles timestamps anyway.

    zic no longer treats a set of rules ending in 2037 specially.
    Previously, zic assumed that such a ruleset meant that future
    timestamps could not be predicted, and therefore omitted a
    POSIX-like TZ string in the TZif output.  The old behavior is no
    longer needed for current tzdata, and caused problems with newlib
    when used with older tzdata (reported by David Gauchard).

    zic no longer generates some artifact transitions.  For example,
    Europe/London no longer has a no-op transition in January 1996.

  Changes to build procedure

    tzdata.zi now assumes zic 2017c or later.  This shrinks tzdata.zi
    by a percent or so.

  Changes to documentation and commentary

    The Makefile now documents the POSIXRULES macro as being obsolete,
    and similarly, zic's -p POSIXRULES option is now documented as
    being obsolete.  Although the POSIXRULES feature still exists and
    works as before, in practice it is rarely used for its intended
    purpose, and it does not work either in the default reference
    implementation (for timestamps after 2037) or in common
    implementations such as GNU/Linux (for contemporary timestamps).
    Since POSIXRULES was designed primarily as a temporary transition
    facility for System V platforms that died off decades ago, it is
    being decommissioned rather than institutionalized.

    New info on Bonin Islands and Marcus (thanks to Wakaba and Phake Nick).


Release 2019a - 2019-03-25 22:01:33 -0700

  Briefly:
    Palestine "springs forward" on 2019-03-30 instead of 2019-03-23.
    Metlakatla "fell back" to rejoin Alaska Time on 2019-01-20 at 02:00.

  Changes to past and future timestamps

    Palestine will not start DST until 2019-03-30, instead of 2019-03-23 as
    previously predicted.  Adjust our prediction by guessing that spring
    transitions will be between 24 and 30 March, which matches recent practice
    since 2016.  (Thanks to Even Scharning and Tim Parenti.)

    Metlakatla ended its observance of Pacific standard time,
    rejoining Alaska Time, on 2019-01-20 at 02:00.  (Thanks to Ryan
    Stanley and Tim Parenti.)

  Changes to past timestamps

    Israel observed DST in 1980 (08-02/09-13) and 1984 (05-05/08-25).
    (Thanks to Alois Treindl and Isaac Starkman.)

  Changes to time zone abbreviations

    Etc/UCT is now a backward-compatibility link to Etc/UTC, instead
    of being a separate zone that generates the abbreviation "UCT",
    which nowadays is typically a typo.  (Problem reported by Isiah
    Meadows.)

  Changes to code

    zic now has an -r option to limit the time range of output data.
    For example, 'zic -r @1000000000' limits the output data to
    timestamps starting 1000000000 seconds after the Epoch.
    This helps shrink output size and can be useful for applications
    not needing the full timestamp history, such as TZDIST truncation;
    see Internet RFC 8536 section 5.1.  (Inspired by a feature request
    from Christopher Wong, helped along by bug reports from Wong and
    from Tim Parenti.)

  Changes to documentation

    Mention Internet RFC 8536 (February 2019), which documents TZif.

    tz-link.html now cites tzdata-meta
    <https://tzdata-meta.timtimeonline.com/>.


Release 2018i - 2018-12-30 11:05:43 -0800

  Briefly:
    São Tomé and Príncipe switches from +01 to +00 on 2019-01-01.

  Changes to future timestamps

    Due to a change in government, São Tomé and Príncipe switches back
    from +01 to +00 on 2019-01-01 at 02:00.  (Thanks to Vadim
    Nasardinov and Michael Deckers.)


Release 2018h - 2018-12-23 17:59:32 -0800

  Briefly:
    Qyzylorda, Kazakhstan moved from +06 to +05 on 2018-12-21.
    New zone Asia/Qostanay because Qostanay, Kazakhstan didn't move.
    Metlakatla, Alaska observes PST this winter only.
    Guess Morocco will continue to adjust clocks around Ramadan.
    Add predictions for Iran from 2038 through 2090.

  Changes to future timestamps

    Guess that Morocco will continue to fall back just before and
    spring forward just after Ramadan, the practice since 2012.
    (Thanks to Maamar Abdelkader.)  This means Morocco will observe
    negative DST during Ramadan in main and vanguard formats, and in
    rearguard format it stays in the +00 timezone and observes
    ordinary DST in all months other than Ramadan.  As before, extend
    this guesswork to the year 2037.  As a consequence, Morocco is
    scheduled to observe three DST transitions in some Gregorian years
    (e.g., 2033) due to the mismatch between the Gregorian and Islamic
    calendars.

    The table of exact transitions for Iranian DST has been extended.
    It formerly cut off before the year 2038 in a nod to 32-bit time_t.
    It now cuts off before 2091 as there is doubt about how the Persian
    calendar will treat 2091.  This change predicts DST transitions in
    2038-9, 2042-3, and 2046-7 to occur one day later than previously
    predicted.  As before, post-cutoff transitions are approximated.

  Changes to past and future timestamps

    Qyzylorda (aka Kyzylorda) oblast in Kazakhstan moved from +06 to
    +05 on 2018-12-21.  This is a zone split as Qostanay (aka
    Kostanay) did not switch, so create a zone Asia/Qostanay.

    Metlakatla moved from Alaska to Pacific standard time on 2018-11-04.
    It did not change clocks that day and remains on -08 this winter.
    (Thanks to Ryan Stanley.)  It will revert to the usual Alaska
    rules next spring, so this change affects only timestamps
    from 2018-11-04 through 2019-03-10.

  Change to past timestamps

    Kwajalein's 1993-08-20 transition from -12 to +12 was at 24:00,
    not 00:00.  I transcribed the time incorrectly from Shanks.
    (Thanks to Phake Nick.)

    Nauru's 1979 transition was on 02-10 at 02:00, not 05-01 at 00:00.
    (Thanks to Phake Nick.)

    Guam observed DST irregularly from 1959 through 1977.
    (Thanks to Phake Nick.)

    Hong Kong observed DST in 1941 starting 06-15 (not 04-01), then on
    10-01 changed standard time to +08:30 (not +08).  Its transition
    back to +08 after WWII was on 1945-09-15, not the previous day.
    Its 1904-10-30 change took effect at 01:00 +08 (not 00:00 LMT).
    (Thanks to Phake Nick, Steve Allen, and Joseph Myers.)  Also,
    its 1952 fallback was on 11-02 (not 10-25).

    This release contains many changes to timestamps before 1946 due
    to Japanese possession or occupation of Pacific/Chuuk,
    Pacific/Guam, Pacific/Kosrae, Pacific/Kwajalein, Pacific/Majuro,
    Pacific/Nauru, Pacific/Palau, and Pacific/Pohnpei.
    (Thanks to Phake Nick.)

    Assume that the Spanish East Indies was like the Philippines and
    observed American time until the end of 1844.  This affects
    Pacific/Chuuk, Pacific/Kosrae, Pacific/Palau, and Pacific/Pohnpei.

  Changes to past tm_isdst flags

    For the recent Morocco change, the tm_isdst flag should be 1 from
    2018-10-27 00:00 to 2018-10-28 03:00.  (Thanks to Michael Deckers.)
    Give a URL to the official decree.  (Thanks to Matt Johnson.)


Release 2018g - 2018-10-26 22:22:45 -0700

  Briefly:
    Morocco switches to permanent +01 on 2018-10-28.

  Changes to future timestamps

    Morocco switches from +00/+01 to permanent +01 effective 2018-10-28,
    so its clocks will not fall back as previously scheduled.
    (Thanks to Mohamed Essedik Najd and Brian Inglis.)

  Changes to code

    When generating TZif files with leap seconds, zic no longer uses a
    format that trips up older 32-bit clients, fixing a bug introduced
    in 2018f.  (Reported by Daniel Fischer.)  Also, the zic workaround
    for QTBUG-53071 now also works for TZif files with leap seconds.

    The translator to rearguard format now rewrites the line
    "Rule Japan 1948 1951 - Sep Sat>=8 25:00 0 S" to
    "Rule Japan 1948 1951 - Sep Sun>=9  1:00 0 S".
    This caters to zic before 2007 and to Oracle TZUpdater 2.2.0
    and earlier.  (Reported by Christos Zoulas.)

  Changes to past time zone abbreviations

    Change HDT to HWT/HPT for WWII-era abbreviations in Hawaii.
    This reverts to 2011h, as the abbreviation change in 2011i was
    likely inadvertent.

  Changes to documentation

    tzfile.5 has new sections on interoperability issues.


Release 2018f - 2018-10-18 00:14:18 -0700

  Briefly:
  Volgograd moves from +03 to +04 on 2018-10-28.
  Fiji ends DST 2019-01-13, not 2019-01-20.
  Most of Chile changes DST dates, effective 2019-04-06.

  Changes to future timestamps

    Volgograd moves from +03 to +04 on 2018-10-28 at 02:00.
    (Thanks to Alexander Fetisov and Stepan Golosunov.)

    Fiji ends DST 2019-01-13 instead of the 2019-01-20 previously
    predicted.  (Thanks to Raymond Kumar.)  Adjust future predictions
    accordingly.

    Most of Chile will end DST on the first Saturday in April at 24:00 mainland
    time, and resume DST on the first Saturday in September at 24:00 mainland
    time.  The changes are effective from 2019-04-06, and do not affect the
    Magallanes region modeled by America/Punta_Arenas.  (Thanks to Juan Correa
    and Tim Parenti.)  Adjust future predictions accordingly.

  Changes to past timestamps

    The 2018-05-05 North Korea 30-minute time zone change took place
    at 23:30 the previous day, not at 00:00 that day.

    China's 1988 spring-forward transition was on April 17, not
    April 10.  Its DST transitions in 1986/91 were at 02:00, not 00:00.
    (Thanks to P Chan.)

    Fix several issues for Macau before 1992.  Macau's pre-1904 LMT
    was off by 10 s.  Macau switched to +08 in 1904 not 1912, and
    temporarily switched to +09/+10 during World War II.  Macau
    observed DST in 1942/79, not 1961/80, and there were several
    errors for transition times and dates.  (Thanks to P Chan.)

    The 1948-1951 fallback transitions in Japan were at 25:00 on
    September's second Saturday, not at 24:00.  (Thanks to Phake Nick.)
    zic turns this into 01:00 on the day after September's second
    Saturday, which is the best that POSIX or C platforms can do.

    Incorporate 1940-1949 Asia/Shanghai DST transitions from a 2014
    paper by Li Yu, replacing more-questionable data from Shanks.

  Changes to time zone abbreviations

    Use "PST" and "PDT" for Philippine time.  (Thanks to Paul Goyette.)

  Changes to code

    zic now always generates TZif files where time type 0 is used for
    timestamps before the first transition.  This simplifies the
    reading of TZif files and should not affect behavior of existing
    TZif readers because the same set of time types is used; only
    their internal indexes may have changed.  This affects only the
    legacy zones EST5EDT, CST6CDT, MST7MDT, PST8PDT, CET, MET, and
    EET, which previously used nonzero types for these timestamps.

    Because of the type 0 change, zic no longer outputs a dummy
    transition at time -2**59 (before the Big Bang), as clients should
    no longer need this to handle historical timestamps correctly.
    This reverts a change introduced in 2013d and shrinks most TZif
    files by a few bytes.

    zic now supports negative time-of-day in Rule and Leap lines, e.g.,
    "Rule X min max - Apr lastSun -6:00 1:00 -" means the transition
    occurs at 18:00 on the Saturday before the last Sunday in April.
    This behavior was documented in 2018a but the code did not
    entirely match the documentation.

    localtime.c no longer requires at least one time type in TZif
    files that lack transitions or have a POSIX-style TZ string.  This
    future-proofs the code against possible future extensions to the
    format that would allow TZif files with POSIX-style TZ strings and
    without transitions or time types.

    A read-access subscript error in localtime.c has been fixed.
    It could occur only in TZif files with timecnt == 0, something that
    does not happen in practice now but could happen in future versions.

    localtime.c no longer ignores TZif POSIX-style TZ strings that
    specify only standard time.  Instead, these TZ strings now
    override the default time type for timestamps after the last
    transition (or for all timestamps if there are no transitions),
    just as DST strings specifying DST have always done.

    leapseconds.awk now outputs "#updated" and "#expires" comments,
    and supports leap seconds at the ends of months other than June
    and December.  (Inspired by suggestions from Chris Woodbury.)

  Changes to documentation

    New restrictions: A Rule name must start with a character that
    is neither an ASCII digit nor "-" nor "+", and an unquoted name
    should not use characters in the set "!$%&'()*,/:;<=>?@[\]^`{|}~".
    The latter restriction makes room for future extensions (a
    possibility noted by Tom Lane).

    tzfile.5 now documents what time types apply before the first and
    after the last transition, if any.

    Documentation now uses the spelling "timezone" for a TZ setting
    that determines timestamp history, and "time zone" for a
    geographic region currently sharing the same standard time.

    The name "TZif" is now used for the tz binary data format.

    tz-link.htm now mentions the A0 TimeZone Migration utilities.
    (Thanks to Aldrin Martoq for the link.)

  Changes to build procedure

    New 'make' target 'rearguard_tarballs' to build the rearguard
    tarball only.  This is a convenience on platforms that lack lzip
    if you want to build the rearguard tarball.  (Problem reported by
    Deborah Goldsmith.)

    tzdata.zi is now more stable from release to release.  (Problem
    noted by Tom Lane.)  It is also a bit shorter.

    tzdata.zi now can contain comment lines documenting configuration
    information, such as which data format was selected, which input
    files were used, and how leap seconds are treated.  (Problems
    noted by Lester Caine and Brian Inglis.)  If the Makefile defaults
    are used these comment lines are absent, for backward
    compatibility.  A redistributor intending to alter its copy of the
    files should also append "-LABEL" to the 'version' file's first
    line, where "LABEL" identifies the redistributor's change.


Release 2018e - 2018-05-01 23:42:51 -0700

  Briefly:

    North Korea switches back to +09 on 2018-05-05.
    The main format uses negative DST again, for Ireland etc.
    'make tarballs' now also builds a rearguard tarball.
    New 's' and 'd' suffixes in SAVE columns of Rule and Zone lines.

  Changes to past and future timestamps

    North Korea switches back from +0830 to +09 on 2018-05-05.
    (Thanks to Kang Seonghoon, Arthur David Olson, Seo Sanghyeon,
    and Tim Parenti.)

    Bring back the negative-DST changes of 2018a, except be more
    compatible with data parsers that do not support negative DST.
    Also, this now affects historical timestamps in Namibia and the
    former Czechoslovakia, not just Ireland.  The main format now uses
    negative DST to model timestamps in Europe/Dublin (from 1971 on),
    Europe/Prague (1946/7), and Africa/Windhoek (1994/2017).  This
    does not affect UT offsets, only time zone abbreviations and the
    tm_isdst flag.  Also, this does not affect rearguard or vanguard
    formats; effectively the main format now uses vanguard instead of
    rearguard format.  Data parsers that do not support negative DST
    can still use data from the rearguard tarball described below.

  Changes to build procedure

    The command 'make tarballs' now also builds the tarball
    tzdataVERSION-rearguard.tar.gz, which is like tzdataVERSION.tar.gz
    except that it uses rearguard format intended for trailing-edge
    data parsers.

  Changes to data format and to code

    The SAVE column of Rule and Zone lines can now have an 's' or 'd'
    suffix, which specifies whether the adjusted time is standard time
    or daylight saving time.  If no suffix is given, daylight saving
    time is used if and only if the SAVE column is nonzero; this is
    the longstanding behavior.  Although this new feature is not used
    in tzdata, it could be used to specify the legal time in Namibia
    1994-2017, as opposed to the popular time (see below).

  Changes to past timestamps

    From 1994 through 2017 Namibia observed DST in winter, not summer.
    That is, it used negative DST, as Ireland still does.  This change
    does not affect UTC offsets; it affects only the tm_isdst flag and
    the abbreviation used during summer, which is now CAT, not WAST.
    Although (as noted by Michael Deckers) summer and winter time were
    both simply called "standard time" in Namibian law, in common
    practice winter time was considered to be DST (as noted by Stephen
    Colebourne).  The full effect of this change is only in vanguard
    and main format; in rearguard format, the tm_isdst flag is still
    zero in winter and nonzero in summer.

    In 1946/7 Czechoslovakia also observed negative DST in winter.
    The full effect of this change is only in vanguard and main
    formats; in rearguard format, it is modeled as plain GMT without
    daylight saving.  Also, the dates of some 1944/5 DST transitions
    in Czechoslovakia have been changed.


Release 2018d - 2018-03-22 07:05:46 -0700

  Briefly:

  Palestine starts DST a week earlier in 2018.
  Add support for vanguard and rearguard data consumers.
  Add subsecond precision to source data format, though not to data.

  Changes to future timestamps

    In 2018, Palestine starts DST on March 24, not March 31.
    Adjust future predictions accordingly.  (Thanks to Sharef Mustafa.)

  Changes to past and future timestamps

    Casey Station in Antarctica changed from +11 to +08 on 2018-03-11
    at 04:00.  (Thanks to Steffen Thorsen.)

  Changes to past timestamps

    Historical transitions for Uruguay, represented by
    America/Montevideo, have been updated per official legal documents,
    replacing previous data mainly originating from the inventions of
    Shanks & Pottenger.  This has resulted in adjustments ranging from
    30 to 90 minutes in either direction over at least two dozen
    distinct periods ranging from one day to several years in length.
    A mere handful of pre-1991 transitions are unaffected; data since
    then has come from more reliable contemporaneous reporting.  These
    changes affect various timestamps in 1920-1923, 1936, 1939,
    1942-1943, 1959, 1966-1970, 1972, 1974-1980, and 1988-1990.
    Additionally, Uruguay's pre-standard-time UT offset has been
    adjusted westward by 7 seconds, from UT-03:44:44 to UT-03:44:51, to
    match the location of the Observatory of the National Meteorological
    Institute in Montevideo.
    (Thanks to Jeremie Bonjour, Tim Parenti, and Michael Deckers.)

    East Kiribati skipped New Year's Eve 1994, not New Year's Day 1995.
    (Thanks to Kerry Shetline.)

    Fix the 1912-01-01 transition for Portugal and its colonies.
    This transition was at 00:00 according to the new UT offset, not
    according to the old one.  Also assume that Cape Verde switched on
    the same date as the rest, not in 1907.  This affects
    Africa/Bissau, Africa/Sao_Tome, Asia/Macau, Atlantic/Azores,
    Atlantic/Cape_Verde, Atlantic/Madeira, and Europe/Lisbon.
    (Thanks to Michael Deckers.)

    Fix an off-by-1 error for pre-1913 timestamps in Jamaica and in
    Turks & Caicos.

  Changes to past time zone abbreviations

    MMT took effect in Uruguay from 1908-06-10, not 1898-06-28.  There
    is no clock change associated with the transition.

  Changes to build procedure

    The new DATAFORM macro in the Makefile lets the installer choose
    among three source data formats.  The idea is to lessen downstream
    disruption when data formats are improved.

    * DATAFORM=vanguard installs from the latest, bleeding-edge
      format.  DATAFORM=main (the default) installs from the format
      used in the 'africa' etc. files.  DATAFORM=rearguard installs
      from a trailing-edge format.  Eventually, elements of today's
      vanguard format should move to the main format, and similarly
      the main format's features should eventually move to the
      rearguard format.

    * In the current version, the main and rearguard formats are
      identical and match that of 2018c, so this change does not
      affect default behavior.  The vanguard format currently contains
      one feature not in the main format: negative SAVE values.  This
      improves support for Ireland, which uses Irish Standard Time
      (IST, UTC+01) in summer and GMT (UTC) in winter.  tzcode has
      supported negative SAVE values for decades, and this feature
      should move to the main format soon.  However, it will not move
      to the rearguard format for quite some time because some
      downstream parsers do not support it.

    * The build procedure constructs three files vanguard.zi, main.zi,
      and rearguard.zi, one for each format.  Although the files
      represent essentially the same data, they may have minor
      discrepancies that users are not likely to notice.  The files
      are intended for downstream data consumers and are not
      installed.  Zoneinfo parsers that do not support negative SAVE values
      should start using rearguard.zi, so that they will be unaffected
      when the negative-DST feature moves from vanguard to main.
      Bleeding-edge Zoneinfo parsers that support the new features
      already can use vanguard.zi; in this respect, current tzcode is
      bleeding-edge.

    The Makefile should now be safe for parallelized builds, and 'make
    -j to2050new.tzs' is now much faster on a multiprocessor host
    with GNU Make.

    When built with -DSUPPRESS_TZDIR, the tzcode library no longer
    prepends TZDIR/ to file names that do not begin with '/'.  This is
    not recommended for general use, due to its security implications.
    (From a suggestion by Manuela Friedrich.)

  Changes to code

    zic now accepts subsecond precision in expressions like
    00:19:32.13, which is approximately the legal time of the
    Netherlands from 1835 to 1937.  However, because it is
    questionable whether the few recorded uses of non-integer offsets
    had subsecond precision in practice, there are no plans for tzdata
    to use this feature.  (Thanks to Steve Allen for pointing out
    the limitations of historical data in this area.)

    The code is a bit more portable to MS-Windows.  Installers can
    compile with -DRESERVE_STD_EXT_IDS on MS-Windows platforms that
    reserve identifiers like 'localtime'.  (Thanks to Manuela
    Friedrich.)

  Changes to documentation and commentary

    theory.html now outlines tzdb's extensions to POSIX's model for
    civil time, and has a section "POSIX features no longer needed"
    that lists POSIX API components that are now vestigial.
    (From suggestions by Steve Summit.)  It also better distinguishes
    time zones from tz regions.  (From a suggestion by Guy Harris.)

    Commentary is now more consistent about using the phrase "daylight
    saving time", to match the C name tm_isdst.  Daylight saving time
    need not occur in summer, and need not have a positive offset from
    standard time.

    Commentary about historical transitions in Uruguay has been expanded
    with links to many relevant legal documents.
    (Thanks to Tim Parenti.)

    Commentary now uses some non-ASCII characters with Unicode value
    less than U+0100, as they can be useful and should work even with
    older editors such as XEmacs.


Release 2018c - 2018-01-22 23:00:44 -0800

  Briefly:
  Revert Irish changes that relied on negative SAVE values.

  Changes to tm_isdst

    Revert the 2018a change to Europe/Dublin.  As before, this change
    does not affect UT offsets or abbreviations; it affects only
    whether timestamps are considered to be standard time or
    daylight-saving time, as expressed in the tm_isdst flag of C's
    struct tm type.  This reversion is intended to be a temporary
    workaround for problems discovered with downstream uses of
    releases 2018a and 2018b, which implemented Irish time by using
    negative SAVE values in the Eire rules of the 'europe' file.
    Although negative SAVE values have been part of tzcode for many
    years and are supported by many platforms, they were not
    documented before 2018a and ICU and OpenJDK do not currently
    support them.  A mechanism to export data to platforms lacking
    support for negative DST is planned to be developed before the
    change is reapplied.  (Problems reported by Deborah Goldsmith and
    Stephen Colebourne.)

  Changes to past timestamps

    Japanese DST transitions (1948-1951) were Sundays at 00:00, not
    Saturdays or Sundays at 02:00.  (Thanks to Takayuki Nikai.)

  Changes to build procedure

    The build procedure now works around mawk 1.3.3's lack of support
    for character class expressions.  (Problem reported by Ohyama.)


Release 2018b - 2018-01-17 23:24:48 -0800

  Briefly:
  Fix a packaging problem in tz2018a, which was missing 'pacificnew'.

  Changes to build procedure

    The distribution now contains the file 'pacificnew' again.
    This file was inadvertantly omitted in the 2018a distribution.
    (Problem reported by Matias Fonzo.)


Release 2018a - 2018-01-12 22:29:21 -0800

  Briefly:
  São Tomé and Príncipe switched from +00 to +01.
  Brazil's DST will now start on November's first Sunday.
  Ireland's standard time is now in the summer, not the winter.
  Use Debian-style installation locations, instead of 4.3BSD-style.
  New zic option -t.

  Changes to past and future timestamps

    São Tomé and Príncipe switched from +00 to +01 on 2018-01-01 at
    01:00.  (Thanks to Steffen Thorsen and Michael Deckers.)

  Changes to future timestamps

    Starting in 2018 southern Brazil will begin DST on November's
    first Sunday instead of October's third Sunday.  (Thanks to
    Steffen Thorsen.)

  Changes to past timestamps

    A discrepancy of 4 s in timestamps before 1931 in South Sudan has
    been corrected.  The 'backzone' and 'zone.tab' files did not agree
    with the 'africa' and 'zone1970.tab' files.  (Problem reported by
    Michael Deckers.)

    The abbreviation invented for Bolivia Summer Time (1931-2) is now
    BST instead of BOST, to be more consistent with the convention
    used for Latvian Summer Time (1918-9) and for British Summer Time.

  Changes to tm_isdst

    Change Europe/Dublin so that it observes Irish Standard Time (UT
    +01) in summer and GMT (as negative daylight-saving) in winter,
    instead of observing standard time (GMT) in winter and Irish
    Summer Time (UT +01) in summer.  This change does not affect UT
    offsets or abbreviations; it affects only whether timestamps are
    considered to be standard time or daylight-saving time, as
    expressed in the tm_isdst flag of C's struct tm type.
    (Discrepancy noted by Derick Rethans.)

  Changes to build procedure

    The default installation locations have been changed to mostly
    match Debian circa 2017, instead of being designed as an add-on to
    4.3BSD circa 1986.  This affects the Makefile macros TOPDIR,
    TZDIR, MANDIR, and LIBDIR.  New Makefile macros TZDEFAULT, USRDIR,
    USRSHAREDIR, BINDIR, ZDUMPDIR, and ZICDIR let installers tailor
    locations more precisely.  (This responds to suggestions from
    Brian Inglis and from Steve Summit.)

    The default installation procedure no longer creates the
    backward-compatibility link US/Pacific-New, which causes
    confusion during user setup (e.g., see Debian bug 815200).
    Use 'make BACKWARD="backward pacificnew"' to create the link
    anyway, for now.  Eventually we plan to remove the link entirely.

    tzdata.zi now contains a version-number comment.
    (Suggested by Tom Lane.)

    The Makefile now quotes values like BACKWARD more carefully when
    passing them to the shell.  (Problem reported by Zefram.)

    Builders no longer need to specify -DHAVE_SNPRINTF on platforms
    that have snprintf and use pre-C99 compilers.  (Problem reported
    by Jon Skeet.)

  Changes to code

    zic has a new option -t FILE that specifies the location of the
    file that determines local time when TZ is unset.  The default for
    this location can be configured via the new TZDEFAULT makefile
    macro, which defaults to /etc/localtime.

    Diagnostics and commentary now distinguish UT from UTC more
    carefully; see theory.html for more information about UT vs UTC.

    zic has been ported to GCC 8's -Wstringop-truncation option.
    (Problem reported by Martin Sebor.)

  Changes to documentation and commentary

    The zic man page now documents the longstanding behavior that
    times and years can be out of the usual range, with negative times
    counting backwards from midnight and with year 0 preceding year 1.
    (Problem reported by Michael Deckers.)

    The theory.html file now mentions the POSIX limit of six chars
    per abbreviation, and lists alphabetic abbreviations used.

    The files tz-art.htm and tz-link.htm have been renamed to
    tz-art.html and tz-link.html, respectively, for consistency with
    other file names and to simplify web server configuration.
```