### PR TITLE
Upgrade idna

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -50,7 +50,8 @@ guppy3==3.1.2; python_version >= '3.0'
 hiredis==1.1.0
 html2text==2019.8.11
 icalendar==4.0.9
-idna==2.9
+idna==2.10; python_version < '3.0'
+idna==3.3; python_version >= '3.0'
 imapclient==2.2.0
 importlib-metadata==2.1.1
 importlib-resources==5.4.0; python_version >= '3.0'


### PR DESCRIPTION
> Support for the Internationalised Domain Names in Applications (IDNA) protocol as specified in RFC 5891. This is the latest version of the protocol and is sometimes referred to as “IDNA 2008”.

Reverse dependencies

```
Python 3.6.9
idna==2.9
  - cryptography==2.1.4 [requires: idna>=2.1]
    - flanker==0.9.11 [requires: cryptography>=0.5]
  - flanker==0.9.11 [requires: idna>=2.5]
  - requests==2.26.0 [requires: idna>=2.5,<4]
    - authalligator-client==0.1 [requires: requests]
    - requests-file==1.5.1 [requires: requests>=1.0.0]
      - tldextract==2.2.3 [requires: requests-file>=1.4]
    - rollbar==0.16.2 [requires: requests>=0.12.1]
    - tldextract==2.2.3 [requires: requests>=2.1.0]
  - tldextract==2.2.3 [requires: idna]
```

```
Python 2.7.17
idna==2.10
  - cryptography==2.1.4 [requires: idna>=2.1]
    - flanker==0.9.11 [requires: cryptography>=0.5]
    - pyOpenSSL==17.5.0 [requires: cryptography>=2.1.4]
      - gevent-openssl==1.2 [requires: pyOpenSSL>=0.11]
      - ndg-httpsclient==0.4.3 [requires: PyOpenSSL]
  - flanker==0.9.11 [requires: idna>=2.5]
  - requests==2.26.0 [requires: idna>=2.5,<3]
    - authalligator-client==0.1 [requires: requests]
    - requests-file==1.5.1 [requires: requests>=1.0.0]
      - tldextract==2.2.3 [requires: requests-file>=1.4]
    - rollbar==0.16.2 [requires: requests>=0.12.1]
    - tldextract==2.2.3 [requires: requests>=2.1.0]
  - tldextract==2.2.3 [requires: idna]
```

Changelog

```

3.3

++++++++++++++++
  
  - Update to Unicode 14.0.0
  - Update to in-line type annotations
  - Throw IDNAError exception correctly for some malformed input
  - Advertise support for Python 3.10
  - Improve testing regime on Github
  - Fix Russian typo in documentation
  
  Thanks to Jon Defresne, Hugo van Kemenade, Seth Michael Larson,
  Patrick Ventuzelo and Boris Verhovsky for contributions to this
  release.

3.2

++++++++++++++++
  
  - Add type hints (Thanks, Seth Michael Larson!)
  - Remove support for Python 3.4

3.1

++++++++++++++++
  
  - Ensure license is included in package (Thanks, Julien Schueller)
  - No longer mark wheel has universal (Thanks, Matthieu Darbois)
  - Test on PowerPC using Travis CI

3.0

++++++++++++++++
  
  - Python 2 is no longer supported (the 2.x branch supports Python 2,
  use "idna<3" in your requirements file if you need Python 2 support)
  - Support for V2 UTS 46 test vectors.

2.10

+++++++++++++++++
  
  - Update to Unicode 13.0.0.
  - Throws a more specific exception if "xn--" is provided as a label.
  - This is expected to be the last version that supports Python 2.


```