### PR TITLE
Fix queue_name returned as bytes on Python 3

### DIFF
--- a/inbox/scheduling/event_queue.py
+++ b/inbox/scheduling/event_queue.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from redis import StrictRedis
 
@@ -38,7 +38,7 @@ class EventQueue(object):
 
     def receive_event(self, timeout=0):
         # type: (int) -> Dict[str, Any]
-        result = None
+        result = None  # type: Optional[Union[bytes, Tuple[bytes, bytes]]]
         if timeout is None:
             result = self.redis.lpop(self.queue_name)
         else:
@@ -78,7 +78,9 @@ class EventQueueGroup(object):
 
     def receive_event(self, timeout=0):
         # type: (int) -> Dict[str, Any]
-        result = self.redis.blpop([q.queue_name for q in self.queues], timeout=timeout)
+        result = self.redis.blpop(
+            [q.queue_name for q in self.queues], timeout=timeout
+        )  # type: Optional[Tuple[bytes, bytes]]
         if result is None:
             return None
         queue_name, event_data = result

--- a/inbox/scheduling/event_queue.py
+++ b/inbox/scheduling/event_queue.py
@@ -49,6 +49,7 @@ class EventQueue(object):
         queue_name, event_data = (
             (self.queue_name, result) if timeout is None else result
         )
+        queue_name = queue_name.decode("utf-8")
         try:
             event = json.loads(event_data)
             event["queue_name"] = queue_name
@@ -81,6 +82,7 @@ class EventQueueGroup(object):
         if result is None:
             return None
         queue_name, event_data = result
+        queue_name = queue_name.decode("utf-8")
         try:
             event = json.loads(event_data)
             event["queue_name"] = queue_name

--- a/tests/scheduling/test_event_queue.py
+++ b/tests/scheduling/test_event_queue.py
@@ -1,0 +1,37 @@
+from inbox.scheduling.event_queue import EventQueue, EventQueueGroup
+
+
+def test_event_queue():
+    queue = EventQueue("name")
+    sent_event = {"event": "test"}
+    queue.send_event(sent_event)
+    received_event = queue.receive_event()
+
+    assert received_event.pop("queue_name") == queue.queue_name
+    assert received_event == sent_event
+
+
+def test_event_queue_empty():
+    queue = EventQueue("name")
+    assert queue.receive_event(1) is None
+
+
+def test_event_queue_group():
+    queue1 = EventQueue("name1")
+    queue2 = EventQueue("name2")
+
+    sent_event_1 = {"event": "test1"}
+    queue1.send_event(sent_event_1)
+
+    sent_event_2 = {"event": "test2"}
+    queue2.send_event(sent_event_2)
+
+    queue_group = EventQueueGroup([queue1, queue2])
+
+    received_event_1 = queue_group.receive_event()
+    assert received_event_1.pop("queue_name") == queue1.queue_name
+    assert received_event_1 == sent_event_1
+
+    received_event_2 = queue_group.receive_event()
+    assert received_event_2.pop("queue_name") == queue2.queue_name
+    assert received_event_2 == sent_event_2


### PR DESCRIPTION
This caused a problem with initial sync in production. It boils down to de fact that `u"asd" != b"asd"` on Python 3 and `u"asd" == b"asd"` on Python 2 due to implicit coercion. Redis returns everything as binary both on Python 2 and Python 3.

I also added tests that used to fail on Python 3. 

```
=============================== FAILURES ================================
___________________________ test_event_queue ____________________________

    def test_event_queue():
        queue = EventQueue("name")
        sent_event = {"event": "test"}
        queue.send_event(sent_event)
        received_event = queue.receive_event()
    
>       assert received_event.pop("queue_name") == queue.queue_name
E       AssertionError: assert b'name' == 'name'
E        +  where b'name' = <built-in method pop of dict object at 0x7f1fe645c630>('queue_name')
E        +    where <built-in method pop of dict object at 0x7f1fe645c630> = {'event': 'test'}.pop
E        +  and   'name' = <inbox.scheduling.event_queue.EventQueue object at 0x7f1fef95cf98>.queue_name

tests/scheduling/test_event_queue.py:10: AssertionError
________________________ test_event_queue_group _________________________

    def test_event_queue_group():
        queue1 = EventQueue("name1")
        queue2 = EventQueue("name2")
    
        sent_event_1 = {"event": "test1"}
        queue1.send_event(sent_event_1)
    
        sent_event_2 = {"event": "test2"}
        queue2.send_event(sent_event_2)
    
        queue_group = EventQueueGroup([queue1, queue2])
    
        received_event_1 = queue_group.receive_event()
>       assert received_event_1.pop("queue_name") == queue1.queue_name
E       AssertionError: assert b'name1' == 'name1'
E        +  where b'name1' = <built-in method pop of dict object at 0x7f1fe619cee8>('queue_name')
E        +    where <built-in method pop of dict object at 0x7f1fe619cee8> = {'event': 'test1'}.pop
E        +  and   'name1' = <inbox.scheduling.event_queue.EventQueue object at 0x7f1fe61cf978>.queue_name

tests/scheduling/test_event_queue.py:32: AssertionError
```