### PR TITLE
Enable Python 3.8 on ARM64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,3 +137,9 @@ workflows:
           resource_class: "arm.medium"
           platform_suffix: "-arm64"
           run_tests: false
+      - build:
+          name: build_arm_py3.8
+          python_version: "3.8"
+          resource_class: "arm.medium"
+          platform_suffix: "-arm64"
+          run_tests: false


### PR DESCRIPTION
I've already started first production tests of Python 3.8 and will need ARM64 images soon.