### PR TITLE
Gate pyasn1

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -77,7 +77,7 @@ psutil==5.8.0
 ptyprocess==0.7.0
 prompt-toolkit==1.0.18; python_version < '3.0'
 prompt-toolkit==3.0.22; python_version >= '3.0'
-pyasn1==0.2.3
+pyasn1==0.2.3; python_version < '3.0'
 pycparser==2.18
 pygments==2.5.2; python_version < '3.0'
 pygments==2.10.0; python_version >= '3.0'


### PR DESCRIPTION
This is Python 2 only dependency of ndg-httpsclient which is only needed on Python 2

Reverse dependencies

```
Python 2.7.17
pyasn1==0.2.3
  - ndg-httpsclient==0.4.3 [requires: pyasn1>=0.1.1]
```