### PR TITLE
Upgrade attrs

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,7 +3,8 @@ alembic==1.7.5; python_version >= '3.0'
 aniso8601==2.0.0
 arrow==0.17.0
 asn1crypto==0.24.0
-attrs==20.2.0
+attrs==20.2.0; python_version < '3.0'
+attrs==21.2.0; python_version >= '3.0'
 git+https://github.com/closeio/authalligator-client.git@fe93c9d2333d2949e44c48a2dd0a9a266734e026#egg=authalligator_client
 backports.functools-lru-cache==1.4; python_version < '3.3'
 backports.shutil_get_terminal_size==1.0; python_version < '3.3'


### PR DESCRIPTION
> attrs is the Python package that will bring back the joy of writing classes by relieving you from the drudgery of implementing object protocols .

Changelog

```

21.2.0 (2021-05-07)
Backward-incompatible Changes

    We had to revert the recursive feature for attr.evolve() because it broke some use-cases – sorry! #806

    Python 3.4 is now blocked using packaging metadata because attrs can’t be imported on it anymore. To ensure that 3.4 users can keep installing attrs easily, we will yank 21.1.0 from PyPI. This has no consequences if you pin attrs to 21.1.0. #807

21.1.0 (2021-05-06)
Deprecations

    The long-awaited, much-talked-about, little-delivered import attrs is finally upon us!

    Since the NG APIs have now been proclaimed stable, the next release of attrs will allow you to actually import attrs. We’re taking this opportunity to replace some defaults in our APIs that made sense in 2015, but don’t in 2021.

    So please, if you have any pet peeves about defaults in attrs’s APIs, now is the time to air your grievances in #487! We’re not gonna get such a chance for a second time, without breaking our backward-compatibility guarantees, or long deprecation cycles. Therefore, speak now or forever hold you peace! #487

    The cmp argument to attr.s() and attr.ib() has been undeprecated It will continue to be supported as syntactic sugar to set eq and order in one go.

    I’m terribly sorry for the hassle around this argument! The reason we’re bringing it back is it’s usefulness regarding customization of equality/ordering.

    The cmp attribute and argument on attr.Attribute remains deprecated and will be removed later this year. #773

Changes

    It’s now possible to customize the behavior of eq and order by passing in a callable. #435, #627

    The instant favorite next-generation APIs are not provisional anymore!

    They are also officially supported by Mypy as of their 0.800 release.

    We hope the next release will already contain an (additional) importable package called attrs. #668, #786

    If an attribute defines a converter, the type of its parameter is used as type annotation for its corresponding __init__ parameter.

    If an attr.converters.pipe is used, the first one’s is used. #710

    Fixed the creation of an extra slot for an attr.ib when the parent class already has a slot with the same name. #718

    __attrs__init__() will now be injected if init=False, or if auto_detect=True and a user-defined __init__() exists.

    This enables users to do “pre-init” work in their __init__() (such as super().__init__()).

    __init__() can then delegate constructor argument processing to self.__attrs_init__(*args, **kwargs). #731

    bool(attr.NOTHING) is now False. #732

    It’s now possible to use super() inside of properties of slotted classes. #747

    Allow for a __attrs_pre_init__() method that – if defined – will get called at the beginning of the attrs-generated __init__() method. #750

    Added forgotten attr.Attribute.evolve() to type stubs. #752

    attrs.evolve() now works recursively with nested attrs classes. #759

    Python 3.10 is now officially supported. #763

    attr.resolve_types() now takes an optional attrib argument to work inside a field_transformer. #774

    ClassVars are now also detected if they come from typing-extensions. #782

    To make it easier to customize attribute comparison (#435), we have added the attr.cmp_with() helper.

    See the new docs on comparison for more details. #787

    Added provisional support for static typing in pyright via the dataclass_transforms specification. Both the pyright specification and attrs implementation may change in future versions of both projects.

    Your constructive feedback is welcome in both attrs#795 and pyright#1782. #796

20.3.0 (2020-11-05)
Backward-incompatible Changes

    attr.define(), attr.frozen(), attr.mutable(), and attr.field() remain provisional.

    This release does not change change anything about them and they are already used widely in production though.

    If you wish to use them together with mypy, you can simply drop this plugin into your project.

    Feel free to provide feedback to them in the linked issue #668.

    We will release the attrs namespace once we have the feeling that the APIs have properly settled. #668

Changes

    attr.s() now has a field_transformer hook that is called for all Attributes and returns a (modified or updated) list of Attribute instances. attr.asdict() has a value_serializer hook that can change the way values are converted. Both hooks are meant to help with data (de-)serialization workflows. #653

    kw_only=True now works on Python 2. #700

    raise from now works on frozen classes on PyPy. #703, #712

    attr.asdict() and attr.astuple() now treat frozensets like sets with regards to the retain_collection_types argument. #704

    The type stubs for attr.s() and attr.make_class() are not missing the collect_by_mro argument anymore. #711


```