### PR TITLE
Upgrade colorlog 

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -22,7 +22,8 @@ charset-normalizer==2.0.7; python_version >= '3.5'
 ciso8601==2.2.0
 click==7.1.2
 colorama==0.3.9
-colorlog==5.0.1
+colorlog==5.0.1; python_version < '3.0'
+colorlog==6.5.0; python_version >= '3.0'
 configparser==4.0.2
 contextlib2==0.5.5; python_version < '3.0'
 cryptography==2.1.4


### PR DESCRIPTION
This is the last version of colorlog

Changelog

```

6.4.1

This breaks backwards compatibility in a few ways, most notably dropping support for Python versions older than 3.5. A warning will be displayed if you try to run it on an older version:
  
  
  Colorlog requires Python 3.6 or above.
  Pin 'colorlog<5' to your dependencies if you require compatibility with older versions of Python.
  
  
  This lets colorlog drop some code that was getting very messy to maintain, which made adding and testing new features a slog. Other backwards incompatible changes have mostly been to internals, and some long requested features that have been a bit easier to add now.
  
  Changes
  
  Changes since [v6.3.0a1](https://github.com/borntyping/python-colorlog/releases/tag/v6.3.0a1).
  
  - Renamed `colorlog.logging` to `colorlog.wrappers`.
  - Import log levels from the `logging` module (111).
  
  Changelog
  
  Changes since [v5.0.0](https://github.com/borntyping/python-colorlog/releases/tag/v5.0.0).
  
  - Dropped support for Python 2 and Python versions below Python 3.5.
  - Added type hints and added mypy to CI (83).
  - Support 256 colour ANSI codes (88).
  - Support "light" ANSI codes (87).
  - Support the `NO_COLOR` environment variable, and a no_color option (70).
  - Updated various examples and documentation (85).
  - Merged `TTYColoredFormatter` into `ColoredFormatter`, and ensure no ANSI codes are printed when colors are disabled.
  - Replaced `LevelFormatter` with a far simpler implementation.
  - Fixed version_info check for the Formatter validate parameter.
  - Define formatMessage instead of format, so that ColoredRecord is used in fewer places.
  - Use setuptool's "normalised" format for the version number.
  - Add PEP 561 typing marker so mypy can find type annotations.
  - Renamed internal modules.
  - `colorlog.colorlog` is now `colorlog.formatter`.
  - `colorlog.logging` is now `colorlog.wrappers`.
  - Removed `colorlog.escape_codes` object so that the `colorlog.escape_codes` module can be imported and used.
  - Import log levels from the `logging` module (111).

6.3.0a1

- Rename internal modules. `colorlog.colorlog` is now `colorlog.formatter`.
  - Remove `colorlog.escape_codes` _object_ so that the `colorlog.escape_codes` _module_ can be imported and used.

6.2.0a1

- Drop support for Python 3.5.
  - Require Python >= 3.6 in package metadata.
  - Cleanup old Python syntax.
  
  Thanks hugovk!

6.1.0a1

- Use setuptool's "normalised" format for the version number.
  - Add PEP 561 typing marker so mypy can find type annotations.

6.0.0alpha.2

* *Dropped support for Python 2* and Python versions below Python 3.5.
  * Added type hints and added mypy to CI (83).
  * Support 256 colour ANSI codes (88).
  * Support "light" ANSI codes (87).
  * Support the [`NO_COLOR`](https://no-color.org/) environment variable, and a `no_color` option (#70).
  * Updates various examples and documenation (85).
  * Merged `TTYColoredFormatter` into `ColoredFormatter`, and ensure no ANSI codes are printed when colors are disabled.
  * Replaced `LevelFormatter` with a far simpler implementation.
  * Fixed `version_info` check for the Formatter `validate` parameter.
  * Define `formatMessage` instead of `format`, so that `ColoredRecord` is used in fewer places.


```