### PR TITLE
Upgrade pycparser

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -78,7 +78,7 @@ ptyprocess==0.7.0
 prompt-toolkit==1.0.18; python_version < '3.0'
 prompt-toolkit==3.0.22; python_version >= '3.0'
 pyasn1==0.2.3
-pycparser==2.18
+pycparser==2.21
 pygments==2.5.2; python_version < '3.0'
 pygments==2.10.0; python_version >= '3.0'
 pyinstrument==3.2.0


### PR DESCRIPTION
> pycparser is a complete parser of the C language, written in pure Python using the PLY parsing library.

This is used in cffi and all libraries that depend on it.

Reverse dependencies

```
Python 3.6.9
pycparser==2.18
  - cffi==1.14.6 [requires: pycparser]
    - cryptography==2.1.4 [requires: cffi>=1.7]
      - flanker==0.9.11 [requires: cryptography>=0.5]
    - PyNaCl==1.4.0 [requires: cffi>=1.4.1]
```

```
Python 2.7.17
pycparser==2.21
  - cffi==1.14.6 [requires: pycparser]
    - cryptography==2.1.4 [requires: cffi>=1.7]
      - flanker==0.9.11 [requires: cryptography>=0.5]
      - pyOpenSSL==17.5.0 [requires: cryptography>=2.1.4]
        - gevent-openssl==1.2 [requires: pyOpenSSL>=0.11]
        - ndg-httpsclient==0.4.3 [requires: PyOpenSSL]
    - PyNaCl==1.4.0 [requires: cffi>=1.4.1]
```

changelog

```
+ Version 2.21 (2021.11.06)

  - Much improved support for C11 (multiple PRs)
  - Support for parehthesized compount statements (#423)
  - Support for modern Python versions (3.9 and 3.10)
  - Fix support for structs with nested enums (#387)
  - Multiple small bug fixes

+ Version 2.20 (2020.03.04)

  - #61: Fix slow backtracking when parsing strings.
  - #99: Parser for FuncDecl incorrectly sets declname attribute on return type.
  - #310: Fix crash when file starts with a semicolon.
  - #313: Fix array type generation.
  - #314: Fix failed parsing of unnamed function parameters with array dim
    qualifiers.
  - #315: Fix pointer type generation.
  - #324: Fixes for u/l constant integer suffix.
  - #346: Fix error transforming an empty switch.
  - #350: Recognize integer multicharacter constants like 'ABCD'.
  - #363: Fix incorrect AST when parsing offsetof.

+ Version 2.19 (2018.09.19)

  - PR #277: Fix parsing of floating point literals
  - PR #254: Add support for parsing empty structs
  - PR #240: Fix enum formatting in generated C code (also #216)
  - PR #222: Add support for #pragma in struct declarations
  - There are reports that this release doesn't work with Python 2.6 (#281).
    Please note that the minimal supported version is 2.7; the required versions
    are listed in the README file.
```