### PR TITLE
pytest warnings

### DIFF
--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -103,7 +103,7 @@ class MockDNSResolver(object):
         return [MockAnswer(e) for e in self._registry[record_type][domain]]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_dns_resolver(monkeypatch):
     dns_resolver = MockDNSResolver()
     monkeypatch.setattr("inbox.util.url.dns_resolver", dns_resolver)
@@ -111,7 +111,7 @@ def mock_dns_resolver(monkeypatch):
     monkeypatch.undo()
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def dump_dns_queries(monkeypatch):
     original_query = dns.resolver.Resolver.query
     query_results = {"ns": {}, "mx": {}}
@@ -277,7 +277,7 @@ class MockIMAPClient(object):
         pass
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_imapclient(monkeypatch):
     conn = MockIMAPClient()
     monkeypatch.setattr(
@@ -296,7 +296,7 @@ class MockSMTPClient(object):
         pass
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mock_smtp_get_connection(monkeypatch):
     client = MockSMTPClient()
 

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -180,7 +180,6 @@ def test_api_update_title(db, api_client, calendar, default_account):
 import pytest
 
 
-@pytest.mark.only
 def test_api_pessimistic_update(db, api_client, calendar, default_account):
     e_data = {
         "title": "",

--- a/tests/api/test_metrics_api.py
+++ b/tests/api/test_metrics_api.py
@@ -12,7 +12,7 @@ class TestGlobalDeltas:
     def clear_redis(self):
         redis_txn.flushdb()
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def unauthed_api_client(self, db, default_namespace):
         from inbox.api.srv import app
 

--- a/tests/api/test_streaming.py
+++ b/tests/api/test_streaming.py
@@ -12,7 +12,7 @@ GEVENT_EPSILON = 0.5  # Greenlet switching time. VMs on Macs suck :()
 LONGPOLL_EPSILON = 2 + GEVENT_EPSILON  # API implementation polls every second
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def streaming_test_client(db):
     from inbox.api.srv import app
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ if sys.version_info < (3,):
 
     gevent_openssl.monkey_patch()
 
-from pytest import fixture, yield_fixture
+from pytest import fixture
 
 from inbox.util.testutils import files  # noqa
 from inbox.util.testutils import mock_dns_resolver  # noqa
@@ -26,7 +26,7 @@ from tests.util.base import *  # noqa
 from inbox.util.testutils import dump_dns_queries  # noqa; noqa
 
 
-@yield_fixture
+@fixture
 def api_client(db, default_namespace):
     from inbox.api.srv import app
 

--- a/tests/events/test_ics_parsing.py
+++ b/tests/events/test_ics_parsing.py
@@ -122,7 +122,6 @@ def test_event_update(db, default_account, message):
 # This test checks that:
 # 1. we're processing invites we've sent to ourselves.
 # 2. update only update events in the "emailed events" calendar.
-@pytest.mark.only
 def test_self_sent_update(db, default_account, message):
 
     # Create the calendars

--- a/tests/general/test_ignition.py
+++ b/tests/general/test_ignition.py
@@ -7,7 +7,7 @@ from inbox.util.sharding import get_shard_schemas
 from inbox.util.testutils import create_test_db, setup_test_db
 
 
-@pytest.yield_fixture(scope="function")
+@pytest.fixture(scope="function")
 def base_db(config):
     from inbox.ignition import engine_manager
 

--- a/tests/general/test_message_parsing.py
+++ b/tests/general/test_message_parsing.py
@@ -565,7 +565,6 @@ def test_attachments_emoji_filename_parsing(
     assert m.attachments[0].content_disposition == "inline"
 
 
-@pytest.mark.only
 def test_long_message_id(db, default_account, thread, raw_message_with_long_message_id):
     m = create_from_synced(db, default_account, raw_message_with_long_message_id)
     m.thread = thread

--- a/tests/imap/test_actions.py
+++ b/tests/imap/test_actions.py
@@ -35,7 +35,6 @@ from inbox.util.testutils import mock_imapclient  # noqa
 from tests.util.base import add_fake_category, add_fake_imapuid
 
 
-@pytest.mark.only
 def test_draft_updates(db, default_account, mock_imapclient):
     # Set up folder list
     mock_imapclient._data["Drafts"] = {}
@@ -198,7 +197,7 @@ def test_folder_crud(db, default_account, mock_imapclient, obj_type):
     assert db.session.query(Category).get(category_id) is None
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_syncback_task(monkeypatch):
     # Ensures 'create_event' actions fail and all others succeed
     def function_for_action(name):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -11,3 +11,6 @@ filterwarnings =
     ignore:PY_SSIZE_T_CLEAN will be required
     # MySQLdb/__init__.py:85: DeprecationWarning: waiter is deprecated and will be removed in 1.4.
     ignore:waiter is deprecated and will be removed
+
+markers =
+    networkrequired: needs internet access

--- a/tests/scheduling/test_syncback_logic.py
+++ b/tests/scheduling/test_syncback_logic.py
@@ -20,7 +20,7 @@ def purge_accounts_and_actions():
             db_session.commit()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_enginemanager(monkeypatch):
     engines = {k: None for k in range(0, 6)}
     monkeypatch.setattr("inbox.ignition.engine_manager.engines", engines)
@@ -28,7 +28,7 @@ def patched_enginemanager(monkeypatch):
     monkeypatch.undo()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def patched_task(monkeypatch):
     def uses_crispin_client(self):
         return False

--- a/tests/security/test_smtp_ssl.py
+++ b/tests/security/test_smtp_ssl.py
@@ -54,7 +54,7 @@ def run_bad_cert_smtp_server():
     asyncore.loop()
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def bad_cert_smtp_server():
     s = gevent.spawn(run_bad_cert_smtp_server)
     yield s

--- a/tests/system/test_events.py
+++ b/tests/system/test_events.py
@@ -16,7 +16,7 @@ from .conftest import calendar_accounts, timeout_loop
 random.seed(None)
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def real_db():
     """A fixture to get access to the real mysql db. We need this
     to log in to providers like gmail to check that events changes

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 import mock
 from flanker import mime
 from mockredis import mock_strict_redis_client
-from pytest import fixture, yield_fixture
+from pytest import fixture
 
 from inbox.util.testutils import MockIMAPClient, setup_test_db  # noqa
 
@@ -47,7 +47,7 @@ def dbloader(config):
     setup_test_db()
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def db(dbloader):
     from inbox.ignition import engine_manager
     from inbox.models.session import new_session
@@ -60,7 +60,7 @@ def db(dbloader):
     engine.session.close()
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def empty_db(config):
     from inbox.ignition import engine_manager
     from inbox.models.session import new_session
@@ -72,7 +72,7 @@ def empty_db(config):
     engine.session.close()
 
 
-@yield_fixture
+@fixture
 def test_client(db):
     from inbox.api.srv import app
 
@@ -81,7 +81,7 @@ def test_client(db):
         yield c
 
 
-@yield_fixture
+@fixture
 def webhooks_client(db):
     from inbox.api.srv import app
 
@@ -147,34 +147,34 @@ def delete_default_accounts(db):
     db.session.commit()
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def default_account(db, config, redis_mock):
     yield make_default_account(db, config)
     delete_default_accounts(db)
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def default_namespace(db, default_account):
     yield default_account.namespace
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def default_accounts(db, config, redis_mock):
     yield [make_default_account(db, config) for _ in range(3)]
     delete_default_accounts(db)
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def default_namespaces(db, default_accounts):
     yield [account.namespace for account in default_accounts]
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def generic_account(db):
     yield add_generic_imap_account(db.session)
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def gmail_account(db):
     yield add_fake_gmail_account(
         db.session,
@@ -553,13 +553,13 @@ def add_fake_category(db_session, namespace_id, display_name, name=None):
     return category
 
 
-@yield_fixture
+@fixture
 def thread(db, default_namespace):
     yield add_fake_thread(db.session, default_namespace.id)
     delete_threads(db.session)
 
 
-@yield_fixture
+@fixture
 def message(db, default_namespace, thread):
     yield add_fake_message(db.session, default_namespace.id, thread)
     delete_messages(db.session)
@@ -586,25 +586,25 @@ def custom_label(db, default_account):
     return Label.find_or_create(db.session, default_account, "Kraftwerk", "")
 
 
-@yield_fixture
+@fixture
 def contact(db, default_account):
     yield add_fake_contact(db.session, default_account.namespace.id)
     delete_contacts(db.session)
 
 
-@yield_fixture
+@fixture
 def imapuid(db, default_account, message, folder):
     yield add_fake_imapuid(db.session, default_account.id, message, folder, 2222)
     delete_imapuids(db.session)
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def calendar(db, default_account):
     yield add_fake_calendar(db.session, default_account.namespace.id)
     delete_calendars(db.session)
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def other_calendar(db, default_account):
     yield add_fake_calendar(
         db.session, default_account.namespace.id, uid="uid2", name="Calendar 2"
@@ -612,14 +612,14 @@ def other_calendar(db, default_account):
     delete_calendars(db.session)
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def event(db, default_account):
     yield add_fake_event(db.session, default_account.namespace.id)
     delete_events(db.session)
     delete_calendars(db.session)
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def imported_event(db, default_account, message):
     ev = add_fake_event(db.session, default_account.namespace.id)
     ev.message = message
@@ -688,7 +688,7 @@ def add_fake_msg_with_calendar_part(db_session, account, ics_str, thread=None):
     return msg
 
 
-@yield_fixture
+@fixture
 def mock_gevent_sleep(monkeypatch):
     monkeypatch.setattr("gevent.sleep", mock.Mock())
     yield
@@ -714,7 +714,7 @@ def mock_client():
     return mock_client
 
 
-@yield_fixture(scope="function")
+@fixture(scope="function")
 def redis_client(monkeypatch):
     client = mock_client()
     yield client
@@ -722,7 +722,7 @@ def redis_client(monkeypatch):
     client.flushdb()
 
 
-@yield_fixture(scope="function", autouse=True)
+@fixture(scope="function", autouse=True)
 def redis_mock(redis_client, monkeypatch):
     def set_self_client(self, *args, **kwargs):
         # Ensure the same 'redis' client is returned across HeartbeatStore


### PR DESCRIPTION
This addresses a couple of pytest warnings

`@yield_fixture` is a synonym of `@fixture` in moder pytest.
There were two markers, I documented `networkrequired` since it seems useful and removed `only` marker since I can't figure out what it was supposed to do.