### PR TITLE
HTMLParser handle unknown marked sections

### DIFF
--- a/inbox/util/html.py
+++ b/inbox/util/html.py
@@ -62,6 +62,11 @@ class HTMLTagStripper(HTMLParser):
             except (ValueError, OverflowError):
                 return
 
+    if (3,) <= sys.version_info < (3, 10):
+
+        def error(self, message):
+            raise HTMLParseError(message)
+
     def handle_entityref(self, d):
         try:
             val = unichr(name2codepoint[d])

--- a/tests/general/test_html_parsing.py
+++ b/tests/general/test_html_parsing.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Regression tests for HTML parsing."""
-from inbox.util.html import strip_tags
+import pytest
+
+from inbox.util.html import HTMLParseError, strip_tags
 
 
 def test_strip_tags():
@@ -9,6 +11,17 @@ def test_strip_tags():
         'check out this <a href="http://example.com">link</a> yo!</div>'
     )
     assert strip_tags(text).strip() == "check out this link yo!"
+
+    # MS Word conditional marked section
+    text = "<![if word]>content<![endif]>"
+
+    assert strip_tags(text).strip() == "content"
+
+    # Unknown marked section
+    text = """<![FOR]>"""
+
+    with pytest.raises(HTMLParseError):
+        strip_tags(text)
 
 
 def test_preserve_refs():


### PR DESCRIPTION
This is a fix for a bug in Python 3's HTMLParser until Python 3.10. 

HTML can contain all the kinds of weird stuff and we were getting errors about `<![FOR]>`. We turn those errors into errors that the message processing pipeline understands and will not try to save HTML snippet for such emails.

https://bugs.python.org/issue31844
https://github.com/python/cpython/pull/8562/files#diff-7304624ffcc8be1268e5f86ebf1723034477694ce33456dc330f9c03f2d1e84f

