### PR TITLE
Upgrade setproctitle

### DIFF
--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -109,7 +109,7 @@ requests-file==1.5.1
 rollbar==0.16.1
 s3transfer==0.4.2
 scandir==1.10.0
-setproctitle==1.1.10
+setproctitle==1.2.2
 setuptools==44.0.0
 simplegeneric==0.8.1
 singledispatch==3.4.0.3

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -109,7 +109,8 @@ requests-file==1.5.1
 rollbar==0.16.1
 s3transfer==0.4.2
 scandir==1.10.0
-setproctitle==1.2.2
+setproctitle==1.1.10; python_version < '3.0'
+setproctitle==1.2.2; python_version >= '3.0'
 setuptools==44.0.0
 simplegeneric==0.8.1
 singledispatch==3.4.0.3


### PR DESCRIPTION
Starting upgrades to versions explicitly tested on Python 3.8. This is the last version of setproctitle.

For the time being I need to keep versions that work on Python 2.7 conditionally. I'll get rid off them once I get green light to ditch Python 2 support.

Changelog

```
1.2.2

-------------
  
  - Fixed Windows build (issues 89, 90).
  - Added wheel packages for Windows (issues 47, 90).
  - Added wheel packages for aarch64 (issues 95).

1.2.1

-------------
  
  - Fixed segfault after ``os.environ.clear()`` (issue 88).

1.2

~~~~~~~~~~~
  
  - added ``getthreadtitle()`` and ``setthreadtitle()``.
  - Initialisation of the module moved to the first usage: importing the module
  doesn't cause side effects.
  - Manage much longer command lines (52)
  - Improved build on BSD, dropped ancient versions (issue 67).
  - Fixed build for Python 3.8 (66, 72)
  - Added support for Python 3.9
  - Dropped support for Python < 3.6
  ```