### PR TITLE
Remove the need to pip install -e before executing commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,7 @@ jobs:
                 command: |
                   docker login -u $DOCKER_USER -p $DOCKER_PASS
                   docker-compose run app bash -ec '
-                    pip install -e . \
-                    && bin/wait-for-it.sh mysql:3306 \
+                    bin/wait-for-it.sh mysql:3306 \
                     && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
                     && coverage html -d pythoncov
                   '

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN \
-  --mount=type=cache,target=/home/sync-engine/.cache,uid=5000,gid=5000  \
   python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==44.0.0 pip==20.3.4 && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,10 +64,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN \
+  --mount=type=cache,target=/home/sync-engine/.cache,uid=5000,gid=5000  \
   python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==44.0.0 pip==20.3.4 && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install -e .
+  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt
 
 RUN /opt/venv/bin/python"${PYTHON_VERSION}" -m pip check
 

--- a/inbox/__init__.py
+++ b/inbox/__init__.py
@@ -2,3 +2,5 @@
 from pkgutil import extend_path
 
 __path__ = extend_path(__path__, __name__)
+
+VERSION = "17.3.8"  # Release Mar 8, 2017

--- a/inbox/sendmail/base.py
+++ b/inbox/sendmail/base.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from past.builtins import basestring
 
+from inbox import VERSION
 from inbox.api.err import InputError
 from inbox.api.validation import (
     get_attachments,

--- a/inbox/sendmail/base.py
+++ b/inbox/sendmail/base.py
@@ -8,7 +8,6 @@ standard_library.install_aliases()
 import re
 from datetime import datetime
 
-import pkg_resources
 from past.builtins import basestring
 
 from inbox.api.err import InputError
@@ -22,8 +21,6 @@ from inbox.contacts.processing import update_contacts_from_message
 from inbox.models import Message, Part
 from inbox.models.action_log import schedule_action
 from inbox.sqlalchemy_ext.util import generate_public_id
-
-VERSION = pkg_resources.get_distribution("inbox-sync").version
 
 
 class SendMailException(Exception):

--- a/inbox/sendmail/message.py
+++ b/inbox/sendmail/message.py
@@ -16,15 +16,12 @@ http://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html
 from datetime import datetime
 from email.header import Header
 
-import pkg_resources
 from flanker import mime
 from flanker.addresslib import address
 from flanker.addresslib.address import MAX_ADDRESS_LENGTH
 from flanker.addresslib.quote import smart_quote
 from flanker.mime.message.headers import WithParams
 from html2text import html2text
-
-VERSION = pkg_resources.get_distribution("inbox-sync").version
 
 REPLYSTR = "Re: "
 

--- a/inbox/sendmail/message.py
+++ b/inbox/sendmail/message.py
@@ -23,6 +23,8 @@ from flanker.addresslib.quote import smart_quote
 from flanker.mime.message.headers import WithParams
 from html2text import html2text
 
+from inbox import VERSION
+
 REPLYSTR = "Re: "
 
 

--- a/inbox/util/file.py
+++ b/inbox/util/file.py
@@ -3,6 +3,7 @@ import fcntl
 import os
 import string
 import sys
+from typing import Generator, List
 
 from gevent.lock import BoundedSemaphore
 
@@ -146,3 +147,20 @@ def get_data(filename):
     """Read contents of a file relative to the project root folder"""
     with open(os.path.join(ROOT_PATH, filename), "rb") as file:
         return file.read()
+
+
+def iter_module_names(paths):
+    # type: (List[str]) -> Generator[str, None, None]
+    """Iterate all Python module names in given paths"""
+    for path in paths:
+        for name in os.listdir(path):
+            isdirectory = os.path.isdir(os.path.join(path, name))
+            if not isdirectory and name == "__init__.py":
+                continue
+
+            if not isdirectory and name.endswith(".py"):
+                yield name[:-3]
+            elif isdirectory and os.path.isfile(
+                os.path.join(path, name, "__init__.py")
+            ):
+                yield name

--- a/inbox/util/file.py
+++ b/inbox/util/file.py
@@ -136,3 +136,13 @@ class Lock(object):
 
     def __del__(self):
         self.handle.close()
+
+
+ROOT_PATH = os.path.normpath(os.path.join(__file__, os.pardir, os.pardir, os.pardir))
+
+
+def get_data(filename):
+    # type: (str) -> bytes
+    """Read contents of a file relative to the project root folder"""
+    with open(os.path.join(ROOT_PATH, filename), "rb") as file:
+        return file.read()

--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -1,4 +1,3 @@
-import pkgutil
 import re
 import sys
 import time
@@ -11,6 +10,7 @@ from future.utils import iteritems
 
 from inbox.logging import get_logger
 from inbox.providers import providers
+from inbox.util.file import iter_module_names
 
 
 class DummyContextManager(object):
@@ -144,7 +144,7 @@ def load_modules(base_name, base_path):
     """
     modules = []
 
-    for _, module_name, _ in pkgutil.iter_modules(base_path):
+    for module_name in iter_module_names(base_path):
         full_module_name = "{}.{}".format(base_name, module_name)
 
         if full_module_name not in sys.modules:

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -13,6 +13,7 @@ import pytest
 from past.builtins import basestring, long
 
 from inbox.basicauth import ValidationError
+from inbox.util.file import get_data
 
 FILENAMES = [
     "muir.jpg",
@@ -87,8 +88,8 @@ class MockDNSResolver(object):
     def __init__(self):
         self._registry = {"mx": {}, "ns": {}}
 
-    def _load_records(self, pkg, filename):
-        self._registry = json.loads(pkgutil.get_data(pkg, filename))
+    def _load_records(self, filename):
+        self._registry = json.loads(get_data(filename))
 
     def query(self, domain, record_type):
         record_type = record_type.lower()

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,23 @@
 import glob
 import os
+import re
 
 from setuptools import find_packages, setup
 
+# approach stolen from sqlalchemy
+with open(
+    os.path.join(os.path.dirname(__file__), "inbox", "__init__.py")
+) as version_file:
+    VERSION = (
+        re.compile(r""".*VERSION = ["'](.*?)['"]""", re.S)
+        .match(version_file.read())
+        .group(1)
+    )
+
+
 setup(
     name="inbox-sync",
-    version="17.3.8",  # Release Mar 8, 2017
+    version=VERSION,
     packages=find_packages(),
     install_requires=[],
     include_package_data=True,

--- a/tests/general/test_message_parsing.py
+++ b/tests/general/test_message_parsing.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 """Sanity-check our construction of a Message object from raw synced data."""
 import datetime
-import pkgutil
 import sys
 
 import pytest
@@ -11,6 +10,7 @@ from flanker import mime
 from inbox.models import Block, Message
 from inbox.util.addr import parse_mimepart_address_header
 from inbox.util.blockstore import get_from_blockstore
+from inbox.util.file import get_data
 
 from tests.util.base import (
     add_fake_thread,
@@ -40,7 +40,7 @@ def create_from_synced(db, account, raw_message):
 def raw_message_with_many_recipients():
     # Message carefully constructed s.t. the length of the serialized 'to'
     # field is 65536.
-    return pkgutil.get_data("tests", "data/raw_message_with_many_recipients.txt")
+    return get_data("tests/data/raw_message_with_many_recipients.txt")
 
 
 @pytest.fixture
@@ -51,47 +51,47 @@ def mime_message_with_bad_date(mime_message):
 
 @pytest.fixture
 def raw_message_with_long_content_id():
-    return pkgutil.get_data("tests", "data/raw_message_with_long_content_id.txt")
+    return get_data("tests/data/raw_message_with_long_content_id.txt")
 
 
 @pytest.fixture
 def raw_message_with_ical_invite():
-    return pkgutil.get_data("tests", "data/raw_message_with_ical_invite.txt")
+    return get_data("tests/data/raw_message_with_ical_invite.txt")
 
 
 @pytest.fixture
 def raw_message_with_bad_attachment():
-    return pkgutil.get_data("tests", "data/raw_message_with_bad_attachment.txt")
+    return get_data("tests/data/raw_message_with_bad_attachment.txt")
 
 
 @pytest.fixture
 def raw_message_with_filename_attachment():
-    return pkgutil.get_data("tests", "data/raw_message_with_filename_attachment.txt")
+    return get_data("tests/data/raw_message_with_filename_attachment.txt")
 
 
 @pytest.fixture
 def raw_message_with_name_attachment():
-    return pkgutil.get_data("tests", "data/raw_message_with_name_attachment.txt")
+    return get_data("tests/data/raw_message_with_name_attachment.txt")
 
 
 @pytest.fixture
 def raw_message_with_inline_name_attachment():
-    return pkgutil.get_data("tests", "data/raw_message_with_inline_attachment.txt")
+    return get_data("tests/data/raw_message_with_inline_attachment.txt")
 
 
 @pytest.fixture
 def raw_message_with_outlook_emoji():
-    return pkgutil.get_data("tests", "data/raw_message_with_outlook_emoji.txt")
+    return get_data("tests/data/raw_message_with_outlook_emoji.txt")
 
 
 @pytest.fixture
 def raw_message_with_outlook_emoji_inline():
-    return pkgutil.get_data("tests", "data/raw_message_with_outlook_emoji_inline.txt")
+    return get_data("tests/data/raw_message_with_outlook_emoji_inline.txt")
 
 
 @pytest.fixture
 def raw_message_with_long_message_id():
-    return pkgutil.get_data("tests", "data/raw_message_with_long_message_id.txt")
+    return get_data("tests/data/raw_message_with_long_message_id.txt")
 
 
 @pytest.mark.usefixtures("blockstore_backend")

--- a/tests/general/test_provider_resolution.py
+++ b/tests/general/test_provider_resolution.py
@@ -8,9 +8,7 @@ from inbox.util.url import InvalidEmailAddressError, provider_from_address
 
 
 def test_provider_resolution(mock_dns_resolver):
-    mock_dns_resolver._load_records(
-        "tests", "data/general_test_provider_resolution.json"
-    )
+    mock_dns_resolver._load_records("tests/data/general_test_provider_resolution.json")
     test_cases = [
         ("foo@example.com", "unknown"),
         ("foo@noresolve.com", "unknown"),


### PR DESCRIPTION
before this PR when running something with docker you needed to stick `pip install -e .` because the code base relied on the fact that the package `inbox` is installed. This is annoying, especially when working with Docker and locally mounted volumes.

The code relied on `pkgutil.get_data()` to load fixture data and `pkgutil.get_modules()` to walk and import modules dynamically. I provided subtitues for those two that work without installing the module.

~~There were also VERSION constans read from setup.py in two places but those are not really needed for anything.~~

I inverted the logic about VERSION constant to read it from main `__init__.py` file, many Python packages do it this way.

Though this adds code, it also saves a lot of typing for everybody trying to run tests, ipython or whatever code in the containers.