### PR TITLE
Monkey patch early

### DIFF
--- a/inbox/api/wsgi.py
+++ b/inbox/api/wsgi.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
 
+import gevent.monkey
+
+gevent.monkey.patch_all()
+
 import errno
 import socket
 import sys


### PR DESCRIPTION
This fixed RecursionError we had on Python 3 in gunicorn workers.

```
Traceback (most recent call last):
  File \"/opt/venv/lib/python3.6/site-packages/flask/app.py\", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File \"/opt/venv/lib/python3.6/site-packages/flask/app.py\", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File \"/opt/app/inbox/api/ns_api.py\", line 640, in message_read_api
    contents = get_raw_from_provider(message)
  File \"/opt/app/inbox/s3/base.py\", line 4, in get_raw_from_provider
    return account.get_raw_message_contents(message)
  File \"/opt/app/inbox/models/backends/gmail.py\", line 108, in get_raw_message_contents
    return get_gmail_raw_contents(message)
  File \"/opt/app/inbox/s3/backends/gmail.py\", line 18, in get_gmail_raw_contents
    auth_token = token_manager.get_token(account)
  File \"/opt/app/inbox/models/backends/oauth.py\", line 29, in get_token
    new_token, expires_in = account.new_token(force_refresh=force_refresh)
  File \"/opt/app/inbox/models/backends/oauth.py\", line 119, in new_token
    self, force_refresh=force_refresh
  File \"/opt/app/inbox/auth/oauth.py\", line 148, in acquire_access_token
    return self._new_access_token_from_refresh_token(account)
  File \"/opt/app/inbox/auth/oauth.py\", line 52, in _new_access_token_from_refresh_token
    response = requests.post(access_token_url, data=data, headers=headers)
  File \"/opt/venv/lib/python3.6/site-packages/requests/api.py\", line 117, in post
    return request('post', url, data=data, json=json, **kwargs)
  File \"/opt/venv/lib/python3.6/site-packages/requests/api.py\", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File \"/opt/venv/lib/python3.6/site-packages/requests/sessions.py\", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File \"/opt/venv/lib/python3.6/site-packages/requests/sessions.py\", line 655, in send
    r = adapter.send(request, **kwargs)
  File \"/opt/venv/lib/python3.6/site-packages/requests/adapters.py\", line 449, in send
    timeout=timeout
  File \"/opt/venv/lib/python3.6/site-packages/urllib3/connectionpool.py\", line 706, in urlopen
    chunked=chunked,
  File \"/opt/venv/lib/python3.6/site-packages/urllib3/connectionpool.py\", line 382, in _make_request
    self._validate_conn(conn)
  File \"/opt/venv/lib/python3.6/site-packages/urllib3/connectionpool.py\", line 1010, in _validate_conn
    conn.connect()
  File \"/opt/venv/lib/python3.6/site-packages/urllib3/connection.py\", line 399, in connect
    cert_reqs=resolve_cert_reqs(self.cert_reqs),
  File \"/opt/venv/lib/python3.6/site-packages/urllib3/util/ssl_.py\", line 312, in create_urllib3_context
    context.options |= options
  File \"/usr/lib/python3.6/ssl.py\", line 465, in options
    super(SSLContext, SSLContext).options.__set__(self, value)
  File \"/usr/lib/python3.6/ssl.py\", line 465, in options
    super(SSLContext, SSLContext).options.__set__(self, value)
  File \"/usr/lib/python3.6/ssl.py\", line 465, in options
    super(SSLContext, SSLContext).options.__set__(self, value)
  [Previous line repeated 307 more times]
RecursionError: maximum recursion depth exceeded while calling a Python object
```


Initially I had no idea why this is happening but then I found https://stackoverflow.com/questions/49820173/requests-recursionerror-maximum-recursion-depth-exceeded. Strangely this was not happening on Python 2.7 but my canary tests confirm that this fixes it.