### PR TITLE
Fix surragate related errors on Python 3

### DIFF
--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -3,6 +3,7 @@ import codecs
 import contextlib
 import re
 import struct
+import sys
 import uuid
 import weakref
 from typing import Any, Optional, Tuple
@@ -331,7 +332,8 @@ def utf8_surrogate_fix_search_function(encoding_name):
     )
 
 
-codecs.register(utf8_surrogate_fix_search_function)
+if sys.version_info >= (3,):
+    codecs.register(utf8_surrogate_fix_search_function)
 
 
 class ForceStrictModePool(QueuePool):
@@ -355,8 +357,9 @@ def receive_connect(dbapi_connection, connection_record):
     )
     cur = None
 
-    assert dbapi_connection.encoding == "utf8"
-    dbapi_connection.encoding = "utf8-surrogate-fix"
+    if sys.version_info >= (3,):
+        assert dbapi_connection.encoding == "utf8"
+        dbapi_connection.encoding = "utf8-surrogate-fix"
 
 
 def maybe_refine_query(query, subquery):

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -302,7 +302,7 @@ def utf8_encode(text, errors="strict"):
 
 
 def utf8_surrogate_fix_decode(memory, errors="strict"):
-    # type: (memoryview) -> Tuple[str, int]
+    # type: (memoryview, str) -> Tuple[str, int]
     binary = memory.tobytes()
 
     try:

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -301,12 +301,12 @@ def utf8_encode(text, errors="strict"):
     return text.encode("utf-8", errors), len(text)
 
 
-def utf8_surrogate_fix_decode(memory):
+def utf8_surrogate_fix_decode(memory, errors="strict"):
     # type: (memoryview) -> Tuple[str, int]
     binary = memory.tobytes()
 
     try:
-        return binary.decode("utf-8"), len(binary)
+        return binary.decode("utf-8", errors), len(binary)
     except UnicodeDecodeError:
         pass
 

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -296,9 +296,9 @@ RE_SURROGATE_CHARACTER = re.compile(r"[\ud800-\udfff]")
 RE_SURROGATE_PAIR = re.compile(r"[\ud800-\udbff][\udc00-\udfff]")
 
 
-def utf8_encode(text):
-    # type: (str) -> Tuple[bytes, int]
-    return text.encode("utf-8"), len(text)
+def utf8_encode(text, errors="strict"):
+    # type: (str, str) -> Tuple[bytes, int]
+    return text.encode("utf-8", errors), len(text)
 
 
 def utf8_surrogate_fix_decode(memory):

--- a/tests/test_sqlalchemy_ext.py
+++ b/tests/test_sqlalchemy_ext.py
@@ -1,0 +1,48 @@
+import pytest
+
+import inbox.sqlalchemy_ext.util
+
+
+def test_utf8_surrogate_fix_codec():
+    assert "abc".encode("utf8-surrogate-fix") == b"abc"
+    assert b"abc".decode("utf8-surrogate-fix") == "abc"
+
+    # 🙏 as single character
+    "🙏".encode("utf8-surrogate-fix") == b"\xf0\x9f\x99\x8f"
+    b"\xf0\x9f\x99\x8f".decode("utf8-surrogate-fix") == "🙏"
+
+    # 🙏 as two surrogate characters
+    with pytest.raises(UnicodeEncodeError):
+        ("\ud83d" + "\ude4f").encode("utf8-surrogate-fix")
+    (b"\xed\xa0\xbd" + b"\xed\xb9\x8f").decode("utf8-surrogate-fix") == "🙏"
+
+    # first surrogate of 🙏
+    with pytest.raises(UnicodeEncodeError):
+        "\ud83d".encode("utf8-surrogate-fix")
+    assert b"\xed\xa0\xbd".decode("utf8-surrogate-fix") == ""
+
+    # second surrogate of 🙏
+    with pytest.raises(UnicodeEncodeError):
+        "\ude4f".encode("utf8-surrogate-fix")
+    assert b"\xed\xb9\x8f".decode("utf8-surrogate-fix") == ""
+
+    # 🙏 as two surrogate characters and first surrogate of 🙏
+    with pytest.raises(UnicodeEncodeError):
+        ("\ud83d" + "\ude4f" + "\ud83d").encode("utf8-surrogate-fix")
+    (b"\xed\xa0\xbd" + b"\xed\xb9\x8f" + b"\xed\xa0\xbd").decode(
+        "utf8-surrogate-fix"
+    ) == "🙏"
+
+    # second surrogate of 🙏 and 🙏 as two surrogate characters
+    with pytest.raises(UnicodeEncodeError):
+        ("\ude4f" + "\ud83d" + "\ude4f").encode("utf8-surrogate-fix")
+    assert (b"\xed\xb9\x8f" + b"\xed\xa0\xbd" + b"\xed\xb9\x8f").decode(
+        "utf8-surrogate-fix"
+    ) == "🙏"
+
+    # 🙏 as single character and 🙏 as two surrogate characters
+    with pytest.raises(UnicodeEncodeError):
+        ("🙏" + "\ud83d" + "\ude4f").encode("utf8-surrogate-fix")
+    (b"\xf0\x9f\x99\x8f" + b"\xed\xa0\xbd" + b"\xed\xb9\x8f").decode(
+        "utf8-surrogate-fix"
+    ) == "🙏🙏"

--- a/tests/test_sqlalchemy_ext.py
+++ b/tests/test_sqlalchemy_ext.py
@@ -1,8 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import sys
+
 import pytest
 
 import inbox.sqlalchemy_ext.util
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3,), reason="Python 2 behaves like surrogatepass"
+)
 def test_utf8_surrogate_fix_codec():
     assert "abc".encode("utf8-surrogate-fix") == b"abc"
     assert b"abc".decode("utf8-surrogate-fix") == "abc"

--- a/tests/test_sqlalchemy_ext.py
+++ b/tests/test_sqlalchemy_ext.py
@@ -15,13 +15,13 @@ def test_utf8_surrogate_fix_codec():
     assert b"abc".decode("utf8-surrogate-fix") == "abc"
 
     # 🙏 as single character
-    "🙏".encode("utf8-surrogate-fix") == b"\xf0\x9f\x99\x8f"
-    b"\xf0\x9f\x99\x8f".decode("utf8-surrogate-fix") == "🙏"
+    assert "🙏".encode("utf8-surrogate-fix") == b"\xf0\x9f\x99\x8f"
+    assert b"\xf0\x9f\x99\x8f".decode("utf8-surrogate-fix") == "🙏"
 
     # 🙏 as two surrogate characters
     with pytest.raises(UnicodeEncodeError):
         ("\ud83d" + "\ude4f").encode("utf8-surrogate-fix")
-    (b"\xed\xa0\xbd" + b"\xed\xb9\x8f").decode("utf8-surrogate-fix") == "🙏"
+    assert (b"\xed\xa0\xbd" + b"\xed\xb9\x8f").decode("utf8-surrogate-fix") == "🙏"
 
     # first surrogate of 🙏
     with pytest.raises(UnicodeEncodeError):
@@ -36,7 +36,7 @@ def test_utf8_surrogate_fix_codec():
     # 🙏 as two surrogate characters and first surrogate of 🙏
     with pytest.raises(UnicodeEncodeError):
         ("\ud83d" + "\ude4f" + "\ud83d").encode("utf8-surrogate-fix")
-    (b"\xed\xa0\xbd" + b"\xed\xb9\x8f" + b"\xed\xa0\xbd").decode(
+    assert (b"\xed\xa0\xbd" + b"\xed\xb9\x8f" + b"\xed\xa0\xbd").decode(
         "utf8-surrogate-fix"
     ) == "🙏"
 
@@ -50,6 +50,6 @@ def test_utf8_surrogate_fix_codec():
     # 🙏 as single character and 🙏 as two surrogate characters
     with pytest.raises(UnicodeEncodeError):
         ("🙏" + "\ud83d" + "\ude4f").encode("utf8-surrogate-fix")
-    (b"\xf0\x9f\x99\x8f" + b"\xed\xa0\xbd" + b"\xed\xb9\x8f").decode(
+    assert (b"\xf0\x9f\x99\x8f" + b"\xed\xa0\xbd" + b"\xed\xb9\x8f").decode(
         "utf8-surrogate-fix"
     ) == "🙏🙏"


### PR DESCRIPTION
TLDR

Python 2.7

```
b'\xed\xa0\xbd'.decode('utf-8')
u'\ud83d'
```

Python 3.x

```
>>> b'\xed\xa0\xbd'.decode('utf-8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 0: invalid continuation byte
```

Python 3.x with surrogatepass

```
>>> b"\xed\xa0\xbd".decode('utf-8', 'surrogatepass')
'\ud83d'
```

Surrogate pairs is an alternative and deprecated way to encode characters that did not fit in original UTF-16 design. They use two separate unicode code points.

Some data that was saved in the database on Python 2 contained surrogate pairs and unpaired surrogate characters. This registers a codec that disallows encoding new surragate pairs but will gracefully decode data that contains surrogate pairs. It will replace pairs with single character and ignore unpaired surrogate characters.