### PR TITLE
Gate simplegeneric on Python 3

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -101,7 +101,7 @@ scandir==1.10.0
 setproctitle==1.1.10; python_version < '3.0'
 setproctitle==1.2.2; python_version >= '3.0'
 setuptools==44.0.0
-simplegeneric==0.8.1
+simplegeneric==0.8.1; python_version < '3.0'
 singledispatch==3.4.0.3
 six==1.11.0
 sqlalchemy==1.4.26


### PR DESCRIPTION
This is a backport. Python 2.7 only dep.