### PR TITLE
Bring back pip install -e temporarily

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN if [ "${PYTHON_VERSION}" != "3.6" ] ; \
 RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
   python"${PYTHON_VERSION}" get-pip.py && \
   python"${PYTHON_VERSION}" -m pip install --upgrade pip==$( if [ "${PYTHON_VERSION}" = "2.7" ] ; then echo 20.3.4; else echo 21.3.1; fi) && \
-  python"${PYTHON_VERSION}" -m pip install virtualenv==20.8.1 && \
+  python"${PYTHON_VERSION}" -m pip install virtualenv==20.8.1
 
 RUN mkdir /etc/inboxapp && \
   chown sync-engine:sync-engine /etc/inboxapp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN \
-  --mount=type=cache,target=/home/sync-engine/.cache,uid=5000,gid=5000  \
   python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==44.0.0 pip==20.3.4 && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
   python"${PYTHON_VERSION}" get-pip.py && \
   python"${PYTHON_VERSION}" -m pip install --upgrade pip==$( if [ "${PYTHON_VERSION}" = "2.7" ] ; then echo 20.3.4; else echo 21.3.1; fi) && \
   python"${PYTHON_VERSION}" -m pip install virtualenv==20.8.1 && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install -e .
+  python"${PYTHON_VERSION}" -m pip install -e .
 
 RUN mkdir /etc/inboxapp && \
   chown sync-engine:sync-engine /etc/inboxapp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
   python"${PYTHON_VERSION}" get-pip.py && \
   python"${PYTHON_VERSION}" -m pip install --upgrade pip==$( if [ "${PYTHON_VERSION}" = "2.7" ] ; then echo 20.3.4; else echo 21.3.1; fi) && \
   python"${PYTHON_VERSION}" -m pip install virtualenv==20.8.1 && \
-  python"${PYTHON_VERSION}" -m pip install -e .
 
 RUN mkdir /etc/inboxapp && \
   chown sync-engine:sync-engine /etc/inboxapp && \
@@ -65,9 +64,11 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN \
+  --mount=type=cache,target=/home/sync-engine/.cache,uid=5000,gid=5000  \
   python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
   /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==44.0.0 pip==20.3.4 && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt
+  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt && \
+  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install -e .
 
 RUN /opt/venv/bin/python"${PYTHON_VERSION}" -m pip check
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN if [ "${PYTHON_VERSION}" != "3.6" ] ; \
 RUN curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
   python"${PYTHON_VERSION}" get-pip.py && \
   python"${PYTHON_VERSION}" -m pip install --upgrade pip==$( if [ "${PYTHON_VERSION}" = "2.7" ] ; then echo 20.3.4; else echo 21.3.1; fi) && \
-  python"${PYTHON_VERSION}" -m pip install virtualenv==20.8.1
+  python"${PYTHON_VERSION}" -m pip install virtualenv==20.8.1 && \
+  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install -e .
 
 RUN mkdir /etc/inboxapp && \
   chown sync-engine:sync-engine /etc/inboxapp && \


### PR DESCRIPTION
When working on https://github.com/closeio/sync-engine/pull/250/files I forgot that we rely on the fact that those scripts end up on PATH when deploying.