### PR TITLE
Upgrade cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -28,7 +28,8 @@ colorlog==5.0.1; python_version < '3.0'
 colorlog==6.5.0; python_version >= '3.0'
 configparser==4.0.2
 contextlib2==0.5.5; python_version < '3.0'
-cryptography==2.1.4
+cryptography==3.3.2; python_version < '3.0'
+cryptography==36.0.0; python_version >= '3.0'
 decorator==4.4.2; python_version < '3.0'
 decorator==5.1.0; python_version >= '3.0'
 dnspython==1.13


### PR DESCRIPTION
Conditionally update cryptography to the latest possible versions on Python 2 and Python 3. The version we are currently using has a CVE assigned.

```
   **SECURITY ISSUE:** Fixed a bug where certain sequences of ``update()`` calls
  when symmetrically encrypting very large payloads (>2GB) could result in an
  integer overflow, leading to buffer overflows. *CVE-2020-36242* **Update:**
  This fix is a workaround for *CVE-2021-23840* in OpenSSL, fixed in OpenSSL
  1.1.1j.
```

Reverse dependencies

```
Python 2.7.17
cryptography==2.1.4
  - flanker==0.9.11 [requires: cryptography>=0.5]
  - pyOpenSSL==17.5.0 [requires: cryptography>=2.1.4]
    - gevent-openssl==1.2 [requires: pyOpenSSL>=0.11]
    - ndg-httpsclient==0.4.3 [requires: PyOpenSSL]
```

```
Python 3.6.9
cryptography==2.1.4
  - flanker==0.9.11 [requires: cryptography>=0.5]
```

Changelog

```

37.0.0

~~~~~~~~~~~~~~~~
  
  .. note:: This version is not yet released and is under active development.
  
  .. _v36-0-0:

36.0.0

~~~~~~~~~~~~~~~~~~~
  
  * **FINAL DEPRECATION** Support for ``verifier`` and ``signer`` on our
  asymmetric key classes was deprecated in version 2.1. These functions had an
  extended deprecation due to usage, however the next version of
  ``cryptography`` will drop support. Users should migrate to ``sign`` and
  ``verify``.
  * The entire :doc:`/x509/index` layer is now written in Rust. This allows
  alternate asymmetric key implementations that can support cloud key
  management services or hardware security modules provided they implement
  the necessary interface (for example:
  :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePrivateKey`).
  * :ref:`Deprecated the backend argument<faq-missing-backend>` for all
  functions.
  * Added support for
  :class:`~cryptography.hazmat.primitives.ciphers.aead.AESOCB3`.
  * Added support for iterating over arbitrary request
  :attr:`~cryptography.x509.CertificateSigningRequest.attributes`.
  * Deprecated the ``get_attribute_for_oid`` method on
  :class:`~cryptography.x509.CertificateSigningRequest` in favor of
  :meth:`~cryptography.x509.Attributes.get_attribute_for_oid` on the new
  :class:`~cryptography.x509.Attributes` object.
  * Fixed handling of PEM files to allow loading when certificate and key are
  in the same file.
  * Fixed parsing of :class:`~cryptography.x509.CertificatePolicies` extensions
  containing legacy ``BMPString`` values in their ``explicitText``.
  * Allow parsing of negative serial numbers in certificates. Negative serial
  numbers are prohibited by :rfc:`5280` so a deprecation warning will be
  raised whenever they are encountered. A future version of ``cryptography``
  will drop support for parsing them.
  * Added support for parsing PKCS12 files with friendly names for all
  certificates with
  :func:`~cryptography.hazmat.primitives.serialization.pkcs12.load_pkcs12`,
  which will return an object of type
  :class:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12KeyAndCertificates`.
  * :meth:`~cryptography.x509.Name.rfc4514_string` and related methods now have
  an optional ``attr_name_overrides`` parameter to supply custom OID to name
  mappings, which can be used to match vendor-specific extensions.
  * **BACKWARDS INCOMPATIBLE:** Reverted the nonstandard formatting of
  email address fields as ``E`` in
  :meth:`~cryptography.x509.Name.rfc4514_string` methods from version 35.0.
  
  The previous behavior can be restored with:
  ``name.rfc4514_string({NameOID.EMAIL_ADDRESS: "E"})``
  * Allow
  :class:`~cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey`
  and
  :class:`~cryptography.hazmat.primitives.asymmetric.x448.X448PublicKey` to
  be used as public keys when parsing certificates or creating them with
  :class:`~cryptography.x509.CertificateBuilder`. These key types must be
  signed with a different signing algorithm as ``X25519`` and ``X448`` do
  not support signing.
  * Extension values can now be serialized to a DER byte string by calling
  :func:`~cryptography.x509.ExtensionType.public_bytes`.
  * Added experimental support for compiling against BoringSSL. As BoringSSL
  does not commit to a stable API, ``cryptography`` tests against the
  latest commit only. Please note that several features are not available
  when building against BoringSSL.
  * Parsing ``CertificateSigningRequest`` from DER and PEM now, for a limited
  time period, allows the ``Extension`` ``critical`` field to be incorrectly
  encoded. See `the issue <https://github.com/pyca/cryptography/issues/6368>`_
  for complete details. This will be reverted in a future ``cryptography``
  release.
  * When :class:`~cryptography.x509.OCSPNonce` are parsed and generated their
  value is now correctly wrapped in an ASN.1 ``OCTET STRING``. This conforms
  to :rfc:`6960` but conflicts with the original behavior specified in
  :rfc:`2560`. For a temporary period for backwards compatibility, we will
  also parse values that are encoded as specified in :rfc:`2560` but this
  behavior will be removed in a future release.
  
  .. _v35-0-0:

35.0.0

~~~~~~~~~~~~~~~~~~~
  
  * Changed the :ref:`version scheme <api-stability:versioning>`. This will
  result in us incrementing the major version more frequently, but does not
  change our existing backwards compatibility policy.
  * **BACKWARDS INCOMPATIBLE:** The :doc:`/x509/index` PEM parsers now require
  that the PEM string passed have PEM delimiters of the correct type. For
  example, parsing a private key PEM concatenated with a certificate PEM will
  no longer be accepted by the PEM certificate parser.
  * **BACKWARDS INCOMPATIBLE:** The X.509 certificate parser no longer allows
  negative serial numbers. :rfc:`5280` has always prohibited these.
  * **BACKWARDS INCOMPATIBLE:** Additional forms of invalid ASN.1 found during
  :doc:`/x509/index` parsing will raise an error on initial parse rather than
  when the malformed field is accessed.
  * Rust is now required for building ``cryptography``, the
  ``CRYPTOGRAPHY_DONT_BUILD_RUST`` environment variable is no longer
  respected.
  * Parsers for :doc:`/x509/index` no longer use OpenSSL and have been
  rewritten in Rust. This should be backwards compatible (modulo the items
  listed above) and improve both security and performance.
  * Added support for OpenSSL 3.0.0 as a compilation target.
  * Added support for
  :class:`~cryptography.hazmat.primitives.hashes.SM3` and
  :class:`~cryptography.hazmat.primitives.ciphers.algorithms.SM4`,
  when using OpenSSL 1.1.1. These algorithms are provided for compatibility
  in regions where they may be required, and are not generally recommended.
  * We now ship ``manylinux_2_24`` and ``musllinux_1_1`` wheels, in addition to
  our ``manylinux2010`` and ``manylinux2014`` wheels. Users on distributions
  like Alpine Linux should ensure they upgrade to the latest ``pip`` to
  correctly receive wheels.
  * Added ``rfc4514_attribute_name`` attribute to :attr:`x509.NameAttribute
  <cryptography.x509.NameAttribute.rfc4514_attribute_name>`.
  * Added :class:`~cryptography.hazmat.primitives.kdf.kbkdf.KBKDFCMAC`.
  
  .. _v3-4-8:

3.4.8

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1l.
  
  .. _v3-4-7:

3.4.7

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1k.
  
  .. _v3-4-6:

3.4.6

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1j.
  
  .. _v3-4-5:

3.4.5

~~~~~~~~~~~~~~~~~~
  
  * Various improvements to type hints.
  * Lower the minimum supported Rust version (MSRV) to >=1.41.0. This change
  improves compatibility with system-provided Rust on several Linux
  distributions.
  * ``cryptography`` will be switching to a new versioning scheme with its next
  feature release. More information is available in our
  :doc:`/api-stability` documentation.
  
  .. _v3-4-4:

3.4.4

~~~~~~~~~~~~~~~~~~
  
  * Added a ``py.typed`` file so that ``mypy`` will know to use our type
  annotations.
  * Fixed an import cycle that could be triggered by certain import sequences.
  
  .. _v3-4-3:

3.4.3

~~~~~~~~~~~~~~~~~~
  
  * Specify our supported Rust version (>=1.45.0) in our ``setup.py`` so users
  on older versions will get a clear error message.
  
  .. _v3-4-2:

3.4.2

~~~~~~~~~~~~~~~~~~
  
  * Improvements to make the rust transition a bit easier. This includes some
  better error messages and small dependency fixes. If you experience
  installation problems **Be sure to update pip** first, then check the
  :doc:`FAQ </faq>`.
  
  .. _v3-4-1:

3.4.1

~~~~~~~~~~~~~~~~~~
  
  * Fixed a circular import issue.
  * Added additional debug output to assist users seeing installation errors
  due to outdated ``pip`` or missing ``rustc``.
  
  .. _v3-4:

3.4

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Support for Python 2 has been removed.
  * We now ship ``manylinux2014`` wheels and no longer ship ``manylinux1``
  wheels. Users should upgrade to the latest ``pip`` to ensure this doesn't
  cause issues downloading wheels on their platform.
  * ``cryptography`` now incorporates Rust code. Users building ``cryptography``
  themselves will need to have the Rust toolchain installed. Users who use an
  officially produced wheel will not need to make any changes. The minimum
  supported Rust version is 1.45.0.
  * ``cryptography`` now has :pep:`484` type hints on nearly all of of its public
  APIs. Users can begin using them to type check their code with ``mypy``.
  
  .. _v3-3-2:

3.3.2

~~~~~~~~~~~~~~~~~~
  
  * **SECURITY ISSUE:** Fixed a bug where certain sequences of ``update()`` calls
  when symmetrically encrypting very large payloads (>2GB) could result in an
  integer overflow, leading to buffer overflows. *CVE-2020-36242* **Update:**
  This fix is a workaround for *CVE-2021-23840* in OpenSSL, fixed in OpenSSL
  1.1.1j.
  
  .. _v3-3-1:

3.3.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Re-added a legacy symbol causing problems for older ``pyOpenSSL`` users.
  
  .. _v3-3:

3.3 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Support for Python 3.5 has been removed due to
  low usage and maintenance burden.
  * **BACKWARDS INCOMPATIBLE:** The
  :class:`~cryptography.hazmat.primitives.ciphers.modes.GCM` and
  :class:`~cryptography.hazmat.primitives.ciphers.aead.AESGCM` now require
  64-bit to 1024-bit (8 byte to 128 byte) initialization vectors. This change
  is to conform with an upcoming OpenSSL release that will no longer support
  sizes outside this window.
  * **BACKWARDS INCOMPATIBLE:** When deserializing asymmetric keys we now
  raise ``ValueError`` rather than ``UnsupportedAlgorithm`` when an
  unsupported cipher is used. This change is to conform with an upcoming
  OpenSSL release that will no longer distinguish between error types.
  * **BACKWARDS INCOMPATIBLE:** We no longer allow loading of finite field
  Diffie-Hellman parameters of less than 512 bits in length. This change is to
  conform with an upcoming OpenSSL release that no longer supports smaller
  sizes. These keys were already wildly insecure and should not have been used
  in any application outside of testing.
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1i.
  * Python 2 support is deprecated in ``cryptography``. This is the last release
  that will support Python 2.
  * Added the
  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey.recover_data_from_signature`
  function to
  :class:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey`
  for recovering the signed data from an RSA signature.
  
  .. _v3-2-1:

3.2.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Disable blinding on RSA public keys to address an error with some versions
  of OpenSSL.
  
  .. _v3-2:

3.2 not secure

~~~~~~~~~~~~~~~~
  
  * **SECURITY ISSUE:** Attempted to make RSA PKCS1v1.5 decryption more constant
  time, to protect against Bleichenbacher vulnerabilities. Due to limitations
  imposed by our API, we cannot completely mitigate this vulnerability and a
  future release will contain a new API which is designed to be resilient to
  these for contexts where it is required. Credit to **Hubert Kario** for
  reporting the issue. *CVE-2020-25659*
  * Support for OpenSSL 1.0.2 has been removed. Users on older version of OpenSSL
  will need to upgrade.
  * Added basic support for PKCS7 signing (including SMIME) via
  :class:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7SignatureBuilder`.
  
  .. _v3-1-1:

3.1.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1h.
  
  .. _v3-1:

3.1 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Removed support for ``idna`` based
  :term:`U-label` parsing in various X.509 classes. This support was originally
  deprecated in version 2.1 and moved to an extra in 2.5.
  * Deprecated OpenSSL 1.0.2 support. OpenSSL 1.0.2 is no longer supported by
  the OpenSSL project. The next version of ``cryptography`` will drop support
  for it.
  * Deprecated support for Python 3.5. This version sees very little use and will
  be removed in the next release.
  * ``backend`` arguments to functions are no longer required and the
  default backend will automatically be selected if no ``backend`` is provided.
  * Added initial support for parsing certificates from PKCS7 files with
  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_pem_pkcs7_certificates`
  and
  :func:`~cryptography.hazmat.primitives.serialization.pkcs7.load_der_pkcs7_certificates`
  .
  * Calling ``update`` or ``update_into`` on
  :class:`~cryptography.hazmat.primitives.ciphers.CipherContext` with ``data``
  longer than 2\ :sup:`31` bytes no longer raises an ``OverflowError``. This
  also resolves the same issue in :doc:`/fernet`.
  
  .. _v3-0:

3.0 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Removed support for passing an
  :class:`~cryptography.x509.Extension` instance to
  :meth:`~cryptography.x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier`,
  as per our deprecation policy.
  * **BACKWARDS INCOMPATIBLE:** Support for LibreSSL 2.7.x, 2.8.x, and 2.9.0 has
  been removed (2.9.1+ is still supported).
  * **BACKWARDS INCOMPATIBLE:** Dropped support for macOS 10.9, macOS users must
  upgrade to 10.10 or newer.
  * **BACKWARDS INCOMPATIBLE:** RSA
  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key`
  no longer accepts ``public_exponent`` values except 65537 and 3 (the latter
  for legacy purposes).
  * **BACKWARDS INCOMPATIBLE:** X.509 certificate parsing now enforces that the
  ``version`` field contains a valid value, rather than deferring this check
  until :attr:`~cryptography.x509.Certificate.version` is accessed.
  * Deprecated support for Python 2. At the time there is no time table for
  actually dropping support, however we strongly encourage all users to upgrade
  their Python, as Python 2 no longer receives support from the Python core
  team.
  
  If you have trouble suppressing this warning in tests view the :ref:`FAQ
  entry addressing this issue <faq-howto-handle-deprecation-warning>`.
  
  * Added support for ``OpenSSH`` serialization format for
  ``ec``, ``ed25519``, ``rsa`` and ``dsa`` private keys:
  :func:`~cryptography.hazmat.primitives.serialization.load_ssh_private_key`
  for loading and
  :attr:`~cryptography.hazmat.primitives.serialization.PrivateFormat.OpenSSH`
  for writing.
  * Added support for ``OpenSSH`` certificates to
  :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_key`.
  * Added :meth:`~cryptography.fernet.Fernet.encrypt_at_time` and
  :meth:`~cryptography.fernet.Fernet.decrypt_at_time` to
  :class:`~cryptography.fernet.Fernet`.
  * Added support for the :class:`~cryptography.x509.SubjectInformationAccess`
  X.509 extension.
  * Added support for parsing
  :class:`~cryptography.x509.SignedCertificateTimestamps` in OCSP responses.
  * Added support for parsing attributes in certificate signing requests via
  ``CertificateSigningRequest.get_attribute_for_oid``.
  * Added support for encoding attributes in certificate signing requests via
  :meth:`~cryptography.x509.CertificateSigningRequestBuilder.add_attribute`.
  * On OpenSSL 1.1.1d and higher ``cryptography`` now uses OpenSSL's
  built-in CSPRNG instead of its own OS random engine because these versions of
  OpenSSL properly reseed on fork.
  * Added initial support for creating PKCS12 files with
  :func:`~cryptography.hazmat.primitives.serialization.pkcs12.serialize_key_and_certificates`.
  
  .. _v2-9-2:

2.9.2 not secure

~~~~~~~~~~~~~~~~~~
  
  * Updated the macOS wheel to fix an issue where it would not run on macOS
  versions older than 10.15.
  
  .. _v2-9-1:

2.9.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1g.
  
  .. _v2-9:

2.9 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Support for Python 3.4 has been removed due to
  low usage and maintenance burden.
  * **BACKWARDS INCOMPATIBLE:** Support for OpenSSL 1.0.1 has been removed.
  Users on older version of OpenSSL will need to upgrade.
  * **BACKWARDS INCOMPATIBLE:** Support for LibreSSL 2.6.x has been removed.
  * Removed support for calling
  :meth:`~cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey.public_bytes`
  with no arguments, as per our deprecation policy. You must now pass
  ``encoding`` and ``format``.
  * **BACKWARDS INCOMPATIBLE:** Reversed the order in which
  :meth:`~cryptography.x509.Name.rfc4514_string` returns the RDNs
  as required by :rfc:`4514`.
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1f.
  * Added support for parsing
  :attr:`~cryptography.x509.ocsp.OCSPResponse.single_extensions` in an OCSP
  response.
  * :class:`~cryptography.x509.NameAttribute` values can now be empty strings.
  
  .. _v2-8:

2.8 not secure

~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux`` wheels to be compiled with
  OpenSSL 1.1.1d.
  * Added support for Python 3.8.
  * Added class methods
  :meth:`Poly1305.generate_tag
  <cryptography.hazmat.primitives.poly1305.Poly1305.generate_tag>`
  and
  :meth:`Poly1305.verify_tag
  <cryptography.hazmat.primitives.poly1305.Poly1305.verify_tag>`
  for Poly1305 sign and verify operations.
  * Deprecated support for OpenSSL 1.0.1. Support will be removed in
  ``cryptography`` 2.9.
  * We now ship ``manylinux2010`` wheels in addition to our ``manylinux1``
  wheels.
  * Added support for ``ed25519`` and ``ed448`` keys in the
  :class:`~cryptography.x509.CertificateBuilder`,
  :class:`~cryptography.x509.CertificateSigningRequestBuilder`,
  :class:`~cryptography.x509.CertificateRevocationListBuilder` and
  :class:`~cryptography.x509.ocsp.OCSPResponseBuilder`.
  * ``cryptography`` no longer depends on ``asn1crypto``.
  * :class:`~cryptography.x509.FreshestCRL` is now allowed as a
  :class:`~cryptography.x509.CertificateRevocationList` extension.
  
  .. _v2-7:

2.7 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** We no longer distribute 32-bit ``manylinux1``
  wheels. Continuing to produce them was a maintenance burden.
  * **BACKWARDS INCOMPATIBLE:** Removed the
  ``cryptography.hazmat.primitives.mac.MACContext`` interface. The ``CMAC`` and
  ``HMAC`` APIs have not changed, but they are no longer registered as
  ``MACContext`` instances.
  * Updated Windows, macOS, and ``manylinux1`` wheels to be compiled with
  OpenSSL 1.1.1c.
  * Removed support for running our tests with ``setup.py test``. Users
  interested in running our tests can continue to follow the directions in our
  :doc:`development documentation</development/getting-started>`.
  * Add support for :class:`~cryptography.hazmat.primitives.poly1305.Poly1305`
  when using OpenSSL 1.1.1 or newer.
  * Support serialization with ``Encoding.OpenSSH`` and ``PublicFormat.OpenSSH``
  in
  :meth:`Ed25519PublicKey.public_bytes
  <cryptography.hazmat.primitives.asymmetric.ed25519.Ed25519PublicKey.public_bytes>`
  .
  * Correctly allow passing a ``SubjectKeyIdentifier`` to
  :meth:`~cryptography.x509.AuthorityKeyIdentifier.from_issuer_subject_key_identifier`
  and deprecate passing an ``Extension`` object. The documentation always
  required ``SubjectKeyIdentifier`` but the implementation previously
  required an ``Extension``.
  
  .. _v2-6-1:

2.6.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Resolved an error in our build infrastructure that broke our Python3 wheels
  for macOS and Linux.
  
  .. _v2-6:

2.6 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Removed
  ``cryptography.hazmat.primitives.asymmetric.utils.encode_rfc6979_signature``
  and
  ``cryptography.hazmat.primitives.asymmetric.utils.decode_rfc6979_signature``,
  which had been deprecated for nearly 4 years. Use
  :func:`~cryptography.hazmat.primitives.asymmetric.utils.encode_dss_signature`
  and
  :func:`~cryptography.hazmat.primitives.asymmetric.utils.decode_dss_signature`
  instead.
  * **BACKWARDS INCOMPATIBLE**: Removed ``cryptography.x509.Certificate.serial``,
  which had been deprecated for nearly 3 years. Use
  :attr:`~cryptography.x509.Certificate.serial_number` instead.
  * Updated Windows, macOS, and ``manylinux1`` wheels to be compiled with
  OpenSSL 1.1.1b.
  * Added support for :doc:`/hazmat/primitives/asymmetric/ed448` when using
  OpenSSL 1.1.1b or newer.
  * Added support for :doc:`/hazmat/primitives/asymmetric/ed25519` when using
  OpenSSL 1.1.1b or newer.
  * :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_key` can
  now load ``ed25519`` public keys.
  * Add support for easily mapping an object identifier to its elliptic curve
  class via
  :func:`~cryptography.hazmat.primitives.asymmetric.ec.get_curve_for_oid`.
  * Add support for OpenSSL when compiled with the ``no-engine``
  (``OPENSSL_NO_ENGINE``) flag.
  
  .. _v2-5:

2.5 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** :term:`U-label` strings were deprecated in
  version 2.1, but this version removes the default ``idna`` dependency as
  well. If you still need this deprecated path please install cryptography
  with the ``idna`` extra: ``pip install cryptography[idna]``.
  * **BACKWARDS INCOMPATIBLE:** The minimum supported PyPy version is now 5.4.
  * Numerous classes and functions have been updated to allow :term:`bytes-like`
  types for keying material and passwords, including symmetric algorithms, AEAD
  ciphers, KDFs, loading asymmetric keys, and one time password classes.
  * Updated Windows, macOS, and ``manylinux1`` wheels to be compiled with
  OpenSSL 1.1.1a.
  * Added support for :class:`~cryptography.hazmat.primitives.hashes.SHA512_224`
  and :class:`~cryptography.hazmat.primitives.hashes.SHA512_256` when using
  OpenSSL 1.1.1.
  * Added support for :class:`~cryptography.hazmat.primitives.hashes.SHA3_224`,
  :class:`~cryptography.hazmat.primitives.hashes.SHA3_256`,
  :class:`~cryptography.hazmat.primitives.hashes.SHA3_384`, and
  :class:`~cryptography.hazmat.primitives.hashes.SHA3_512` when using OpenSSL
  1.1.1.
  * Added support for :doc:`/hazmat/primitives/asymmetric/x448` when using
  OpenSSL 1.1.1.
  * Added support for :class:`~cryptography.hazmat.primitives.hashes.SHAKE128`
  and :class:`~cryptography.hazmat.primitives.hashes.SHAKE256` when using
  OpenSSL 1.1.1.
  * Added initial support for parsing PKCS12 files with
  :func:`~cryptography.hazmat.primitives.serialization.pkcs12.load_key_and_certificates`.
  * Added support for :class:`~cryptography.x509.IssuingDistributionPoint`.
  * Added ``rfc4514_string()`` method to
  :meth:`x509.Name <cryptography.x509.Name.rfc4514_string>`,
  :meth:`x509.RelativeDistinguishedName
  <cryptography.x509.RelativeDistinguishedName.rfc4514_string>`, and
  :meth:`x509.NameAttribute <cryptography.x509.NameAttribute.rfc4514_string>`
  to format the name or component an :rfc:`4514` Distinguished Name string.
  * Added
  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`,
  which immediately checks if the point is on the curve and supports compressed
  points. Deprecated the previous method
  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.from_encoded_point`.
  * Added :attr:`~cryptography.x509.ocsp.OCSPResponse.signature_hash_algorithm`
  to ``OCSPResponse``.
  * Updated :doc:`/hazmat/primitives/asymmetric/x25519` support to allow
  additional serialization methods. Calling
  :meth:`~cryptography.hazmat.primitives.asymmetric.x25519.X25519PublicKey.public_bytes`
  with no arguments has been deprecated.
  * Added support for encoding compressed and uncompressed points via
  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.public_bytes`. Deprecated the previous method
  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers.encode_point`.
  
  
  .. _v2-4-2:

2.4.2 not secure

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux1`` wheels to be compiled with
  OpenSSL 1.1.0j.
  
  .. _v2-4-1:

2.4.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Fixed a build breakage in our ``manylinux1`` wheels.
  
  .. _v2-4:

2.4 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Dropped support for LibreSSL 2.4.x.
  * Deprecated OpenSSL 1.0.1 support. OpenSSL 1.0.1 is no longer supported by
  the OpenSSL project. At this time there is no time table for dropping
  support, however we strongly encourage all users to upgrade or install
  ``cryptography`` from a wheel.
  * Added initial :doc:`OCSP </x509/ocsp>` support.
  * Added support for :class:`~cryptography.x509.PrecertPoison`.
  
  .. _v2-3-1:

2.3.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux1`` wheels to be compiled with
  OpenSSL 1.1.0i.
  
  .. _v2-3:

2.3 not secure

~~~~~~~~~~~~~~~~
  
  * **SECURITY ISSUE:**
  :meth:`~cryptography.hazmat.primitives.ciphers.AEADDecryptionContext.finalize_with_tag`
  allowed tag truncation by default which can allow tag forgery in some cases.
  The method now enforces the ``min_tag_length`` provided to the
  :class:`~cryptography.hazmat.primitives.ciphers.modes.GCM` constructor.
  *CVE-2018-10903*
  * Added support for Python 3.7.
  * Added :meth:`~cryptography.fernet.Fernet.extract_timestamp` to get the
  authenticated timestamp of a :doc:`Fernet </fernet>` token.
  * Support for Python 2.7.x without ``hmac.compare_digest`` has been deprecated.
  We will require Python 2.7.7 or higher (or 2.7.6 on Ubuntu) in the next
  ``cryptography`` release.
  * Fixed multiple issues preventing ``cryptography`` from compiling against
  LibreSSL 2.7.x.
  * Added
  :class:`~cryptography.x509.CertificateRevocationList.get_revoked_certificate_by_serial_number`
  for quick serial number searches in CRLs.
  * The :class:`~cryptography.x509.RelativeDistinguishedName` class now
  preserves the order of attributes. Duplicate attributes now raise an error
  instead of silently discarding duplicates.
  * :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap` and
  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap_with_padding`
  now raise :class:`~cryptography.hazmat.primitives.keywrap.InvalidUnwrap` if
  the wrapped key is an invalid length, instead of ``ValueError``.
  
  .. _v2-2-2:

2.2.2 not secure

~~~~~~~~~~~~~~~~~~
  
  * Updated Windows, macOS, and ``manylinux1`` wheels to be compiled with
  OpenSSL 1.1.0h.
  
  .. _v2-2-1:

2.2.1 not secure

~~~~~~~~~~~~~~~~~~
  
  * Reverted a change to ``GeneralNames`` which prohibited having zero elements,
  due to breakages.
  * Fixed a bug in
  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap_with_padding`
  that caused it to raise ``InvalidUnwrap`` when key length modulo 8 was
  zero.
  
  
  .. _v2-2:

2.2 not secure

~~~~~~~~~~~~~~~~
  
  * **BACKWARDS INCOMPATIBLE:** Support for Python 2.6 has been dropped.
  * Resolved a bug in ``HKDF`` that incorrectly constrained output size.
  * Added :class:`~cryptography.hazmat.primitives.asymmetric.ec.BrainpoolP256R1`,
  :class:`~cryptography.hazmat.primitives.asymmetric.ec.BrainpoolP384R1`, and
  :class:`~cryptography.hazmat.primitives.asymmetric.ec.BrainpoolP512R1` to
  support inter-operating with systems like German smart meters.
  * Added token rotation support to :doc:`Fernet </fernet>` with
  :meth:`~cryptography.fernet.MultiFernet.rotate`.
  * Fixed a memory leak in
  :func:`~cryptography.hazmat.primitives.asymmetric.ec.derive_private_key`.
  * Added support for AES key wrapping with padding via
  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_wrap_with_padding`
  and
  :func:`~cryptography.hazmat.primitives.keywrap.aes_key_unwrap_with_padding`
  .
  * Allow loading DSA keys with 224 bit ``q``.
  
  .. _v2-1-4:


```