### PR TITLE
Upgrade gunicorn

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -44,7 +44,8 @@ gdata==2.0.18
 gevent==21.8.0
 gevent-openssl==1.2; python_version < '3.0'
 greenlet==1.1.2
-gunicorn==19.10.0
+gunicorn==19.10.0; python_version < '3.0'
+gunicorn==20.1.0; python_version >= '3.0'
 guppy==0.1.10; python_version < '3.0'
 guppy3==3.1.2; python_version >= '3.0'
 hiredis==1.1.0


### PR DESCRIPTION
Changelog

```

20.1.0

===================
  
  - document WEB_CONCURRENCY is set by, at least, Heroku
  - capture peername from accept: Avoid calls to getpeername by capturing the peer name returned by
  accept
  - log a warning when a worker was terminated due to a signal
  - fix tornado usage with latest versions of Django
  - add support for python -m gunicorn
  - fix systemd socket activation example
  - allows to set wsgi application in configg file using `wsgi_app`
  - document `--timeout = 0`
  - always close a connection when the number of requests exceeds the max requests
  - Disable keepalive during graceful shutdown
  - kill tasks in the gthread workers during upgrade
  - fix latency in gevent worker when accepting new requests
  - fix file watcher: handle errors when new worker reboot and ensure the list of files is kept
  - document the default name and path of the configuration file
  - document how variable impact configuration
  - document the `$PORT` environment variable
  - added milliseconds option to request_time in access_log
  - added PIP requirements to be used for example
  - remove version from the Server header
  - fix sendfile: use `socket.sendfile` instead of `os.sendfile`
  - reloader: use  absolute path to prevent empty to prevent0 `InotifyError` when a file
  is added to the working directory
  - Add --print-config option to print the resolved settings at startup.
  - remove the `--log-dict-config` CLI flag because it never had a working format
  (the `logconfig_dict` setting in configuration files continues to work)
  
  
  ** Breaking changes **
  
  - minimum version is Python 3.5
  - remove version from the Server header
  
  ** Documentation **
  
  
  
  ** Others **
  
  - miscellaneous changes in the code base to be a better citizen with Python 3
  - remove dead code
  - fix documentation generation

20.0.4

===================
  
  - fix binding a socket using the file descriptor
  - remove support for the `bdist_rpm` build

20.0.3

===================
  
  - fixed load of a config file without a Python extension
  - fixed `socketfromfd.fromfd` when defaults are not set
  
  .. note:: we now warn when we load a config file without Python Extension

20.0.2

===================
  
  - fix changelog

20.0.1

===================
  
  - fixed the way the config module is loaded. `__file__` is now available
  - fixed `wsgi.input_terminated`. It is always true.
  - use the highest protocol version of openssl by default
  - only support Python >= 3.5
  - added `__repr__` method to `Config` instance
  - fixed support of AIX platform and musl libc in  `socketfromfd.fromfd` function
  - fixed support of applications loaded from a factory function
  - fixed chunked encoding support to prevent any `request smuggling <https://portswigger.net/research/http-desync-attacks-request-smuggling-reborn>`_
  - Capture os.sendfile before patching in gevent and eventlet workers.
  fix `RecursionError`.
  - removed locking in reloader when adding new files
  - load the WSGI application before the loader to pick up all files
  
  .. note:: this release add official support for applications loaded from a factory function
  as documented in Flask and other places.

20.0

=================
  
  - Fixed `fdopen` `RuntimeWarning` in Python 3.8
  - Added  check and exception for str type on value in Response process_headers method.
  - Ensure WSGI header value is string before conducting regex search on it.
  - Added pypy3 to list of tested environments
  - Grouped `StopIteration` and `KeyboardInterrupt` exceptions with same body together in Arbiter.run()
  - Added `setproctitle` module to `extras_require` in setup.py
  - Avoid unnecessary chown of temporary files
  - Logging: Handle auth type case insensitively
  - Removed `util.import_module`
  - Removed fallback for `types.SimpleNamespace` in tests utils
  - Use `SourceFileLoader` instead instead of `execfile_`
  - Use `importlib` instead of `__import__` and eval`
  - Fixed eventlet patching
  - Added optional `datadog <https://www.datadoghq.com>`_ tags for statsd metrics
  - Header values now are encoded using latin-1, not ascii.
  - Rewritten `parse_address` util added test
  - Removed redundant super() arguments
  - Simplify `futures` import in gthread module
  - Fixed worker_connections` setting to also affects the Gthread worker type
  - Fixed setting max_requests
  - Bump minimum Eventlet and Gevent versions to 0.24 and 1.4
  - Use Python default SSL cipher list by default
  - handle `wsgi.input_terminated` extension
  - Simplify Paste Deployment documentation
  - Fix root logging: root and logger are same level.
  - Fixed typo in ssl_version documentation
  - Documented  systemd deployement unit examples
  - Added systemd sd_notify support
  - Fixed typo in gthread.py
  - Added `tornado <https://www.tornadoweb.org/>`_ 5 and  6 support
  - Declare our setuptools dependency
  - Added support to `--bind` to open file descriptors
  - Document how to serve WSGI app modules from Gunicorn
  - Provide guidance on X-Forwarded-For access log in documentation
  - Add support for named constants in the `--ssl-version` flag
  - Clarify log format usage of header & environment in documentation
  - Fixed systemd documentation to properly setup gunicorn unix socket
  - Prevent removal unix socket for reuse_port
  - Fix `ResourceWarning` when reading a Python config module
  - Remove unnecessary call to dict keys method
  - Support str and bytes for UNIX socket addresses
  - fixed `InotifyReloadeder`:  handle `module.__file__` is None
  - `/dev/shm` as a convenient alternative to making your own tmpfs mount in fchmod FAQ
  - fix examples to work on python3
  - Fix typo in `--max-requests` documentation
  - Clear tornado ioloop before os.fork
  - Miscellaneous fixes and improvement for linting using Pylint
  
  Breaking Change
  +++++++++++++++
  
  - Removed gaiohttp worker
  - Drop support for Python 2.x
  - Drop support for EOL Python 3.2 and 3.3
  - Drop support for Paste Deploy server blocks
```