### PR TITLE
Upgrade importlib-metadata

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -52,7 +52,8 @@ html2text==2019.8.11
 icalendar==4.0.9
 idna==2.9
 imapclient==2.2.0
-importlib-metadata==2.1.1
+importlib-metadata==2.1.1; python_version < '3.0'
+importlib-metadata==4.8.1; python_version >= '3.0'
 importlib-resources==5.4.0; python_version >= '3.0'
 importlib-resources==3.3.1; python_version < '3.0'
 ipaddress==1.0.19


### PR DESCRIPTION
> This package supplies third-party access to the functionality of importlib.metadata including improvements added to subsequent Python versions.

Reverse dependencies

```
Python 3.6.9
importlib-metadata==2.1.1
  - alembic==1.7.5 [requires: importlib-metadata]
  - pluggy==0.13.1 [requires: importlib-metadata>=0.12]
    - pytest==6.2.5 [requires: pluggy>=0.12,<2.0]
      - pytest-cov==3.0.0 [requires: pytest>=4.6]
      - pytest-timeout==2.0.1 [requires: pytest>=5.0.0]
  - pytest==6.2.5 [requires: importlib-metadata>=0.12]
    - pytest-cov==3.0.0 [requires: pytest>=4.6]
    - pytest-timeout==2.0.1 [requires: pytest>=5.0.0]
  - SQLAlchemy==1.4.26 [requires: importlib-metadata]
    - alembic==1.7.5 [requires: SQLAlchemy>=1.3.0]
```

```
Python 2.7.17
importlib-metadata==2.1.1
  - pluggy==0.13.1 [requires: importlib-metadata>=0.12]
    - pytest==4.6.11 [requires: pluggy>=0.12,<1.0]
      - pytest-cov==2.12.1 [requires: pytest>=4.6]
      - pytest-timeout==1.4.2 [requires: pytest>=3.6.0]
  - pytest==4.6.11 [requires: importlib-metadata>=0.12]
    - pytest-cov==2.12.1 [requires: pytest>=4.6]
    - pytest-timeout==1.4.2 [requires: pytest>=3.6.0]
  - SQLAlchemy==1.4.26 [requires: importlib-metadata]
    - alembic==1.6.4 [requires: SQLAlchemy>=1.3.0]
```

Changelog

```

v4.8.1

    #348: Restored support for EntryPoint access by item, deprecating support in the process. Users are advised to use direct member access instead of item-based access:

    - ep[0] -> ep.name
    - ep[1] -> ep.value
    - ep[2] -> ep.group
    - ep[:] -> ep.name, ep.value, ep.group

v4.8.0

    #337: Rewrote EntryPoint as a simple class, still immutable and still with the attributes, but without any expectation for namedtuple functionality such as _asdict.

v4.7.1

    #344: Fixed regression in packages_distributions when neither top-level.txt nor a files manifest is present.

v4.7.0

    #330: In packages_distributions, now infer top-level names from .files() when a top-level.txt (Setuptools-specific metadata) is not present.

v4.6.4

    #334: Correct SimplePath protocol to match pathlib protocol for __truediv__.

v4.6.3

    Moved workaround for #327 to _compat module.

v4.6.2

    bpo-44784: Avoid errors in test suite when DeprecationWarnings are treated as errors.

v4.6.1

    #327: Deprecation warnings now honor call stack variance on PyPy.

v4.6.0

    #326: Performance tests now rely on pytest-perf. To disable these tests, which require network access and a git checkout, pass -p no:perf to pytest.

v4.5.0

    #319: Remove SelectableGroups deprecation exception for flake8.

v4.4.0

    #300: Restore compatibility in the result from Distribution.entry_points (EntryPoints) to honor expectations in older implementations and issuing deprecation warnings for these cases:
        EntryPoints objects are once again mutable, allowing for sort() and other list-based mutation operations. Avoid deprecation warnings by casting to a mutable sequence (e.g. list(dist.entry_points).sort()).
        EntryPoints results once again allow for access by index. To avoid deprecation warnings, cast the result to a Sequence first (e.g. tuple(dist.entry_points)[0]).

v4.3.1

    #320: Fix issue where normalized name for eggs was incorrectly solicited, leading to metadata being unavailable for eggs.

v4.3.0

    #317: De-duplication of distributions no longer requires loading the full metadata for PathDistribution objects, entry point loading performance by ~10x.

v4.2.0

    Prefer f-strings to .format calls.

v4.1.0

    #312: Add support for metadata 2.2 (Dynamic field).
    #315: Add SimplePath protocol for interface clarity in PathDistribution.

v4.0.1

    #306: Clearer guidance about compatibility in readme.

v4.0.0

    #304: PackageMetadata as returned by metadata() and Distribution.metadata() now provides normalized metadata honoring PEP 566:
        If a long description is provided in the payload of the RFC 822 value, it can be retrieved as the Description field.
        Any multi-line values in the metadata will be returned as such.
        For any multi-line values, line continuation characters are removed. This backward-incompatible change means that any projects relying on the RFC 822 line continuation characters being present must be tolerant to them having been removed.
        Add a json property that provides the metadata converted to a JSON-compatible form per PEP 566.

v3.10.1

    Minor tweaks from CPython.

v3.10.0

    #295: Internal refactoring to unify section parsing logic.

v3.9.1

    #296: Exclude 'prepare' package.
    #297: Fix ValueError when entry points contains comments.

v3.9.0

    Use of Mapping (dict) interfaces on SelectableGroups is now flagged as deprecated. Instead, users are advised to use the select interface for future compatibility.

    Suppress the warning with this filter: ignore:SelectableGroups dict interface.

    Or with this invocation in the Python environment: warnings.filterwarnings('ignore', 'SelectableGroups dict interface').

    Preferably, switch to the select interface introduced in 3.7.0. See the entry points documentation and changelog for the 3.6 release below for more detail.

    For some use-cases, especially those that rely on importlib.metadata in Python 3.8 and 3.9 or those relying on older importlib_metadata (especially on Python 3.5 and earlier), backports.entry_points_selectable was created to ease the transition. Please have a look at that project if simply relying on importlib_metadata 3.6+ is not straightforward. Background in #298.

    #283: Entry point parsing no longer relies on ConfigParser and instead uses a custom, one-pass parser to load the config, resulting in a ~20% performance improvement when loading entry points.

v3.8.2

    #293: Re-enabled lazy evaluation of path lookup through a FreezableDefaultDict.

v3.8.1

    #293: Workaround for error in distribution search.

v3.8.0

    #290: Add mtime-based caching for FastPath and its lookups, dramatically increasing performance for repeated distribution lookups.

v3.7.3

    Docs enhancements and cleanup following review in GH-24782.

v3.7.2

    Cleaned up cruft in entry_points docstring.

v3.7.1

    Internal refactoring to facilitate entry_points() -> dict deprecation.

v3.7.0

    #131: Added packages_distributions to conveniently resolve a top-level package or module to its distribution(s).

v3.6.0

    #284: Introduces new EntryPoints object, a tuple of EntryPoint objects but with convenience properties for selecting and inspecting the results:
        .select() accepts group or name keyword parameters and returns a new EntryPoints tuple with only those that match the selection.
        .groups property presents all of the group names.
        .names property presents the names of the entry points.
        Item access (e.g. eps[name]) retrieves a single entry point by name.

    entry_points now accepts "selection parameters", same as EntryPoint.select().

    entry_points() now provides a future-compatible SelectableGroups object that supplies the above interface (except item access) but remains a dict for compatibility.

    In the future, entry_points() will return an EntryPoints object for all entry points.

    If passing selection parameters to entry_points, the future behavior is invoked and an EntryPoints is the result.

    #284: Construction of entry points using dict([EntryPoint, ...]) is now deprecated and raises an appropriate DeprecationWarning and will be removed in a future version.

    #300: Distribution.entry_points now presents as an EntryPoints object and access by index is no longer allowed. If access by index is required, cast to a sequence first.

v3.5.0

    #280: entry_points now only returns entry points for unique distributions (by name).

v3.4.0

    #10: Project now declares itself as being typed.
    #272: Additional performance enhancements to distribution discovery.
    #111: For PyPA projects, add test ensuring that MetadataPathFinder._search_paths honors the needed interface. Method is still private.

v3.3.0

    #265: EntryPoint objects now expose a .dist object referencing the Distribution when constructed from a Distribution.

v3.2.0

    The object returned by metadata() now has a formally-defined protocol called PackageMetadata with declared support for the .get_all() method. Fixes #126.

v3.1.1

    #261: Restored compatibility for package discovery for metadata without version in the name and for legacy eggs.

v3.1.0

    Merge with 2.1.0.

v3.0.0

    Require Python 3.6 or later.
```