### PR TITLE
Upgrade boto3 on Python 3

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,8 +11,10 @@ backports.ssl==0.0.9; python_version < '3.0'
 backcall==0.2.0; python_version > '3.0'
 jedi==0.18.1; python_version > '3.0'
 boto==2.49.0
-boto3==1.17.112
-botocore==1.20.112
+boto3==1.17.112; python_version < '3.0'
+boto3==1.19.4; python_version >= '3.0'
+botocore==1.20.112; python_version < '3.0'
+botocore==1.22.9; python_version >= '3.0'
 cchardet==2.1.1; python_version < '3.0'
 cchardet==2.1.7; python_version >= '3.0'
 certifi==2020.4.5.1; python_version < '3.0'
@@ -22,7 +24,6 @@ chardet==3.0.4
 charset-normalizer==2.0.7; python_version >= '3.5'
 ciso8601==2.2.0
 click==7.1.2
-colorama==0.3.9
 colorlog==5.0.1; python_version < '3.0'
 colorlog==6.5.0; python_version >= '3.0'
 configparser==4.0.2
@@ -96,7 +97,8 @@ regex==2018.1.10
 requests==2.26.0
 requests-file==1.5.1
 rollbar==0.16.2
-s3transfer==0.4.2
+s3transfer==0.4.2; python_version < '3.0'
+s3transfer==0.5.0; python_version >= '3.0'
 scandir==1.10.0
 setproctitle==1.1.10; python_version < '3.0'
 setproctitle==1.2.2; python_version >= '3.0'

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -24,6 +24,7 @@ chardet==3.0.4
 charset-normalizer==2.0.7; python_version >= '3.5'
 ciso8601==2.2.0
 click==7.1.2
+colorama==0.3.9
 colorlog==5.0.1; python_version < '3.0'
 colorlog==6.5.0; python_version >= '3.0'
 configparser==4.0.2


### PR DESCRIPTION
This is only used in contact sync feature that we don't use.

Changelog

```

1.19.4

======
  
  * api-change:``emr-containers``: [``botocore``] This feature enables auto-generation of certificate  to secure the managed-endpoint and removes the need for customer provided certificate-arn during managed-endpoint setup.
  * api-change:``chime-sdk-messaging``: [``botocore``] The Amazon Chime SDK now supports push notifications through Amazon Pinpoint
  * api-change:``chime-sdk-identity``: [``botocore``] The Amazon Chime SDK now supports push notifications through Amazon Pinpoint

1.19.3

======
  
  * api-change:``rds``: [``botocore``] This release adds support for Amazon RDS Custom, which is a new RDS management type that gives you full access to your database and operating system. For more information, see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-custom.html
  * api-change:``auditmanager``: [``botocore``] This release introduces a new feature for Audit Manager: Custom framework sharing. You can now share your custom frameworks with another AWS account, or replicate them into another AWS Region under your own account.
  * api-change:``ec2``: [``botocore``] This release adds support to create a VPN Connection that is not attached to a Gateway at the time of creation. Use this to create VPNs associated with Core Networks, or modify your VPN and attach a gateway using the modify API after creation.
  * api-change:``route53resolver``: [``botocore``] New API for ResolverConfig, which allows autodefined rules for reverse DNS resolution to be disabled for a VPC

1.19.2

======
  
  * api-change:``quicksight``: [``botocore``] Added QSearchBar option for GenerateEmbedUrlForRegisteredUser ExperienceConfiguration to support Q search bar embedding
  * api-change:``auditmanager``: [``botocore``] This release introduces character restrictions for ControlSet names. We updated regex patterns for the following attributes: ControlSet, CreateAssessmentFrameworkControlSet, and UpdateAssessmentFrameworkControlSet.
  * api-change:``chime``: [``botocore``] Chime VoiceConnector and VoiceConnectorGroup APIs will now return an ARN.

1.19.1

======
  
  * api-change:``connect``: [``botocore``] Released Amazon Connect hours of operation API for general availability (GA). This API also supports AWS CloudFormation. For more information, see Amazon Connect Resource Type Reference in the AWS CloudFormation User Guide.

1.19.0

======
  
  * api-change:``appflow``: [``botocore``] Feature to add support for  JSON-L format for S3 as a source.
  * api-change:``mediapackage-vod``: [``botocore``] MediaPackage passes through digital video broadcasting (DVB) subtitles into the output.
  * api-change:``mediaconvert``: [``botocore``] AWS Elemental MediaConvert SDK has added support for specifying caption time delta in milliseconds and the ability to apply color range legalization to source content other than AVC video.
  * api-change:``mediapackage``: [``botocore``] When enabled, MediaPackage passes through digital video broadcasting (DVB) subtitles into the output.
  * api-change:``panorama``: [``botocore``] General availability for AWS Panorama. AWS SDK for Panorama includes APIs to manage your devices and nodes, and deploy computer vision applications to the edge. For more information, see the AWS Panorama documentation at http://docs.aws.amazon.com/panorama
  * feature:Serialization: [``botocore``] rest-json serialization defaults aligned across AWS SDKs
  * api-change:``directconnect``: [``botocore``] This release adds 4 new APIS, which needs to be public able
  * api-change:``securityhub``: [``botocore``] Added support for cross-Region finding aggregation, which replicates findings from linked Regions to a single aggregation Region. Added operations to view, enable, update, and delete the finding aggregation.

1.18.65

=======
  
  * api-change:``dataexchange``: [``botocore``] This release adds support for our public preview of AWS Data Exchange for Amazon Redshift. This enables data providers to list products including AWS Data Exchange datashares for Amazon Redshift, giving subscribers read-only access to provider data in Amazon Redshift.
  * api-change:``chime-sdk-messaging``: [``botocore``] The Amazon Chime SDK now allows developers to execute business logic on in-flight messages before they are delivered to members of a messaging channel with channel flows.

1.18.64

=======
  
  * api-change:``quicksight``: [``botocore``] AWS QuickSight Service  Features    - Add IP Restriction UI and public APIs support.
  * enchancement:AWSCRT: [``botocore``] Upgrade awscrt extra to 0.12.5
  * api-change:``ivs``: [``botocore``] Bug fix: remove unsupported maxResults and nextToken pagination parameters from ListTagsForResource

1.18.63

=======
  
  * api-change:``efs``: [``botocore``] Update efs client to latest version
  * api-change:``glue``: [``botocore``] Enable S3 event base crawler API.

1.18.62

=======
  
  * api-change:``elbv2``: [``botocore``] Update elbv2 client to latest version
  * api-change:``autoscaling``: [``botocore``] Amazon EC2 Auto Scaling now supports filtering describe Auto Scaling groups API using tags
  * api-change:``sagemaker``: [``botocore``] This release updates the provisioning artifact ID to an optional parameter in CreateProject API. The provisioning artifact ID defaults to the latest provisioning artifact ID of the product if you don't provide one.
  * api-change:``robomaker``: [``botocore``] Adding support to GPU simulation jobs as well as non-ROS simulation jobs.

1.18.61

=======
  
  * api-change:``config``: [``botocore``] Adding Config support for AWS::OpenSearch::Domain
  * api-change:``ec2``: [``botocore``] This release adds support for additional VPC Flow Logs delivery options to S3, such as Apache Parquet formatted files, Hourly partitions and Hive-compatible S3 prefixes
  * api-change:``storagegateway``: [``botocore``] Adding support for Audit Logs on NFS shares and Force Closing Files on SMB shares.
  * api-change:``workmail``: [``botocore``] This release adds APIs for adding, removing and retrieving details of mail domains
  * api-change:``kinesisanalyticsv2``: [``botocore``] Support for Apache Flink 1.13 in Kinesis Data Analytics. Changed the required status of some Update properties to better fit the corresponding Create properties.

1.18.60

=======
  
  * api-change:``cloudsearch``: [``botocore``] Adds an additional validation exception for Amazon CloudSearch configuration APIs for better error handling.
  * api-change:``ecs``: [``botocore``] Documentation only update to address tickets.
  * api-change:``mediatailor``: [``botocore``] MediaTailor now supports ad prefetching.
  * api-change:``ec2``: [``botocore``] EncryptionSupport for InstanceStorageInfo added to DescribeInstanceTypes API

1.18.59

=======
  
  * api-change:``elbv2``: [``botocore``] Update elbv2 client to latest version
  * bugfix:Signing: [``botocore``] SigV4QueryAuth and CrtSigV4QueryAuth now properly respect AWSRequest.params while signing boto/botocore`2521 <https://github.com/boto/botocore/issues/2521>`__
  * api-change:``medialive``: [``botocore``] This release adds support for Transport Stream files as an input type to MediaLive encoders.
  * api-change:``ec2``: [``botocore``] Documentation update for Amazon EC2.
  * api-change:``frauddetector``: [``botocore``] New model type: Transaction Fraud Insights, which is optimized for online transaction fraud. Stored Events, which allows customers to send and store data directly within Amazon Fraud Detector. Batch Import, which allows customers to upload a CSV file of historic event data for processing and storage

1.18.58

=======
  
  * api-change:``lexv2-runtime``: [``botocore``] Update lexv2-runtime client to latest version
  * api-change:``lexv2-models``: [``botocore``] Update lexv2-models client to latest version
  * api-change:``secretsmanager``: [``botocore``] Documentation updates for Secrets Manager
  * api-change:``securityhub``: [``botocore``] Added new resource details objects to ASFF, including resources for WAF rate-based rules, EC2 VPC endpoints, ECR repositories, EKS clusters, X-Ray encryption, and OpenSearch domains. Added additional details for CloudFront distributions, CodeBuild projects, ELB V2 load balancers, and S3 buckets.
  * api-change:``mediaconvert``: [``botocore``] AWS Elemental MediaConvert has added the ability to set account policies which control access restrictions for HTTP, HTTPS, and S3 content sources.
  * api-change:``ec2``: [``botocore``] This release removes a requirement for filters on SearchLocalGatewayRoutes operations.

1.18.57

=======
  
  * api-change:``kendra``: [``botocore``] Amazon Kendra now supports indexing and querying documents in different languages.
  * api-change:``grafana``: [``botocore``] Initial release of the SDK for Amazon Managed Grafana API.
  * api-change:``firehose``: [``botocore``] Allow support for Amazon Opensearch Service(successor to Amazon Elasticsearch Service) as a Kinesis Data Firehose delivery destination.
  * api-change:``backup``: [``botocore``] Launch of AWS Backup Vault Lock, which protects your backups from malicious and accidental actions, works with existing backup policies, and helps you meet compliance requirements.
  * api-change:``schemas``: [``botocore``] Removing unused request/response objects.
  * api-change:``chime``: [``botocore``] This release enables customers to configure Chime MediaCapturePipeline via API.

1.18.56

=======
  
  * api-change:``sagemaker``: [``botocore``] This release adds a new TrainingInputMode FastFile for SageMaker Training APIs.
  * api-change:``amplifybackend``: [``botocore``] Adding a new field 'AmplifyFeatureFlags' to the response of the GetBackend operation. It will return a stringified version of the cli.json file for the given Amplify project.
  * api-change:``fsx``: [``botocore``] This release adds support for Lustre 2.12 to FSx for Lustre.
  * api-change:``kendra``: [``botocore``] Amazon Kendra now supports integration with AWS SSO

1.18.55

=======
  
  * api-change:``workmail``: [``botocore``] This release allows customers to change their inbound DMARC settings in Amazon WorkMail.
  * api-change:``location``: [``botocore``] Add support for PositionFiltering.
  * api-change:``application-autoscaling``: [``botocore``] With this release, Application Auto Scaling adds support for Amazon Neptune. Customers can now automatically add or remove Read Replicas of their Neptune clusters to keep the average CPU Utilization at the target value specified by the customers.
  * api-change:``ec2``: [``botocore``] Released Capacity Reservation Fleet, a feature of Amazon EC2 Capacity Reservations, which provides a way to manage reserved capacity across instance types. For more information: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/cr-fleets.html
  * api-change:``glue``: [``botocore``] This release adds tag as an input of CreateConnection
  * api-change:``backup``: [``botocore``] AWS Backup Audit Manager framework report.

1.18.54

=======
  
  * api-change:``codebuild``: [``botocore``] CodeBuild now allows you to select how batch build statuses are sent to the source provider for a project.
  * api-change:``efs``: [``botocore``] Update efs client to latest version
  * api-change:``kms``: [``botocore``] Added SDK examples for ConnectCustomKeyStore, CreateCustomKeyStore, CreateKey, DeleteCustomKeyStore, DescribeCustomKeyStores, DisconnectCustomKeyStore, GenerateDataKeyPair, GenerateDataKeyPairWithoutPlaintext, GetPublicKey, ReplicateKey, Sign, UpdateCustomKeyStore and Verify APIs

1.18.53

=======
  
  * api-change:``synthetics``: [``botocore``] CloudWatch Synthetics now enables customers to choose a customer managed AWS KMS key or an Amazon S3-managed key instead of an AWS managed key (default) for the encryption of artifacts that the canary stores in Amazon S3. CloudWatch Synthetics also supports artifact S3 location updation now.
  * api-change:``ssm``: [``botocore``] When "AutoApprovable" is true for a Change Template, then specifying --auto-approve (boolean) in Start-Change-Request-Execution will create a change request that bypasses approver review. (except for change calendar restrictions)
  * api-change:``apprunner``: [``botocore``] This release contains several minor bug fixes.

1.18.52

=======
  
  * api-change:``network-firewall``: [``botocore``] This release adds support for strict ordering for stateful rule groups. Using strict ordering, stateful rules are evaluated in the exact order in which you provide them.
  * api-change:``dataexchange``: [``botocore``] This release enables subscribers to set up automatic exports of newly published revisions using the new EventAction API.
  * api-change:``workmail``: [``botocore``] This release adds support for mobile device access overrides management in Amazon WorkMail.
  * api-change:``account``: [``botocore``] This release of the Account Management API enables customers to manage the alternate contacts for their AWS accounts. For more information, see https://docs.aws.amazon.com/accounts/latest/reference/accounts-welcome.html
  * api-change:``workspaces``: [``botocore``] Added CreateUpdatedWorkspaceImage API to update WorkSpace images with latest software and drivers. Updated DescribeWorkspaceImages API to display if there are updates available for WorkSpace images.
  * api-change:``cloudcontrol``: [``botocore``] Initial release of the SDK for AWS Cloud Control API
  * api-change:``macie2``: [``botocore``] Amazon S3 bucket metadata now indicates whether an error or a bucket's permissions settings prevented Amazon Macie from retrieving data about the bucket or the bucket's objects.

1.18.51

=======
  
  * api-change:``lambda``: [``botocore``] Adds support for Lambda functions powered by AWS Graviton2 processors. Customers can now select the CPU architecture for their functions.
  * api-change:``sesv2``: [``botocore``] This release includes the ability to use 2048 bits RSA key pairs for DKIM in SES, either with Easy DKIM or Bring Your Own DKIM.
  * api-change:``amp``: [``botocore``] This release adds alert manager and rule group namespace APIs

1.18.50

=======
  
  * api-change:``transfer``: [``botocore``] Added changes for managed workflows feature APIs.
  * api-change:``imagebuilder``: [``botocore``] Fix description for AmiDistributionConfiguration Name property, which actually refers to the output AMI name. Also updated for consistent terminology to use "base" image, and another update to fix description text.

1.18.49

=======
  
  * api-change:``appintegrations``: [``botocore``] The Amazon AppIntegrations service enables you to configure and reuse connections to external applications.
  * api-change:``wisdom``: [``botocore``] Released Amazon Connect Wisdom, a feature of Amazon Connect, which provides real-time recommendations and search functionality in general availability (GA).  For more information, see https://docs.aws.amazon.com/wisdom/latest/APIReference/Welcome.html.
  * api-change:``pinpoint``: [``botocore``] Added support for journey with contact center activity
  * api-change:``voice-id``: [``botocore``] Released the Amazon Voice ID SDK, for usage with the Amazon Connect Voice ID feature released for Amazon Connect.
  * api-change:``connect``: [``botocore``] This release updates a set of APIs: CreateIntegrationAssociation, ListIntegrationAssociations, CreateUseCase, and StartOutboundVoiceContact. You can use it to create integrations with Amazon Pinpoint for the Amazon Connect Campaigns use case, Amazon Connect Voice ID, and Amazon Connect Wisdom.
  * api-change:``elbv2``: [``botocore``] Update elbv2 client to latest version

1.18.48

=======
  
  * api-change:``license-manager``: [``botocore``] AWS License Manager now allows customers to get the LicenseArn in the Checkout API Response.
  * api-change:``ec2``: [``botocore``] DescribeInstances now returns Platform Details, Usage Operation, and Usage Operation Update Time.

1.18.47

=======
  
  * api-change:``mediaconvert``: [``botocore``] This release adds style and positioning support for caption or subtitle burn-in from rich text sources such as TTML. This release also introduces configurable image-based trick play track generation.
  * api-change:``appsync``: [``botocore``] Documented the new OpenSearchServiceDataSourceConfig data type. Added deprecation notes to the ElasticsearchDataSourceConfig data type.
  * api-change:``ssm``: [``botocore``] Added cutoff behavior support for preventing new task invocations from starting when the maintenance window cutoff time is reached.

1.18.46

=======
  
  * api-change:``imagebuilder``: [``botocore``] This feature adds support for specifying GP3 volume throughput and configuring instance metadata options for instances launched by EC2 Image Builder.
  * api-change:``wafv2``: [``botocore``] Added the regex match rule statement, for matching web requests against a single regular expression.
  * api-change:``mediatailor``: [``botocore``] This release adds support to configure logs for playback configuration.
  * api-change:``lexv2-models``: [``botocore``] Update lexv2-models client to latest version
  * api-change:``iam``: [``botocore``] Added changes to OIDC API about not using port numbers in the URL.
  * api-change:``license-manager``: [``botocore``] AWS License Manager now allows customers to change their Windows Server or SQL license types from Bring-Your-Own-License (BYOL) to License Included or vice-versa (using the customer's media).
  * api-change:``mediapackage-vod``: [``botocore``] MediaPackage VOD will now return the current processing statuses of an asset's endpoints. The status can be QUEUED, PROCESSING, PLAYABLE, or FAILED.

1.18.45

=======
  
  * api-change:``comprehend``: [``botocore``] Amazon Comprehend now supports versioning of custom models, improved training with ONE_DOC_PER_FILE text documents for custom entity recognition, ability to provide specific test sets during training, and live migration to new model endpoints.
  * api-change:``iot``: [``botocore``] This release adds support for verifying, viewing and filtering AWS IoT Device Defender detect violations with four verification states.
  * api-change:``ecr``: [``botocore``] This release adds additional support for repository replication
  * api-change:``ec2``: [``botocore``] This update adds support for downloading configuration templates using new APIs (GetVpnConnectionDeviceTypes and GetVpnConnectionDeviceSampleConfiguration) and Internet Key Exchange version 2 (IKEv2) parameters for many popular CGW devices.

1.18.44

=======
  
  * api-change:``opensearch``: [``botocore``] This release adds an optional parameter in the ListDomainNames API to filter domains based on the engine type (OpenSearch/Elasticsearch).
  * api-change:``es``: [``botocore``] This release adds an optional parameter in the ListDomainNames API to filter domains based on the engine type (OpenSearch/Elasticsearch).
  * api-change:``dms``: [``botocore``] Optional flag force-planned-failover added to reboot-replication-instance API call. This flag can be used to test a planned failover scenario used during some maintenance operations.

1.18.43

=======
  
  * api-change:``kafkaconnect``: [``botocore``] This is the initial SDK release for Amazon Managed Streaming for Apache Kafka Connect (MSK Connect).
  * api-change:``macie2``: [``botocore``] This release adds support for specifying which managed data identifiers are used by a classification job, and retrieving a list of managed data identifiers that are available.
  * api-change:``robomaker``: [``botocore``] Adding support to create container based Robot and Simulation applications by introducing an environment field
  * api-change:``s3``: [``botocore``] Add support for access point arn filtering in S3 CW Request Metrics
  * api-change:``transcribe``: [``botocore``] This release adds support for subtitling with Amazon Transcribe batch jobs.
  * api-change:``sagemaker``: [``botocore``] Add API for users to retry a failed pipeline execution or resume a stopped one.
  * api-change:``pinpoint``: [``botocore``] This SDK release adds a new feature for Pinpoint campaigns, in-app messaging.

1.18.42

=======
  
  * api-change:``sagemaker``: [``botocore``] This release adds support for "Project Search"
  * api-change:``ec2``: [``botocore``] This release adds support for vt1 3xlarge, 6xlarge and 24xlarge instances powered by Xilinx Alveo U30 Media Accelerators for video transcoding workloads
  * api-change:``wafv2``: [``botocore``] This release adds support for including rate based rules in a rule group.
  * api-change:``chime``: [``botocore``] Adds support for SipHeaders parameter for CreateSipMediaApplicationCall.
  * api-change:``comprehend``: [``botocore``] Amazon Comprehend now allows you to train and run PDF and Word documents for custom entity recognition. With PDF and Word formats, you can extract information from documents containing headers, lists and tables.

1.18.41

=======
  
  * api-change:``iot``: [``botocore``] AWS IoT Rules Engine adds OpenSearch action. The OpenSearch rule action lets you stream data from IoT sensors and applications to Amazon OpenSearch Service which is a successor to Amazon Elasticsearch Service.
  * api-change:``ec2``: [``botocore``] Adds support for T3 instances on Amazon EC2 Dedicated Hosts.
  * enhancement:Tagged Unions: [``botocore``] Introducing support for the `union` trait on structures in request and response objects.

1.18.40

=======
  
  * api-change:``cloudformation``: [``botocore``] Doc only update for CloudFormation that fixes several customer-reported issues.
  * api-change:``rds``: [``botocore``] This release adds support for providing a custom timeout value for finding a scaling point during autoscaling in Aurora Serverless v1.
  * api-change:``ecr``: [``botocore``] This release updates terminology around KMS keys.
  * api-change:``sagemaker``: [``botocore``] This release adds support for "Lifecycle Configurations" to SageMaker Studio
  * api-change:``transcribe``: [``botocore``] This release adds an API option for startTranscriptionJob and startMedicalTranscriptionJob that allows the user to specify encryption context key value pairs for batch jobs.
  * api-change:``quicksight``: [``botocore``] Add new data source type for Amazon OpenSearch (successor to Amazon ElasticSearch).

1.18.39

=======
  
  * api-change:``emr``: [``botocore``] Update emr client to latest version
  * api-change:``codeguru-reviewer``: [``botocore``] The Amazon CodeGuru Reviewer API now includes the RuleMetadata data object and a Severity attribute on a RecommendationSummary object. A RuleMetadata object contains information about a rule that generates a recommendation. Severity indicates how severe the issue associated with a recommendation is.
  * api-change:``lookoutequipment``: [``botocore``] Added OffCondition parameter to CreateModel API

1.18.38

=======
  
  * api-change:``opensearch``: [``botocore``] Updated Configuration APIs for Amazon OpenSearch Service (successor to Amazon Elasticsearch Service)
  * api-change:``ram``: [``botocore``] A minor text-only update that fixes several customer issues.
  * api-change:``kafka``: [``botocore``] Amazon MSK has added a new API that allows you to update the encrypting and authentication settings for an existing cluster.

1.18.37

=======
  
  * api-change:``elasticache``: [``botocore``] Doc only update for ElastiCache
  * api-change:``amp``: [``botocore``] This release adds tagging support for Amazon Managed Service for Prometheus workspace.
  * api-change:``forecast``: [``botocore``] Predictor creation now supports selecting an accuracy metric to optimize in AutoML and hyperparameter optimization. This release adds additional accuracy metrics for predictors - AverageWeightedQuantileLoss, MAPE and MASE.
  * api-change:``xray``: [``botocore``] Updated references to AWS KMS keys and customer managed keys to reflect current terminology.
  * api-change:``ssm-contacts``: [``botocore``] Added SDK examples for SSM-Contacts.
  * api-change:``mediapackage``: [``botocore``] SPEKE v2 support for live CMAF packaging type. SPEKE v2 is an upgrade to the existing SPEKE API to support multiple encryption keys, it supports live DASH currently.
  * api-change:``eks``: [``botocore``] Adding RegisterCluster and DeregisterCluster operations, to support connecting external clusters to EKS.

1.18.36

=======
  
  * api-change:``chime-sdk-identity``: [``botocore``] Documentation updates for Chime
  * api-change:``chime-sdk-messaging``: [``botocore``] Documentation updates for Chime
  * api-change:``outposts``: [``botocore``] This release adds a new API CreateOrder.
  * api-change:``frauddetector``: [``botocore``] Enhanced GetEventPrediction API response to include risk scores from imported SageMaker models
  * api-change:``codeguru-reviewer``: [``botocore``] Added support for CodeInconsistencies detectors

1.18.35

=======
  
  * api-change:``acm-pca``: [``botocore``] Private Certificate Authority Service now allows customers to enable an online certificate status protocol (OCSP) responder service on their private certificate authorities. Customers can also optionally configure a custom CNAME for their OCSP responder.
  * api-change:``s3control``: [``botocore``] S3 Multi-Region Access Points provide a single global endpoint to access a data set that spans multiple S3 buckets in different AWS Regions.
  * api-change:``accessanalyzer``: [``botocore``] Updates service API, documentation, and paginators to support multi-region access points from Amazon S3.
  * api-change:``schemas``: [``botocore``] This update include the support for Schema Discoverer to discover the events sent to the bus from another account. The feature will be enabled by default when discoverer is created or updated but can also be opt-in or opt-out  by specifying the value for crossAccount.
  * api-change:``securityhub``: [``botocore``] New ASFF Resources: AwsAutoScalingLaunchConfiguration, AwsEc2VpnConnection, AwsEcrContainerImage. Added KeyRotationStatus to AwsKmsKey. Added AccessControlList, BucketLoggingConfiguration,BucketNotificationConfiguration and BucketNotificationConfiguration to AwsS3Bucket.
  * enhancement:s3: [``botocore``] Added support for S3 Multi-Region Access Points
  * api-change:``efs``: [``botocore``] Update efs client to latest version
  * api-change:``transfer``: [``botocore``] AWS Transfer Family introduces Managed Workflows for creating, executing, monitoring, and standardizing post file transfer processing
  * api-change:``ebs``: [``botocore``] Documentation updates for Amazon EBS direct APIs.
  * api-change:``quicksight``: [``botocore``] This release adds support for referencing parent datasets as sources in a child dataset.
  * api-change:``fsx``: [``botocore``] Announcing Amazon FSx for NetApp ONTAP, a new service that provides fully managed shared storage in the AWS Cloud with the data access and management capabilities of ONTAP.
  * enhancement:Signers: [``botocore``] Added support for Sigv4a Signing Algorithm
  * api-change:``lex-models``: [``botocore``] Lex now supports Korean (ko-KR) locale.

1.18.34

=======
  
  * api-change:``ec2``: [``botocore``] Added LaunchTemplate support for the IMDS IPv6 endpoint
  * api-change:``cloudtrail``: [``botocore``] Documentation updates for CloudTrail
  * api-change:``mediatailor``: [``botocore``] This release adds support for wall clock programs in LINEAR channels.
  * api-change:``config``: [``botocore``] Documentation updates for config
  * api-change:``servicecatalog-appregistry``: [``botocore``] Introduction of GetAssociatedResource API and GetApplication response extension for Resource Groups support.

1.18.33

=======
  
  * api-change:``iot``: [``botocore``] Added Create/Update/Delete/Describe/List APIs for a new IoT resource named FleetMetric. Added a new Fleet Indexing query API named GetBucketsAggregation. Added a new field named DisconnectedReason in Fleet Indexing query response. Updated their related documentations.
  * api-change:``polly``: [``botocore``] Amazon Polly adds new South African English voice - Ayanda. Ayanda is available as Neural voice only.
  * api-change:``compute-optimizer``: [``botocore``] Documentation updates for Compute Optimizer
  * api-change:``sqs``: [``botocore``] Amazon SQS adds a new queue attribute, RedriveAllowPolicy, which includes the dead-letter queue redrive permission parameters. It defines which source queues can specify dead-letter queues as a JSON object.
  * api-change:``memorydb``: [``botocore``] Documentation updates for MemoryDB

1.18.32

=======
  
  * api-change:``codebuild``: [``botocore``] Documentation updates for CodeBuild
  * api-change:``firehose``: [``botocore``] This release adds the Dynamic Partitioning feature to Kinesis Data Firehose service for S3 destinations.
  * api-change:``kms``: [``botocore``] This release has changes to KMS nomenclature to remove the word master from both the "Customer master key" and "CMK" abbreviation and replace those naming conventions with "KMS key".
  * api-change:``cloudformation``: [``botocore``] AWS CloudFormation allows you to iteratively develop your applications when failures are encountered without rolling back successfully provisioned resources. By specifying stack failure options, you can troubleshoot resources in a CREATE_FAILED or UPDATE_FAILED status.

1.18.31

=======
  
  * api-change:``s3``: [``botocore``] Documentation updates for Amazon S3.
  * api-change:``emr``: [``botocore``] Update emr client to latest version
  * api-change:``ec2``: [``botocore``] This release adds the BootMode flag to the ImportImage API and showing the detected BootMode of an ImportImage task.

1.18.30

=======
  
  * api-change:``transcribe``: [``botocore``] This release adds support for batch transcription in six new languages - Afrikaans, Danish, Mandarin Chinese (Taiwan), New Zealand English, South African English, and Thai.
  * api-change:``rekognition``: [``botocore``] This release added new attributes to Rekognition RecognizeCelebities and GetCelebrityInfo API operations.
  * api-change:``ec2``: [``botocore``] Support added for resizing VPC prefix lists
  * api-change:``compute-optimizer``: [``botocore``] Adds support for 1) the AWS Graviton (AWS_ARM64) recommendation preference for Amazon EC2 instance and Auto Scaling group recommendations, and 2) the ability to get the enrollment statuses for all member accounts of an organization.

1.18.29

=======
  
  * api-change:``fms``: [``botocore``] AWS Firewall Manager now supports triggering resource cleanup workflow when account or resource goes out of policy scope for AWS WAF, Security group, AWS Network Firewall, and Amazon Route 53 Resolver DNS Firewall policies.
  * api-change:``ec2``: [``botocore``] Support added for IMDS IPv6 endpoint
  * api-change:``datasync``: [``botocore``] Added include filters to CreateTask and UpdateTask, and added exclude filters to StartTaskExecution, giving customers more granular control over how DataSync transfers files, folders, and objects.
  * api-change:``events``: [``botocore``] AWS CWEvents adds an enum of EXTERNAL for EcsParameters LaunchType for PutTargets API

1.18.28

=======
  
  * api-change:``mediaconvert``: [``botocore``] AWS Elemental MediaConvert SDK has added MBAFF encoding support for AVC video and the ability to pass encryption context from the job settings to S3.
  * api-change:``polly``: [``botocore``] Amazon Polly adds new New Zealand English voice - Aria. Aria is available as Neural voice only.
  * api-change:``transcribe``: [``botocore``] This release adds support for feature tagging with Amazon Transcribe batch jobs.
  * api-change:``ssm``: [``botocore``] Updated Parameter Store property for logging improvements.
  * api-change:``iot-data``: [``botocore``] Updated Publish with support for new Retain flag and added two new API operations: GetRetainedMessage, ListRetainedMessages.

1.18.27

=======
  
  * api-change:``dms``: [``botocore``] Amazon AWS DMS service now support Redis target endpoint migration. Now S3 endpoint setting is capable to setup features which are used to be configurable only in extract connection attributes.
  * api-change:``frauddetector``: [``botocore``] Updated an element of the DescribeModelVersion API response (LogitMetrics -> logOddsMetrics) for clarity. Added new exceptions to several APIs to protect against unlikely scenarios.
  * api-change:``iotsitewise``: [``botocore``] Documentation updates for AWS IoT SiteWise
  * api-change:``dlm``: [``botocore``] Added AMI deprecation support for Amazon Data Lifecycle Manager EBS-backed AMI policies.
  * api-change:``glue``: [``botocore``] Add support for Custom Blueprints
  * api-change:``apigateway``: [``botocore``] Adding some of the pending releases (1) Adding WAF Filter to GatewayResponseType enum (2) Ensuring consistent error model for all operations (3) Add missing BRE to GetVpcLink operation
  * api-change:``backup``: [``botocore``] AWS Backup - Features: Evaluate your backup activity and generate audit reports.

1.18.26

=======
  
  * api-change:``eks``: [``botocore``] Adds support for EKS add-ons "preserve" flag, which allows customers to maintain software on their EKS clusters after removing it from EKS add-ons management.
  * api-change:``comprehend``: [``botocore``] Add tagging support for Comprehend async inference job.
  * api-change:``robomaker``: [``botocore``] Documentation updates for RoboMaker
  * api-change:``ec2``: [``botocore``] encryptionInTransitSupported added to DescribeInstanceTypes API

1.18.25

=======
  
  * api-change:``ec2``: [``botocore``] The ImportImage API now supports the ability to create AMIs with AWS-managed licenses for Microsoft SQL Server for both Windows and Linux.
  * api-change:``memorydb``: [``botocore``] AWS MemoryDB  SDK now supports all APIs for newly launched MemoryDB service.
  * api-change:``application-autoscaling``: [``botocore``] This release extends Application Auto Scaling support for replication group of Amazon ElastiCache Redis clusters. Auto Scaling monitors and automatically expands node group count and number of replicas per node group when a critical usage threshold is met or according to customer-defined schedule.
  * api-change:``appflow``: [``botocore``] This release adds support for SAPOData connector and extends Veeva connector for document extraction.

1.18.24

=======
  
  * api-change:``codebuild``: [``botocore``] CodeBuild now allows you to make the build results for your build projects available to the public without requiring access to an AWS account.
  * api-change:``route53``: [``botocore``] Documentation updates for route53
  * api-change:``sagemaker-runtime``: [``botocore``] Update sagemaker-runtime client to latest version
  * api-change:``route53resolver``: [``botocore``] Documentation updates for Route 53 Resolver
  * api-change:``sagemaker``: [``botocore``] Amazon SageMaker now supports Asynchronous Inference endpoints. Adds PlatformIdentifier field that allows Notebook Instance creation with different platform selections. Increases the maximum number of containers in multi-container endpoints to 15. Adds more instance types to InstanceType field.

1.18.23

=======
  
  * api-change:``cloud9``: [``botocore``] Added DryRun parameter to CreateEnvironmentEC2 API. Added ManagedCredentialsActions parameter to UpdateEnvironment API
  * api-change:``ec2``: [``botocore``] This release adds support for EC2 ED25519 key pairs for authentication
  * api-change:``clouddirectory``: [``botocore``] Documentation updates for clouddirectory
  * api-change:``ce``: [``botocore``] This release is a new feature for Cost Categories: Split charge rules. Split charge rules enable you to allocate shared costs between your cost category values.
  * api-change:``logs``: [``botocore``] Documentation-only update for CloudWatch Logs

1.18.22

=======
  
  * api-change:``iotsitewise``: [``botocore``] AWS IoT SiteWise added query window for the interpolation interval. AWS IoT SiteWise computes each interpolated value by using data points from the timestamp of each interval minus the window to the timestamp of each interval plus the window.
  * api-change:``s3``: [``botocore``] Documentation updates for Amazon S3
  * api-change:``codebuild``: [``botocore``] CodeBuild now allows you to select how batch build statuses are sent to the source provider for a project.
  * api-change:``ds``: [``botocore``] This release adds support for describing client authentication settings.
  * api-change:``config``: [``botocore``] Update ResourceType enum with values for Backup Plan, Selection, Vault, RecoveryPoint; ECS Cluster, Service, TaskDefinition; EFS AccessPoint, FileSystem; EKS Cluster; ECR Repository resources
  * api-change:``license-manager``: [``botocore``] AWS License Manager now allows end users to call CheckoutLicense API using new CheckoutType PERPETUAL. Perpetual checkouts allow sellers to check out a quantity of entitlements to be drawn down for consumption.

1.18.21

=======
  
  * api-change:``quicksight``: [``botocore``] Documentation updates for QuickSight.
  * api-change:``emr``: [``botocore``] Update emr client to latest version
  * api-change:``customer-profiles``: [``botocore``] This release introduces Standard Profile Objects, namely Asset and Case which contain values populated by data from third party systems and belong to a specific profile. This release adds an optional parameter, ObjectFilter to the ListProfileObjects API in order to search for these Standard Objects.
  * api-change:``elasticache``: [``botocore``] This release adds ReplicationGroupCreateTime field to ReplicationGroup which indicates the UTC time when ElastiCache ReplicationGroup is created

1.18.20

=======
  
  * api-change:``sagemaker``: [``botocore``] Amazon SageMaker Autopilot adds new metrics for all candidate models generated by Autopilot experiments.
  * api-change:``apigatewayv2``: [``botocore``] Adding support for ACM imported or private CA certificates for mTLS enabled domain names
  * api-change:``apigateway``: [``botocore``] Adding support for ACM imported or private CA certificates for mTLS enabled domain names
  * api-change:``databrew``: [``botocore``] This SDK release adds support for the output of a recipe job results to Tableau Hyper format.
  * api-change:``lambda``: [``botocore``] Lambda Python 3.9 runtime launch

1.18.19

=======
  
  * api-change:``snow-device-management``: [``botocore``] AWS Snow Family customers can remotely monitor and operate their connected AWS Snowcone devices.
  * api-change:``ecs``: [``botocore``] Documentation updates for ECS.
  * api-change:``nimble``: [``botocore``] Add new attribute 'ownedBy' in Streaming Session APIs. 'ownedBy' represents the AWS SSO Identity Store User ID of the owner of the Streaming Session resource.
  * api-change:``codebuild``: [``botocore``] CodeBuild now allows you to make the build results for your build projects available to the public without requiring access to an AWS account.
  * api-change:``ebs``: [``botocore``] Documentation updates for Amazon EBS direct APIs.
  * api-change:``route53``: [``botocore``] Documentation updates for route53

1.18.18

=======
  
  * api-change:``chime``: [``botocore``] Add support for "auto" in Region field of StartMeetingTranscription API request.
  * enchancement:Client: [``botocore``] Improve client performance by caching _alias_event_name on EventAliaser

1.18.17

=======
  
  * api-change:``wafv2``: [``botocore``] This release adds APIs to support versioning feature of AWS WAF Managed rule groups
  * api-change:``rekognition``: [``botocore``] This release adds support for four new types of segments (opening credits, content segments, slates, and studio logos), improved accuracy for credits and shot detection and new filters to control black frame detection.
  * api-change:``ssm``: [``botocore``] Documentation updates for AWS Systems Manager.

1.18.16

=======
  
  * api-change:``synthetics``: [``botocore``] Documentation updates for Visual Monitoring feature and other doc ticket fixes.
  * api-change:``chime-sdk-identity``: [``botocore``] The Amazon Chime SDK Identity APIs allow software developers to create and manage unique instances of their messaging applications.
  * api-change:``chime-sdk-messaging``: [``botocore``] The Amazon Chime SDK Messaging APIs allow software developers to send and receive messages in custom messaging applications.
  * api-change:``connect``: [``botocore``] This release adds support for agent status and hours of operation. For details, see the Release Notes in the Amazon Connect Administrator Guide.
  * api-change:``lightsail``: [``botocore``] This release adds support to track when a bucket access key was last used.
  * api-change:``athena``: [``botocore``] Documentation updates for Athena.

1.18.15

=======
  
  * api-change:``lexv2-models``: [``botocore``] Update lexv2-models client to latest version
  * api-change:``autoscaling``: [``botocore``] EC2 Auto Scaling adds configuration checks and Launch Template validation to Instance Refresh.

1.18.14

=======
  
  * api-change:``rds``: [``botocore``] This release adds AutomaticRestartTime to the DescribeDBInstances and DescribeDBClusters operations. AutomaticRestartTime indicates the time when a stopped DB instance or DB cluster is restarted automatically.
  * api-change:``imagebuilder``: [``botocore``] Updated list actions to include a list of valid filters that can be used in the request.
  * api-change:``transcribe``: [``botocore``] This release adds support for call analytics (batch) within Amazon Transcribe.
  * api-change:``events``: [``botocore``] Update events client to latest version
  * api-change:``ssm-incidents``: [``botocore``] Documentation updates for Incident Manager.

1.18.13

=======
  
  * api-change:``redshift``: [``botocore``] API support for Redshift Data Sharing feature.
  * api-change:``iotsitewise``: [``botocore``] My AWS Service (placeholder) - This release introduces custom Intervals and offset for tumbling window in metric for AWS IoT SiteWise.
  * api-change:``glue``: [``botocore``] Add ConcurrentModificationException to create-table, delete-table, create-database, update-database, delete-database
  * api-change:``mediaconvert``: [``botocore``] AWS Elemental MediaConvert SDK has added control over the passthrough of XDS captions metadata to outputs.
  * api-change:``proton``: [``botocore``] Docs only add idempotent create apis

1.18.12

=======
  
  * api-change:``ssm-contacts``: [``botocore``] Added new attribute in AcceptCode API. AcceptCodeValidation takes in two values - ENFORCE, IGNORE. ENFORCE forces validation of accept code and IGNORE ignores it which is also the default behavior; Corrected TagKeyList length from 200 to 50
  * api-change:``greengrassv2``: [``botocore``] This release adds support for component system resource limits and idempotent Create operations. You can now specify the maximum amount of CPU and memory resources that each component can use.

1.18.11

=======
  
  * api-change:``appsync``: [``botocore``] AWS AppSync now supports a new authorization mode allowing you to define your own authorization logic using an AWS Lambda function.
  * api-change:``elbv2``: [``botocore``] Update elbv2 client to latest version
  * api-change:``secretsmanager``: [``botocore``] Add support for KmsKeyIds in the ListSecretVersionIds API response
  * api-change:``sagemaker``: [``botocore``] API changes with respect to Lambda steps in model building pipelines. Adds several waiters to async Sagemaker Image APIs. Add more instance types to AppInstanceType field

1.18.10

=======
  
  * api-change:``savingsplans``: [``botocore``] Documentation update for valid Savings Plans offering ID pattern
  * api-change:``ec2``: [``botocore``] This release adds support for G4ad xlarge and 2xlarge instances powered by AMD Radeon Pro V520 GPUs and AMD 2nd Generation EPYC processors
  * api-change:``chime``: [``botocore``] Adds support for live transcription of meetings with Amazon Transcribe and Amazon Transcribe Medical.  The new APIs, StartMeetingTranscription and StopMeetingTranscription, control the generation of user-attributed transcriptions sent to meeting clients via Amazon Chime SDK data messages.
  * api-change:``iotsitewise``: [``botocore``] Added support for AWS IoT SiteWise Edge. You can now create an AWS IoT SiteWise gateway that runs on AWS IoT Greengrass V2. With the gateway,  you can collect local server and equipment data, process the data, and export the selected data from the edge to the AWS Cloud.
  * api-change:``iot``: [``botocore``] Increase maximum credential duration of role alias to 12 hours.

1.18.9

======
  
  * api-change:``sso-admin``: [``botocore``] Documentation updates for arn:aws:trebuchet:::service:v1:03a2216d-1cda-4696-9ece-1387cb6f6952
  * api-change:``cloudformation``: [``botocore``] SDK update to support Importing existing Stacks to new/existing Self Managed StackSet - Stack Import feature.

1.18.8

======
  
  * api-change:``route53``: [``botocore``] This release adds support for the RECOVERY_CONTROL health check type to be used in conjunction with Route53 Application Recovery Controller.
  * api-change:``iotwireless``: [``botocore``] Add SidewalkManufacturingSn as an identifier to allow Customer to query WirelessDevice, in the response, AmazonId is added in the case that Sidewalk device is return.
  * api-change:``route53-recovery-control-config``: [``botocore``] Amazon Route 53 Application Recovery Controller's routing control - Routing Control Configuration APIs help you create and delete clusters, control panels, routing controls and safety rules. State changes (On/Off) of routing controls are not part of configuration APIs.
  * api-change:``route53-recovery-readiness``: [``botocore``] Amazon Route 53 Application Recovery Controller's readiness check capability continually monitors resource quotas, capacity, and network routing policies to ensure that the recovery environment is scaled and configured to take over when needed.
  * api-change:``quicksight``: [``botocore``] Add support to use row-level security with tags when embedding dashboards for users not provisioned in QuickSight
  * api-change:``iotanalytics``: [``botocore``] IoT Analytics now supports creating a dataset resource with IoT SiteWise MultiLayerStorage data stores, enabling customers to query industrial data within the service. This release includes adding JOIN functionality for customers to query multiple data sources in a dataset.
  * api-change:``shield``: [``botocore``] Change name of DDoS Response Team (DRT) to Shield Response Team (SRT)
  * api-change:``lexv2-models``: [``botocore``] Update lexv2-models client to latest version
  * api-change:``redshift-data``: [``botocore``] Added structures to support new Data API operation BatchExecuteStatement, used to execute multiple SQL statements within a single transaction.
  * api-change:``route53-recovery-cluster``: [``botocore``] Amazon Route 53 Application Recovery Controller's routing control - Routing Control Data Plane APIs help you update the state (On/Off) of the routing controls to reroute traffic across application replicas in a 100% available manner.
  * api-change:``batch``: [``botocore``] Add support for ListJob filters

1.18.7

======
  
  * api-change:``s3control``: [``botocore``] S3 Access Point aliases can be used anywhere you use S3 bucket names to access data in S3
  * api-change:``textract``: [``botocore``] Adds support for AnalyzeExpense, a new API to extract relevant data such as contact information, items purchased, and vendor name, from almost any invoice or receipt without the need for any templates or configuration.
  * api-change:``proton``: [``botocore``] Documentation-only update links
  * api-change:``identitystore``: [``botocore``] Documentation updates for SSO API Ref.
  * api-change:``cloudwatch``: [``botocore``] Update cloudwatch client to latest version
  * api-change:``synthetics``: [``botocore``] CloudWatch Synthetics now supports visual testing in its canaries.

1.18.6

======
  
  * api-change:``securityhub``: [``botocore``] Added product name, company name, and Region fields for security findings. Added details objects for RDS event subscriptions and AWS ECS services. Added fields to the details for AWS Elasticsearch domains.
  * api-change:``imagebuilder``: [``botocore``] Update to documentation to reapply missing change to SSM uninstall switch default value and improve description.
  * api-change:``s3outposts``: [``botocore``] Add on-premise access type support for endpoints

1.18.5

======
  
  * api-change:``medialive``: [``botocore``] MediaLive now supports passing through style data on WebVTT caption outputs.
  * api-change:``databrew``: [``botocore``] This SDK release adds two new features: 1) Output to Native JDBC destinations and 2) Adding configurations to profile jobs
  * api-change:``elbv2``: [``botocore``] Update elbv2 client to latest version
  * api-change:``s3control``: [``botocore``] Documentation updates for Amazon S3-control
  * api-change:``ec2``: [``botocore``] This release allows customers to assign prefixes to their elastic network interface and to reserve IP blocks in their subnet CIDRs. These reserved blocks can be used to assign prefixes to elastic network interfaces or be excluded from auto-assignment.
  * api-change:``qldb``: [``botocore``] Amazon QLDB now supports ledgers encrypted with customer managed KMS keys. Changes in CreateLedger, UpdateLedger and DescribeLedger APIs to support the changes.

1.18.4

======
  
  * api-change:``kendra``: [``botocore``] Amazon Kendra now provides a data source connector for Amazon WorkDocs. For more information, see https://docs.aws.amazon.com/kendra/latest/dg/data-source-workdocs.html
  * api-change:``proton``: [``botocore``] Documentation updates for AWS Proton
  * api-change:``iam``: [``botocore``] Documentation updates for AWS Identity and Access Management (IAM).
  * api-change:``rds``: [``botocore``] Adds the OriginalSnapshotCreateTime field to the DBSnapshot response object. This field timestamps the underlying data of a snapshot and doesn't change when the snapshot is copied.
  * api-change:``elbv2``: [``botocore``] Update elbv2 client to latest version
  * api-change:``lambda``: [``botocore``] New ResourceConflictException error code for PutFunctionEventInvokeConfig, UpdateFunctionEventInvokeConfig, and DeleteFunctionEventInvokeConfig operations.
  * api-change:``codebuild``: [``botocore``] AWS CodeBuild now allows you to set the access permissions for build artifacts, project artifacts, and log files that are uploaded to an Amazon S3 bucket that is owned by another account.
  * api-change:``personalize``: [``botocore``] My AWS Service (placeholder) - Making minProvisionedTPS an optional parameter when creating a campaign. If not provided, it defaults to 1.
  * api-change:``emr``: [``botocore``] Update emr client to latest version

1.18.3

======
  
  * api-change:``compute-optimizer``: [``botocore``] Documentation updates for Compute Optimizer
  * api-change:``ec2``: [``botocore``] Added idempotency to the CreateVolume API using the ClientToken request parameter

1.18.2

======
  
  * api-change:``imagebuilder``: [``botocore``] Documentation updates for reversal of default value for additional instance configuration SSM switch, plus improved descriptions for semantic versioning.
  * api-change:``directconnect``: [``botocore``] Documentation updates for directconnect
  * api-change:``health``: [``botocore``] In the Health API, the maximum number of entities for the EventFilter and EntityFilter data types has changed from 100 to 99. This change is related to an internal optimization of the AWS Health service.
  * api-change:``robomaker``: [``botocore``] This release allows customers to create a new version of WorldTemplates with support for Doors.
  * api-change:``location``: [``botocore``] Add five new API operations: UpdateGeofenceCollection, UpdateMap, UpdatePlaceIndex, UpdateRouteCalculator, UpdateTracker.
  * api-change:``emr-containers``: [``botocore``] Updated DescribeManagedEndpoint and ListManagedEndpoints to return failureReason and stateDetails in API response.

1.18.1

======
  
  * api-change:``appintegrations``: [``botocore``] Documentation update for AppIntegrations Service
  * api-change:``chime``: [``botocore``] This SDK release adds Account Status as one of the attributes in Account API response
  * api-change:``auditmanager``: [``botocore``] This release relaxes the S3 URL character restrictions in AWS Audit Manager. Regex patterns have been updated for the following attributes: s3RelativePath, destination, and s3ResourcePath. 'AWS' terms have also been replaced with entities to align with China Rebrand documentation efforts.

1.18.0

======
  
  * api-change:``ec2``: [``botocore``] This feature enables customers  to specify weekly recurring time window(s) for scheduled events that reboot, stop or terminate EC2 instances.
  * api-change:``cognito-idp``: [``botocore``] Documentation updates for cognito-idp
  * api-change:``ecs``: [``botocore``] Documentation updates for support of awsvpc mode on Windows.
  * api-change:``lex-models``: [``botocore``] Lex now supports the en-IN locale
  * api-change:``iotsitewise``: [``botocore``] Update the default endpoint for the APIs used to manage asset models, assets, gateways, tags, and account configurations. If you have firewalls with strict egress rules, configure the rules to grant you access to api.iotsitewise.[region].amazonaws.com or api.iotsitewise.[cn-region].amazonaws.com.cn.
  * feature:Python: Drop support for Python 2.7
  * feature:Python: [``botocore``] Dropped support for Python 2.7


```