### PR TITLE
Upgrade six

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -111,7 +111,7 @@ setproctitle==1.2.2; python_version >= '3.0'
 setuptools==44.0.0
 simplegeneric==0.8.1; python_version < '3.0'
 singledispatch==3.4.0.3; python_version < '3.0'
-six==1.11.0
+six==1.16.0
 sqlalchemy==1.4.26
 statsd==3.3.0
 tldextract==2.2.3; python_version < '3.0'


### PR DESCRIPTION
> Six is a Python 2 and 3 compatibility library.

Changelog:

```

1.16.0

------
  
  - Pull request 343, issue 341, pull request 349: Port _SixMetaPathImporter to
  Python 3.10.

1.15.0

------
  
  - Pull request 331: Optimize `six.ensure_str` and `six.ensure_binary`.

1.14.0

------
  
  - Issue 288, pull request 289: Add `six.assertNotRegex`.
  
  - Issue 317: `six.moves._dummy_thread` now points to the `_thread` module on
  Python 3.9+. Python 3.7 and later requires threading and deprecated the
  `_dummy_thread` module.
  
  - Issue 308, pull request 314: Remove support for Python 2.6 and Python 3.2.
  
  - Issue 250, issue 165, pull request 251: `six.wraps` now ignores missing
  attributes. This follows the Python 3.2+ standard library behavior.

1.13.0

------
  
  - Issue 298, pull request 299: Add `six.moves.dbm_ndbm`.
  
  - Issue 155: Add `six.moves.collections_abc`, which aliases the `collections`
  module on Python 2-3.2 and the `collections.abc` on Python 3.3 and greater.
  
  - Pull request 304: Re-add distutils fallback in `setup.py`.
  
  - Pull request 305: On Python 3.7, `with_metaclass` supports classes using PEP
  560 features.

1.12.0

------
  
  - Issue 259, pull request 260: `six.add_metaclass` now preserves
  `__qualname__` from the original class.
  
  - Pull request 204: Add `six.ensure_binary`, `six.ensure_text`, and
  `six.ensure_str`.


```