### PR TITLE
Upgrade vobject

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -122,7 +122,7 @@ traitlets==4.3.3
 typing==3.10.0.0; python_version < '3.5'
 typing_extensions==4.0.1; python_version >= '3.0'
 urllib3==1.26.7
-vobject==0.9.1
+vobject==0.9.6.1
 wcwidth==0.2.5
 WebOb==1.8.7
 Werkzeug==1.0.1


### PR DESCRIPTION
> Parses iCalendar and vCard files into Python data structures, decoding the relevant encodings. Also serializes vobject data structures to iCalendar, vCard, or (experimentally) hCalendar unicode strings.

Note that this is only used in contact import from iCloud, which we don't use ourselves.

Changelog

```

0.9.6

- Correctly order calendar properties before calendar components (98)
  - Correctly serialize timestamp values (i.e. `REV`) (99)
  - Pass correct formatting string to logger (102) - thanks CruzR!
  - RRULE: Fix floating UNTIL with dateutil > 2.6.1 (115) - thanks Unrud!
  - Encode params if necessary in serialization (109) - thanks matthias-k!
  - Ignore escaped semi-colons in UNTIL value (114) - thanks Unrud!
  - RRULE: Fix VTODO without DTSTART (116) - thanks Unrud!
  - Fixed regexp for VCF Version 2.1 (121) - thanks farmovit!
  - repr changed for datetime.timedelta in python 3.7 (122) - thanks sharkcz!

0.9.5

- Make ics_diff.py work with Python 3 (67)
  - Huge changes to text encoding for Python 2/3 compatibility (70, 86)
  - Autogenerate DTSTAMP if not provided (92)
  - Fix getrruleset() for Python 3 and in the case that `addRDate=True` (85)
  - Update vCard property validation to match specifications (77) - thanks tasn!
  - Handle offset-naive and offset-aware datetimes in recurrence rules (76) - thanks htgoebel!
  - Improved documentation for multi-value properties (79, 88)

0.9.4.1

- Pickling/deepcopy hotfix (60)

0.9.4

- Improved PEP8 compliance (53)
  - Improved Python 3 compatibility (55)
  - Improved encoding/decoding (49, 58) - thanks pbiering!
  - Correct handling of pytz timezones (45) - thanks Achimh3011!

0.9.3

- Fixed use of **doc** in setup.py for -OO mode (19) - thanks dsanders11!
  - Added python3 compatibility for base64 encoding (21) - thanks prauscher!
  - Fixed ORG fields with multiple components (23) - thanks untitaker!
  - Removed stray HTML entity in README (26) - thanks inglesp!
  - Updated README.md to show example of adding "ORG" to a vCard (28) - thanks Tamerz!
  - Handle pytz timezones in iCalendar serialization (33) - thanks medmunds!
  - Use logging instead of printing to stdout (35) - thanks lucc!

0.9.2

- Better line folding for utf-8 string (15) - thanks glibin!
  - Convert unicode to utf-8 to be StringIO compatible (17) - thanks mholtzberg!


```