### PR TITLE
Upgrade structlog

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -110,7 +110,8 @@ singledispatch==3.4.0.3; python_version < '3.0'
 six==1.11.0
 sqlalchemy==1.4.26
 statsd==3.3.0
-structlog==20.1.0
+structlog==20.1.0; python_version < '3.0'
+structlog==21.4.0; python_version >= '3.0'
 tldextract==2.2.3
 traitlets==4.3.3
 typing==3.10.0.0; python_version < '3.5'

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -115,6 +115,7 @@ structlog==21.4.0; python_version >= '3.0'
 tldextract==2.2.3
 traitlets==4.3.3
 typing==3.10.0.0; python_version < '3.5'
+typing_extensions==4.0.1; python_version >= '3.0'
 urllib3==1.26.7
 vobject==0.9.1
 wcwidth==0.2.5


### PR DESCRIPTION
> structlog makes logging in Python faster, less painful, and more powerful by adding structure to your log entries. 

Changelog

```

21.4.0 (2021-11-25)
Backward-incompatible changes:

none
Deprecations:

none
Changes:

    Fixed import when running in optimized mode (PYTHONOPTIMIZE=2 or python -OO). #373

    Added the structlog.threadlocal.bound_threadlocal and structlog.contextvars.bound_contextvars decorator/context managers to temporarily bind key/value pairs to a thread-local and context-local context. #371

21.3.0 (2021-11-20)
Backward-incompatible changes:

    structlog switched its packaging to flit. Users shouldn’t notice a difference, but (re-)packagers might.

Deprecations:

none
Changes:

    structlog.dev.ConsoleRenderer now has sort_keys boolean parameter that allows to disable the sorting of keys on output. #358

    structlog.processors.TimeStamper now works well with FreezeGun even when it gets applied before the loggers are configured. #364

    structlog.stdlib.AsyncBoundLogger now determines the running loop when logging, not on instantiation. That has a minor performance impact, but makes it more robust when loops change (e.g. aiohttp.web.run_app()), or you want to use sync_bl before a loop has started.

    structlog.stdlib.ProcessorFormatter now has a processors argument that allows to define a processor chain to run over all log entries.

    Before running the chain, two additional keys are added to the event dictionary: _record and _from_structlog. With them it’s possible to extract information from logging.LogRecords and differentiate between structlog and logging log entries while processing them.

    The old processor (singular) parameter is now deprecated, but no plans exist to remove it. #365

21.2.0 (2021-10-12)
Backward-incompatible changes:

    To implement pretty exceptions (see Changes below), structlog.dev.ConsoleRenderer now formats exceptions itself.

    Make sure to remove format_exc_info from your processor chain if you configure structlog manually. This change is not really breaking, because the old use-case will keep working as before. However if you pass pretty_exceptions=True (which is the default if either rich or better-exceptions is installed), a warning will be raised and the exception will be renderered without prettyfication.

Deprecations:

none
Changes:

    structlog is now importable if sys.stdout is None (e.g. when running using pythonw). #313

    structlog.threadlocal.get_threadlocal() and structlog.contextvars.get_contextvars() can now be used to get a copy of the current thread-local/context-local context that has been bound using structlog.threadlocal.bind_threadlocal() and structlog.contextvars.bind_contextvars(). #331 #337

    structlog.threadlocal.get_merged_threadlocal(bl) and structlog.contextvars.get_merged_contextvars(bl) do the same, but also merge the context from a bound logger bl. Same pull requests as previous change.

    structlog.contextvars.bind_contextvars() now returns a mapping of keys to contextvars.Tokens, allowing you to reset values using the new structlog.contextvars.reset_contextvars(). #339

    Exception rendering in structlog.dev.ConsoleLogger is now configurable using the exception_formatter setting. If either the rich or the better-exceptions package is present, structlog will use them for pretty-printing tracebacks. rich takes precedence over better-exceptions if both are present.

    This only works if format_exc_info is absent in the processor chain. #330 #349

    All use of colorama on non-Windows systems has been excised. Thus, colors are now enabled by default in structlog.dev.ConsoleRenderer on non-Windows systems. You can keep using colorama to customize colors, of course. #345

    The final processor can now return a bytearray (additionally to str and bytes). #344

21.1.0 (2021-02-18)
Backward-incompatible changes:

none
Deprecations:

none
Changes:

    structlog.threadlocal.wrap_dict() now has a correct type annotation. #290

    Fix isolation in structlog.contextvars. #302

    The default configuration and loggers are pickleable again. #301

    structlog.dev.ConsoleRenderer will now look for a logger_name key if no logger key is set. #295

20.2.0 (2020-12-31)
Backward-incompatible changes:

    Python 2.7 and 3.5 aren’t supported anymore. The package meta data should ensure that you keep getting 20.1.0 on those versions. #244

    structlog is now fully type-annotated. This won’t break your applications, but if you use Mypy, it will most likely break your CI.

    Check out the new chapter on typing for details.

    The default bound logger (wrapper_class) if you don’t configure structlog has changed. It’s mostly compatible with the old one but a few uncommon methods like log, failure, or err don’t exist anymore.

    You can regain the old behavior by using structlog.configure(wrapper_class=structlog.BoundLogger).

    Please note that due to the various interactions between settings, it’s possible that you encounter even more errors. We strongly urge you to always configure all possible settings since the default configuration is not covered by our backward compatibility policy.

Deprecations:

    Accessing the _context attribute of a bound logger is now deprecated. Please use the new structlog.get_context().

Changes:

    structlog has now type hints for all of its APIs! Since structlog is highly dynamic and configurable, this led to a few concessions like a specialized structlog.stdlib.get_logger() whose only difference to structlog.get_logger() is that it has the correct type hints.

    We consider them provisional for the time being – i.e. the backward compatibility does not apply to them in its full strength until we feel we got it right. Please feel free to provide feedback! #223, #282

    Added structlog.make_filtering_logger that can be used like configure(wrapper_class=make_filtering_bound_logger(logging.INFO)). It creates a highly optimized bound logger whose inactive methods only consist of a return None. This is now also the default logger.

    As a complement, structlog.stdlib.add_log_level() can now additionally be imported as structlog.processors.add_log_level since it just adds the method name to the event dict.

    structlog.processors.add_log_level() is now part of the default configuration.

    structlog.stdlib.ProcessorFormatter no longer uses exceptions for control flow, allowing foreign_pre_chain processors to use sys.exc_info() to access the real exception.

    Added structlog.BytesLogger to avoid unnecessary encoding round trips. Concretely this is useful with orjson which returns bytes. #271

    The final processor now also may return bytes that are passed untouched to the wrapped logger.

    structlog.get_context() allows you to retrieve the original context of a bound logger. #266,

    structlog.PrintLogger now supports copy.deepcopy(). #268

    Added structlog.testing.CapturingLogger for more unit testing goodness.

    Added structlog.stdlib.AsyncBoundLogger that executes logging calls in a thread executor and therefore doesn’t block. #245


```