### PR TITLE
Fix the case where queue_name is already string because it did not arrive from Redis.

### DIFF
--- a/inbox/scheduling/event_queue.py
+++ b/inbox/scheduling/event_queue.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from redis import StrictRedis
 
@@ -38,7 +38,7 @@ class EventQueue(object):
 
     def receive_event(self, timeout=0):
         # type: (int) -> Dict[str, Any]
-        result = None
+        result = None  # type: Optional[Union[bytes, Tuple[bytes, bytes]]]
         if timeout is None:
             result = self.redis.lpop(self.queue_name)
         else:
@@ -78,7 +78,9 @@ class EventQueueGroup(object):
 
     def receive_event(self, timeout=0):
         # type: (int) -> Dict[str, Any]
-        result = self.redis.blpop([q.queue_name for q in self.queues], timeout=timeout)
+        result = self.redis.blpop(
+            [q.queue_name for q in self.queues], timeout=timeout
+        )  # type: Optional[Tuple[bytes, bytes]]
         if result is None:
             return None
         queue_name, event_data = result

--- a/inbox/scheduling/event_queue.py
+++ b/inbox/scheduling/event_queue.py
@@ -37,19 +37,38 @@ class EventQueue(object):
         self.queue_name = queue_name
 
     def receive_event(self, timeout=0):
-        # type: (int) -> Dict[str, Any]
-        result = None  # type: Optional[Union[bytes, Tuple[bytes, bytes]]]
-        if timeout is None:
-            result = self.redis.lpop(self.queue_name)
-        else:
-            result = self.redis.blpop([self.queue_name], timeout=timeout)
+        # type: (Optional[int]) -> Optional[Dict[str, Any]]
+        """
+        Receive single event from the queue.
 
-        if result is None:
-            return None
-        queue_name, event_data = (
-            (self.queue_name, result) if timeout is None else result
-        )
-        queue_name = queue_name.decode("utf-8")
+        * When timeout is set to 0:
+            Block infinitely until receiving an event and return event dictionary.
+        * When timeout is positive integer:
+            Return None if the queue was still empty after timeout seconds.
+            Return event dictionary if the queue was not empty.
+        * When timeout is set to None:
+            Return None immediately if the queue was empty.
+            Return event dictionary if the queue was not empty.
+        """
+        assert self.redis
+
+        if timeout is None:
+            lpop_result = self.redis.lpop(self.queue_name)  # type: Optional[bytes]
+            if lpop_result is None:
+                return None
+
+            queue_name = self.queue_name  # type: str
+            event_data = lpop_result
+        else:
+            blpop_result = self.redis.blpop(
+                [self.queue_name], timeout=timeout
+            )  # type: Optional[Tuple[bytes, bytes]]
+            if blpop_result is None:
+                return None
+
+            blpop_queue_name, event_data = blpop_result
+            queue_name = blpop_queue_name.decode("utf-8")
+
         try:
             event = json.loads(event_data)
             event["queue_name"] = queue_name
@@ -62,6 +81,8 @@ class EventQueue(object):
 
     def send_event(self, event_data):
         # type: (Dict[str, Any]) -> None
+        assert self.redis
+
         event_data.pop("queue_name", None)
         self.redis.rpush(self.queue_name, json.dumps(event_data))
 
@@ -77,14 +98,16 @@ class EventQueueGroup(object):
             self.redis = self.queues[0].redis
 
     def receive_event(self, timeout=0):
-        # type: (int) -> Dict[str, Any]
+        # type: (int) -> Optional[Dict[str, Any]]
+        assert self.redis
+
         result = self.redis.blpop(
             [q.queue_name for q in self.queues], timeout=timeout
         )  # type: Optional[Tuple[bytes, bytes]]
         if result is None:
             return None
-        queue_name, event_data = result
-        queue_name = queue_name.decode("utf-8")
+        blpop_queue_name, event_data = result
+        queue_name = blpop_queue_name.decode("utf-8")
         try:
             event = json.loads(event_data)
             event["queue_name"] = queue_name

--- a/inbox/scheduling/event_queue.py
+++ b/inbox/scheduling/event_queue.py
@@ -49,6 +49,7 @@ class EventQueue(object):
         queue_name, event_data = (
             (self.queue_name, result) if timeout is None else result
         )
+        queue_name = queue_name.decode("utf-8")
         try:
             event = json.loads(event_data)
             event["queue_name"] = queue_name
@@ -81,6 +82,7 @@ class EventQueueGroup(object):
         if result is None:
             return None
         queue_name, event_data = result
+        queue_name = queue_name.decode("utf-8")
         try:
             event = json.loads(event_data)
             event["queue_name"] = queue_name

--- a/tests/scheduling/test_event_queue.py
+++ b/tests/scheduling/test_event_queue.py
@@ -1,0 +1,37 @@
+from inbox.scheduling.event_queue import EventQueue, EventQueueGroup
+
+
+def test_event_queue():
+    queue = EventQueue("name")
+    sent_event = {"event": "test"}
+    queue.send_event(sent_event)
+    received_event = queue.receive_event()
+
+    assert received_event.pop("queue_name") == queue.queue_name
+    assert received_event == sent_event
+
+
+def test_event_queue_empty():
+    queue = EventQueue("name")
+    assert queue.receive_event(1) is None
+
+
+def test_event_queue_group():
+    queue1 = EventQueue("name1")
+    queue2 = EventQueue("name2")
+
+    sent_event_1 = {"event": "test1"}
+    queue1.send_event(sent_event_1)
+
+    sent_event_2 = {"event": "test2"}
+    queue2.send_event(sent_event_2)
+
+    queue_group = EventQueueGroup([queue1, queue2])
+
+    received_event_1 = queue_group.receive_event()
+    assert received_event_1.pop("queue_name") == queue1.queue_name
+    assert received_event_1 == sent_event_1
+
+    received_event_2 = queue_group.receive_event()
+    assert received_event_2.pop("queue_name") == queue2.queue_name
+    assert received_event_2 == sent_event_2

--- a/tests/scheduling/test_event_queue.py
+++ b/tests/scheduling/test_event_queue.py
@@ -11,9 +11,20 @@ def test_event_queue():
     assert received_event == sent_event
 
 
+def test_event_queue_timeout_none():
+    queue = EventQueue("name")
+    sent_event = {"event": "test"}
+    queue.send_event(sent_event)
+    received_event = queue.receive_event(None)
+
+    assert received_event.pop("queue_name") == queue.queue_name
+    assert received_event == sent_event
+
+
 def test_event_queue_empty():
     queue = EventQueue("name")
     assert queue.receive_event(1) is None
+    assert queue.receive_event(None) is None
 
 
 def test_event_queue_group():


### PR DESCRIPTION
While canary testing this change I found out that I did not properly cover for the fact that queue_name can be already a string if `timeout is None`. As a result we got an exception on this line:

AttributeError: 'str' object has no attribute 'decode'

`queue_name = queue_name.decode("utf-8")`

I rewrote the logic slightly to make mypy happy. Note that I only ran mypy on this single file.
