### PR TITLE
Upgrade regex

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -92,7 +92,8 @@ python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==5.4.1
 redis==2.10.6
-regex==2018.1.10
+regex==2021.3.17; python_version < '3.0'
+regex==2021.11.10; python_version >= '3.0'
 requests==2.26.0
 requests-file==1.5.1
 rollbar==0.16.2


### PR DESCRIPTION
This is flanker dependency.

https://github.com/mrabarnett/mrab-regex does not provide a changelog or tags so ...
It's mostly extending stdlib re and adding new features only so it should be safe to do.