### PR TITLE
Upgrade pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ "${PYTHON_VERSION}" != "3.6" ] ; \
 
 RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
   python"${PYTHON_VERSION}" get-pip.py && \
-  python"${PYTHON_VERSION}" -m pip install --upgrade pip==20.3.4 && \
+  python"${PYTHON_VERSION}" -m pip install --upgrade pip==$( if [ "${PYTHON_VERSION}" = "2.7" ] ; then echo 20.3.4; else echo 21.3.1; fi) && \
   python"${PYTHON_VERSION}" -m pip install virtualenv==20.8.1
 
 RUN mkdir /etc/inboxapp && \


### PR DESCRIPTION
This is the last version of pip. It only works on Python 3 so it's conditionally guarded until we drop Python 2.