### PR TITLE
Upgrade tldextract

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -111,7 +111,8 @@ six==1.11.0
 sqlalchemy==1.4.26
 statsd==3.3.0
 structlog==20.1.0
-tldextract==2.2.3
+tldextract==2.2.3; python_version < '3.0'
+tldextract==3.1.2; python_versuib >= '3.0'
 traitlets==4.3.3
 typing==3.10.0.0; python_version < '3.5'
 urllib3==1.26.7

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -35,6 +35,7 @@ decorator==5.1.0; python_version >= '3.0'
 dnspython==1.13
 enum34==1.1.3; python_version < '3.4'
 faulthandler==3.2; python_version < '3.3'
+filelock==3.4.0; python_version >= '3.0'
 git+https://github.com/closeio/flanker-new.git@fa272d95345d45e8bb1f9bc32bc2c074bf52a484#egg=flanker
 tld==0.12.6
 Flask==1.1.4

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -112,7 +112,7 @@ sqlalchemy==1.4.26
 statsd==3.3.0
 structlog==20.1.0
 tldextract==2.2.3; python_version < '3.0'
-tldextract==3.1.2; python_versuib >= '3.0'
+tldextract==3.1.2; python_version >= '3.0'
 traitlets==4.3.3
 typing==3.10.0.0; python_version < '3.5'
 urllib3==1.26.7


### PR DESCRIPTION
> tldextract accurately separates the gTLD or ccTLD (generic or country code top-level domain) from the registered domain and subdomains of a URL.

We use it to find parent domains.

Changelog

```

3.1.2

* Misc.
  * Only run pylint in Tox environments, i.e. CI, not by default in tests ([230](https://github.com/john-kurkowski/tldextract/issues/230))

3.1.1

* Bugfixes
  * Support Python 3.9
  * Drop support for EOL Python 3.5

3.1.0

* Features
  * Prefer to cache in XDG cache directory in user folder, vs. in Python install folder ([213](https://github.com/john-kurkowski/tldextract/issues/213))
  * Bugfixes
  * Fix `AttributeError` on `--update` ([215](https://github.com/john-kurkowski/tldextract/issues/215))

3.0.2

* Bugfixes
  * Catch permission error when making cache dir, as well as cache file ([211](https://github.com/john-kurkowski/tldextract/issues/211))

3.0.1

* Bugfixes
  * Fix `tlds` property `AttributeError` ([210](https://github.com/john-kurkowski/tldextract/issues/210))
  * Allow `include_psl_private_domains` in global `extract` too ([210](https://github.com/john-kurkowski/tldextract/issues/210))

3.0.0

No changes since 3.0.0.rc1.

3.0.0.rc1

This release fixes the long standing bug that public and private suffixes were
  generated separately and could not be switched at runtime,
  [66](https://github.com/john-kurkowski/tldextract/issues/66).
  
  * Breaking Changes
  * Rename `cache_file` to `cache_dir` as it is no longer a single file but a directory ([207](https://github.com/john-kurkowski/tldextract/issues/207))
  * Rename CLI arg also, from `--cache_file` to `--cache_dir`
  * Remove Python 2.7 support
  * Features
  * Can pass `include_psl_private_domains` on call, not only on construction
  * Use filelocking to support multi-processing and multithreading environments
  * Bugfixes
  * Select public or private suffixes at runtime ([66](https://github.com/john-kurkowski/tldextract/issues/66))
  * Removals
  * Do not `debug` log the diff during update


```