### PR TITLE
Upgrade html2text

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -48,7 +48,8 @@ gunicorn==19.10.0
 guppy==0.1.10; python_version < '3.0'
 guppy3==3.1.2; python_version >= '3.0'
 hiredis==1.1.0
-html2text==2019.8.11
+html2text==2019.8.11; python_version < '3.0'
+html2text==2020.1.16; python_version >= '3.0'
 icalendar==4.0.9
 idna==2.9
 imapclient==2.2.0


### PR DESCRIPTION
The project uses html2text to generate plain text part from HTML when sending an email. We don't use this functionality ourselves.

Changelog

```

2020.1.16

=========
  ----
  
  * Add type annotations.
  * Add support for Python 3.8.
  * Performance improvements when ``wrap_links`` is ``False`` (the default).
  * Configure setuptools using setup.cfg.

2019.9.26

=========
  ----
  
  * Fix long blockquotes wrapping.
  * Remove the trailing whitespaces that were added after wrapping list items & blockquotes.
  * Remove support for Python ≤ 3.4. Now requires Python 3.5+.
  * Fix memory leak when processing a document containing a ``<abbr>`` tag.
  * Fix ``AttributeError`` when reading text from stdin.
  * Fix ``UnicodeEncodeError`` when writing output to stdout.


```