### PR TITLE
Upgrade ipython

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,6 +8,8 @@ git+https://github.com/closeio/authalligator-client.git@fe93c9d2333d2949e44c48a2
 backports.functools-lru-cache==1.4; python_version < '3.3'
 backports.shutil_get_terminal_size==1.0; python_version < '3.3'
 backports.ssl==0.0.9; python_version < '3.0'
+backcall==0.2.0; python_version > '3.0'
+jedi==0.18.1; python_version > '3.0'
 boto==2.49.0
 boto3==1.17.112
 botocore==1.20.112
@@ -25,7 +27,8 @@ colorlog==5.0.1
 configparser==4.0.2
 contextlib2==0.5.5
 cryptography==2.1.4
-decorator==4.4.2
+decorator==4.4.2; python_version < '3.0'
+decorator==5.1.0; python_version >= '3.0'
 dnspython==1.13
 docutils==0.14
 enum34==1.1.3; python_version < '3.4'
@@ -51,7 +54,8 @@ idna==2.9
 imapclient==2.2.0
 importlib-metadata==2.1.1
 ipaddress==1.0.19
-ipython==5.8.0
+ipython==5.8.0; python_version < '3.0'
+ipython==7.16.0; python_version >= '3.0'
 ipython_genutils==0.2.0
 itsdangerous==1.1.0
 Jinja2==2.11.3
@@ -63,16 +67,19 @@ Mako==1.0.7
 MarkupSafe==1.1.1
 mysqlclient==1.3.14
 ndg-httpsclient==0.4.3; python_version < '3.0'
+parso==0.8.2; python_version >= '3.0'
 pathlib2==2.3.6
 pexpect==4.8.0
 pickleshare==0.7.5
 ply==3.10
 psutil==5.8.0
 ptyprocess==0.7.0
-prompt-toolkit==1.0.18
+prompt-toolkit==1.0.18; python_version < '3.0'
+prompt-toolkit==3.0.22; python_version >= '3.0'
 pyasn1==0.2.3
 pycparser==2.18
-pygments==2.5.2
+pygments==2.5.2; python_version < '3.0'
+pygments==2.10.0; python_version >= '3.0'
 pyinstrument==3.2.0
 pyinstrument-cext==0.2.2
 pymongo==2.9.5  # For json_util in bson
@@ -100,7 +107,7 @@ sqlalchemy==1.4.26
 statsd==3.3.0
 structlog==20.1.0
 tldextract==2.2.3
-traitlets==4.3.2
+traitlets==4.3.3
 typing==3.10.0.0; python_version < '3.5'
 urllib3==1.26.7
 vobject==0.9.1


### PR DESCRIPTION
This is the last version that works on python 3.6

Changelog

6.0 series: https://ipython.readthedocs.io/en/stable/whatsnew/version6.html
7.0 series: https://ipython.readthedocs.io/en/stable/whatsnew/version7.html