### PR TITLE
Flake8 on Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,26 +24,11 @@ jobs:
           name: isort
           when: always
           command: isort -c .
-        
-  static-code-analysis-flake8:
-    docker:
-      - image: circleci/python:2.7
-        auth:
-          username: $DOCKER_USER
-          password: $DOCKER_PASS
-    working_directory: ~/code
-    steps:
-      - checkout
-
-      - run:
-          name: Prepare Environment
-          command: |
-            sudo -E pip install --no-deps -r requirements/lint.txt
 
       - run:
           name: flake8
           command: flake8
-
+        
   build:
     parameters:
       python_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ workflows:
   workflow:
     jobs:
       - static-code-analysis
-      - static-code-analysis-flake8
       - build:
           name: build_py2.7
           python_version: "2.7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: flake8
           command: flake8
-        
+
   build:
     parameters:
       python_version:

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -77,7 +77,7 @@ def retry(
         while True:
             try:
                 return func(*args, **kwargs)
-            except gevent.GreenletExit as e:
+            except gevent.GreenletExit:
                 # GreenletExit isn't actually a subclass of Exception.
                 # This is also considered to be a successful execution
                 # (somebody intentionally killed the greenlet).


### PR DESCRIPTION
With all the code being syntactically correct Python 3 we can switch Flake8 to Python 3.