### PR TITLE
Remove extend_path

### DIFF
--- a/inbox/__init__.py
+++ b/inbox/__init__.py
@@ -1,6 +1,1 @@
-# Allow out-of-tree submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
-
 VERSION = "17.3.8"  # Release Mar 8, 2017

--- a/inbox/actions/backends/__init__.py
+++ b/inbox/actions/backends/__init__.py
@@ -7,10 +7,6 @@ For example, 'gmail', 'imap', 'eas', 'yahoo' etc.
 2. Live in the 'inbox.actions.backends' module tree.
 
 """
-# Allow out-of-tree action submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.util.misc import register_backends
 
 module_registry = register_backends(__name__, __path__)

--- a/inbox/contacts/__init__.py
+++ b/inbox/contacts/__init__.py
@@ -1,4 +1,0 @@
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/inbox/events/__init__.py
+++ b/inbox/events/__init__.py
@@ -1,4 +1,0 @@
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/inbox/events/actions/backends/__init__.py
+++ b/inbox/events/actions/backends/__init__.py
@@ -1,7 +1,3 @@
-# Allow out-of-tree action submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.util.misc import register_backends
 
 module_registry = register_backends(__name__, __path__)

--- a/inbox/mailsync/backends/__init__.py
+++ b/inbox/mailsync/backends/__init__.py
@@ -18,10 +18,6 @@ submodule of `backends`, and that top-level module must import the
 referenced class.
 
 """
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.util.misc import register_backends
 
 module_registry = register_backends(__name__, __path__)

--- a/inbox/models/__init__.py
+++ b/inbox/models/__init__.py
@@ -14,21 +14,7 @@ Previously, this was accomplished by doing:
 from inbox.models.account import Account
 
 etc. right here.
-
-However, this file is part of a namespace package: the contents of
-inbox.models.backends may be extended by separately distributed projects.
-Thus, those projects also contain their own "inbox/models/". If
-its contents differ from this one, things break if the wrong __init__ file is
-loaded first. But it's painful to have to change all the __init__ files each
-time you add a model. So we hoist the actual importing out of this file and
-into inbox.models.meta, and engage in a bit of trickery to make model classes
-actually available via e.g.
->>> from inbox.models import Account
 """
-
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.models.backends import module_registry as backend_module_registry
 from inbox.models.meta import load_models
 

--- a/inbox/models/backends/__init__.py
+++ b/inbox/models/backends/__init__.py
@@ -1,10 +1,6 @@
 """
 Per-provider table modules.
 """
-# Allow out-of-tree table submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.util.misc import register_backends
 
 module_registry = register_backends(__name__, __path__)

--- a/inbox/s3/__init__.py
+++ b/inbox/s3/__init__.py
@@ -1,4 +1,0 @@
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/inbox/s3/backends/__init__.py
+++ b/inbox/s3/backends/__init__.py
@@ -1,4 +1,0 @@
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/inbox/search/backends/__init__.py
+++ b/inbox/search/backends/__init__.py
@@ -1,7 +1,3 @@
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.util.misc import register_backends
 
 module_registry = register_backends(__name__, __path__)

--- a/inbox/sendmail/__init__.py
+++ b/inbox/sendmail/__init__.py
@@ -10,10 +10,6 @@ For example, 'gmail', 'eas' etc.
 `SENDMAIL_CLS` variable.
 
 """
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.util.misc import register_backends
 
 module_registry = register_backends(__name__, __path__)

--- a/inbox/util/__init__.py
+++ b/inbox/util/__init__.py
@@ -4,7 +4,3 @@
     Don't add new code here! Find the relevant submodule, or use misc.py if
     there's really no other place.
 """
-# Allow out-of-tree submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -132,10 +132,6 @@ def load_modules(base_name, base_path):
     """
     Imports all modules underneath `base_module` in the module tree.
 
-    Note that if submodules are located in different directory trees, you
-    need to use `pkgutil.extend_path` to make all the folders appear in
-    the module's `__path__`.
-
     Returns
     -------
     list

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import contextlib
 import json
 import os
-import pkgutil
 import re
 import subprocess
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-# Allow out-of-tree submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -1,4 +1,0 @@
-# Allow out-of-tree submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/tests/auth/providers/__init__.py
+++ b/tests/auth/providers/__init__.py
@@ -1,4 +1,0 @@
-# Allow out-of-tree submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)

--- a/tests/providers/__init__.py
+++ b/tests/providers/__init__.py
@@ -1,7 +1,3 @@
-# Allow out-of-tree backend submodules.
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
 from inbox.util.misc import register_backends
 
 module_registry = register_backends(__name__, __path__)


### PR DESCRIPTION
This was needed previously because `inbox` package was split between many root trees. With all the vendoring this is no longer needed.