### PR TITLE
Upgrade freezegun

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -34,7 +34,6 @@ git+https://github.com/closeio/flanker-new.git@fa272d95345d45e8bb1f9bc32bc2c074b
 tld==0.12.6
 Flask==1.1.4
 Flask-RESTful==0.3.9
-freezegun==0.3.15
 future==0.18.2
 futures==2.2.0
 gdata==2.0.18

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,8 @@ atomicwrites==1.4.0
 coverage==5.5; python_version < '3.0'
 coverage==6.1.2; python_version >= '3.0'
 funcsigs==1.0.2
+freezegun==0.3.15; python_version < '3.0'
+freezegun==1.1.0; python_version >= '3.0'
 hypothesis==4.57.1
 iniconfig==1.1.1; python_version >= '3.0'
 mock==1.3.0


### PR DESCRIPTION
Changelog

```

1.1.0

-----
  
  * Add support for `time.monotonic` (and `…_ns`)
  
  * Allow to configure default ignore list, and also to just extend the default
  
  * Fixed when accessing from thread after stop()

1.0.0

------
  
  * Dropped Py2 support
  * Added as_kwarg argument in order to have the frozen time object passed with the name pr
  ```