### PR TITLE
Fix plaintext2html

### DIFF
--- a/inbox/util/html.py
+++ b/inbox/util/html.py
@@ -113,7 +113,7 @@ def plaintext2html(text, tabstop=4):
     def do_sub(m):
         c = m.groupdict()
         if c["htmlchars"]:
-            return html_escape(c["htmlchars"], False)
+            return html_escape(c["htmlchars"], quote=False)
         if c["lineend"]:
             return "<br>"
         elif c["space"]:

--- a/inbox/util/html.py
+++ b/inbox/util/html.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
-import cgi
 import re
 import sys
+
+if sys.version_info < (3, 8):
+    from cgi import escape as html_escape
+else:
+    from html import escape as html_escape
+
 
 if sys.version_info >= (3,):
     unichr = chr
@@ -96,7 +101,7 @@ def strip_tags(html):
 
 # https://djangosnippets.org/snippets/19/
 re_string = re.compile(
-    r"(?P<htmlchars>[<&>])|(?P<space>^[ \t]+)|(?P<lineend>\n)|(?P<protocol>(^|\s)((http|ftp)://.*?))(\s|$)",
+    r"(?P<htmlchars>[<&>])|(?P<space>^[ \t]+)|(?P<lineend>\n)|(?P<protocol>(^|\s)((https?|ftp)://.*?))(\s|$)",
     re.S | re.M | re.I | re.U,
 )
 
@@ -108,7 +113,7 @@ def plaintext2html(text, tabstop=4):
     def do_sub(m):
         c = m.groupdict()
         if c["htmlchars"]:
-            return cgi.escape(c["htmlchars"])
+            return html_escape(c["htmlchars"], False)
         if c["lineend"]:
             return "<br>"
         elif c["space"]:

--- a/tests/util/test_html.py
+++ b/tests/util/test_html.py
@@ -1,0 +1,22 @@
+import pytest
+
+from inbox.util.html import plaintext2html
+
+
+@pytest.mark.parametrize(
+    "plaintext,html",
+    [
+        ("", "<p></p>"),
+        ("a\nb", "<p>a<br>b</p>"),
+        ("a\n\nb", "<p>a</p>\n<p>b</p>"),
+        ("<", "<p>&lt;</p>"),
+        (">", "<p>&gt;</p>"),
+        ("R&D", "<p>R&amp;D</p>"),
+        (
+            "Go to https://example.com",
+            '<p>Go to <a href="https://example.com">https://example.com</a></p>',
+        ),
+    ],
+)
+def test_plaintext2html(plaintext, html):
+    assert plaintext2html(plaintext) == html


### PR DESCRIPTION
Out first Python 3.8 bug.

`cgi.escape` was deprecated since 3.2 (https://docs.python.org/3.7/library/cgi.html#cgi.escape) and was finally removed in 3.8.  One is suppoed to use `html.escape`. Note that there is a difference between `quote` param which is True by default in `html.escape`. We will be generating things that don't end up in HTML attributes so we can leave it set to False in both cases.