### PR TITLE
Gate configparser on Python 3.

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -26,7 +26,7 @@ ciso8601==2.2.0
 click==7.1.2
 colorlog==5.0.1; python_version < '3.0'
 colorlog==6.5.0; python_version >= '3.0'
-configparser==4.0.2
+configparser==4.0.2; python_version < '3.0'
 contextlib2==0.5.5; python_version < '3.0'
 cryptography==2.1.4
 decorator==4.4.2; python_version < '3.0'


### PR DESCRIPTION
This is Python 2 only dependency:
```
Python 2.7.17
configparser==4.0.2
  - importlib-metadata==2.1.1 [requires: configparser>=3.5]
    - pluggy==0.13.1 [requires: importlib-metadata>=0.12]
      - pytest==4.6.11 [requires: pluggy>=0.12,<1.0]
        - pytest-cov==2.12.1 [requires: pytest>=4.6]
        - pytest-timeout==1.4.2 [requires: pytest>=3.6.0]
    - pytest==4.6.11 [requires: importlib-metadata>=0.12]
      - pytest-cov==2.12.1 [requires: pytest>=4.6]
      - pytest-timeout==1.4.2 [requires: pytest>=3.6.0]
    - SQLAlchemy==1.4.26 [requires: importlib-metadata]
      - alembic==1.6.4 [requires: SQLAlchemy>=1.3.0]
```

```
Python 3.6.9
configparser==4.0.2
```