### PR TITLE
Upgrade and gate ipaddress

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -55,7 +55,7 @@ imapclient==2.2.0
 importlib-metadata==2.1.1
 importlib-resources==5.4.0; python_version >= '3.0'
 importlib-resources==3.3.1; python_version < '3.0'
-ipaddress==1.0.19
+ipaddress==1.0.23; python_version < '3.3'
 ipython==5.8.0; python_version < '3.0'
 ipython==7.16.0; python_version >= '3.0'
 ipython_genutils==0.2.0


### PR DESCRIPTION
> Port of the 3.3+ ipaddress module to 2.6, 2.7, 3.2

Reverse dependencies

```
Python 2.7.17
ipaddress==1.0.19
  - cryptography==2.1.4 [requires: ipaddress]
    - flanker==0.9.11 [requires: cryptography>=0.5]
    - pyOpenSSL==17.5.0 [requires: cryptography>=2.1.4]
      - gevent-openssl==1.2 [requires: pyOpenSSL>=0.11]
      - ndg-httpsclient==0.4.3 [requires: PyOpenSSL]
```

Changelog

https://github.com/phihag/ipaddress/compare/v1.0.19...v1.0.23