### PR TITLE
Upgrade hypothesis

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,8 @@ coverage==6.1.2; python_version >= '3.0'
 funcsigs==1.0.2
 freezegun==0.3.15; python_version < '3.0'
 freezegun==1.1.0; python_version >= '3.0'
-hypothesis==4.57.1
+hypothesis==4.57.1; python_version < '3.0'
+hypothesis==6.30.0; python_version >= '3.0'
 iniconfig==1.1.1; python_version >= '3.0'
 mock==1.3.0
 mockredispy==2.9.3

--- a/tests/security/test_blobstorage.py
+++ b/tests/security/test_blobstorage.py
@@ -3,6 +3,7 @@ import zlib
 import hypothesis
 from hypothesis import strategies as s
 
+from inbox.models.message import Message
 from inbox.security.blobstorage import decode_blob, encode_blob
 
 
@@ -27,7 +28,8 @@ def test_encoded_format(config, sample_input, encrypt):
 
 
 @hypothesis.given(s.text(), s.booleans())
-def test_message_body_storage(config, message, sample_input, encrypt):
+def test_message_body_storage(config, sample_input, encrypt):
+    message = Message()
     config["ENCRYPT_SECRETS"] = encrypt
     message.body = None
     assert message._compacted_body is None


### PR DESCRIPTION
> Hypothesis is an advanced testing library for Python. It lets you write tests which are parametrized by a source of examples, and then generates simple and comprehensible examples that make your tests fail.

Test only dependency

Changelog

```
Hypothesis
6.30.0

-------------------
  
  This release adds an ``allow_subnormal`` argument to the
  :func:`~hypothesis.strategies.floats` strategy, which can explicitly toggle the
  generation of :wikipedia:`subnormal floats <Subnormal_number>` (:issue:`3155`).
  Disabling such generation is useful when testing flush-to-zero builds of
  libraries.
  
  :func:`nps.from_dtype() <hypothesis.extra.numpy.from_dtype>` and
  :func:`xps.from_dtype` can also accept the ``allow_subnormal`` argument, and
  :func:`xps.from_dtype` or :func:`xps.arrays` will disable subnormals by default
  if the array module ``xp`` is detected to flush-to-zero (like is typical with
  CuPy).

6.29.3

-------------------
  
  This patch fixes a bug in :func:`~hypothesis.extra.numpy.mutually_broadcastable_shapes`,
  which restricted the patterns of singleton dimensions that could be generated for
  dimensions that extended beyond ``base_shape`` (:issue:`3170`).

6.29.2

-------------------
  
  This patch clarifies our pretty-printing of DataFrames (:issue:`3114`).

6.29.1

-------------------
  
  This patch documents :func:`~hypothesis.strategies.timezones`
  `Windows-only requirement <https://docs.python.org/3/library/zoneinfo.html#data-sources>`__
  for the :pypi:`tzdata` package, and ensures that
  ``pip install hypothesis[zoneinfo]`` will install the latest version.

6.29.0

-------------------
  
  This release teaches :func:`~hypothesis.strategies.builds` to use
  :func:`~hypothesis.strategies.deferred` when resolving unrecognised type hints,
  so that you can conveniently register strategies for recursive types
  with constraints on some arguments (:issue:`3026`):
  
  .. code-block:: python
  
  class RecursiveClass:
  def __init__(self, value: int, next_node: typing.Optional["SomeClass"]):
  assert value > 0
  self.value = value
  self.next_node = next_node
  
  
  st.register_type_strategy(
  RecursiveClass, st.builds(RecursiveClass, value=st.integers(min_value=1))
  )

6.28.1

-------------------
  
  This release fixes some internal calculations related to collection sizes (:issue:`3143`).

6.28.0

-------------------
  
  This release modifies our :pypi:`pytest` plugin, to avoid importing Hypothesis
  and therefore triggering :ref:`Hypothesis' entry points <entry-points>` for
  test suites where Hypothesis is installed but not actually used (:issue:`3140`).

6.27.3

-------------------
  
  This release fixes :issue:`3080`, where :func:`~hypothesis.strategies.from_type`
  failed on unions containing :pep:`585` builtin generic types (like ``list[int]``)
  in Python 3.9 and later.

6.27.2

-------------------
  
  This patch makes the :command:`hypothesis codemod`
  :ref:`command <hypothesis-cli>` somewhat faster.

6.27.1

-------------------
  
  This patch changes the backing datastructures of :func:`~hypothesis.register_random`
  and a few internal caches to use :class:`weakref.WeakKeyDictionary`.  This reduces
  memory usage and may improve performance when registered :class:`~random.Random`
  instances are only used for a subset of your tests (:issue:`3131`).

6.27.0

-------------------
  
  This release teaches Hypothesis' multiple-error reporting to format tracebacks
  using :pypi:`pytest` or :pypi:`better-exceptions`, if they are installed and
  enabled (:issue:`3116`).

6.26.0

-------------------
  
  Did you know that of the 2\ :superscript:`64` possible floating-point numbers,
  2\ :superscript:`53` of them are ``nan`` - and Python prints them all the same way?
  
  While nans *usually* have all zeros in the sign bit and mantissa, this
  `isn't always true <https://wingolog.org/archives/2011/05/18/value-representation-in-javascript-implementations>`__,
  and :wikipedia:`'signaling' nans might trap or error <https://en.wikipedia.org/wiki/NaN#Signaling_NaN>`.
  To help distinguish such errors in e.g. CI logs, Hypothesis now prints ``-nan`` for
  negative nans, and adds a comment like `` Saw 3 signaling NaNs`` if applicable.

6.25.0

-------------------
  
  This release adds special filtering logic to make a few special cases
  like ``s.map(lambda x: x)`` and ``lists().filter(len)`` more efficient
  (:issue:`2701`).

6.24.6

-------------------
  
  This patch makes :func:`~hypothesis.strategies.floats` generate
  :wikipedia:`"subnormal" floating point numbers <Subnormal_number>`
  more often, as these rare values can have strange interactions with
  `unsafe compiler optimisations like -ffast-math
  <https://simonbyrne.github.io/notes/fastmath/#flushing_subnormals_to_zero>`__
  (:issue:`2976`).

6.24.5

-------------------
  
  This patch fixes a rare internal error in the :func:`~hypothesis.strategies.datetimes`
  strategy, where the implementation of ``allow_imaginary=False`` crashed when checking
  a time during the skipped hour of a DST transition *if* the DST offset is negative -
  only true of ``Europe/Dublin``, who we presume have their reasons - and the ``tzinfo``
  object is a :pypi:`pytz` timezone (which predates :pep:`495`).

6.24.4

-------------------
  
  This patch gives Hypothesis it's own internal :class:`~random.Random` instance,
  ensuring that test suites which reset the global random state don't induce
  weird correlations between property-based tests (:issue:`2135`).

6.24.3

-------------------
  
  This patch updates documentation of :func:`~hypothesis.note`
  (:issue:`3147`).

6.24.2

-------------------
  
  This patch updates internal testing for the :ref:`Array API extra <array-api>`
  to be consistent with new specification changes: ``sum()`` not accepting
  boolean arrays (`234 <https://github.com/data-apis/array-api/pull/234>`_),
  ``unique()`` split into separate functions
  (`275 <https://github.com/data-apis/array-api/pull/275>`_), and treating NaNs
  as distinct (`310 <https://github.com/data-apis/array-api/pull/310>`_). It has
  no user visible impact.

6.24.1

-------------------
  
  This patch updates our vendored `list of top-level domains <https://www.iana.org/domains/root/db>`__,
  which is used by the provisional :func:`~hypothesis.provisional.domains` strategy.

6.24.0

-------------------
  
  This patch updates our vendored `list of top-level domains
  <https://data.iana.org/TLD/tlds-alpha-by-domain.txt>`__, which is used
  by the provisional :func:`~hypothesis.provisional.domains` strategy.
  
  (did you know that gTLDs can be both `added <https://newgtlds.icann.org/en/>`__
  and `removed <https://www.icann.org/resources/pages/gtld-registry-agreement-termination-2015-10-09-en>`__?)

6.23.4

-------------------
  
  This patch adds an error for when ``shapes`` in :func:`xps.arrays()` is not
  passed as either a valid shape or strategy.

6.23.3

-------------------
  
  This patch updates our formatting with :pypi:`shed`.

6.23.2

-------------------
  
  This patch replaces external links to :doc:`NumPy <numpy:index>` API docs
  with :mod:`sphinx.ext.intersphinx` cross-references. It is purely a documentation improvement.

6.23.1

-------------------
  
  This patch cleans up internal logic for :func:`xps.arrays()`. There is no
  user-visible change.

6.23.0

-------------------
  
  This release follows :pypi:`pytest` in considering :class:`SystemExit` and
  :class:`GeneratorExit` exceptions to be test failures, meaning that we will
  shink to minimal examples and check for flakiness even though they subclass
  :class:`BaseException` directly (:issue:`2223`).
  
  :class:`KeyboardInterrupt` continues to interrupt everything, and will be
  re-raised immediately.

6.22.0

-------------------
  
  This release adds :class:`~hypothesis.extra.django.LiveServerTestCase` and
  :class:`~hypothesis.extra.django.StaticLiveServerTestCase` for django test.
  Thanks to Ivan Tham for this feature!

6.21.6

-------------------
  
  This patch fixes some new linter warnings such as :pypi:`flake8-bugbear`'s
  ``B904`` for explicit exception chaining, so tracebacks might be a bit nicer.

6.21.5

-------------------
  
  This release fixes ``None`` being inferred as the float64 dtype in
  :func:`~xps.from_dtype()` and :func:`~xps.arrays()` from the
  :ref:`Array API extra <array-api>`.

6.21.4

-------------------
  
  This release fixes the type hint for the
  :func:`given() <hypothesis.given>` decorator
  when decorating an ``async`` function (:issue:`3099`).

6.21.3

-------------------
  
  This release improves Ghostwritten tests for builtins (:issue:`2977`).

6.21.2

-------------------
  
  This release deprecates use of both ``min_dims > len(shape)`` and
  ``max_dims > len(shape)`` when ``allow_newaxis == False`` in
  :func:`~hypothesis.extra.numpy.basic_indices` (:issue:`3091`).

6.21.1

-------------------
  
  This release improves the behaviour of :func:`~hypothesis.strategies.builds`
  and :func:`~hypothesis.strategies.from_type` in certain situations involving
  decorators (:issue:`2495` and :issue:`3029`).

6.21.0

-------------------
  
  This release introduces strategies for array/tensor libraries adopting the
  `Array API standard <https://data-apis.org/>`__ (:issue:`3037`).
  They are available in :ref:`the hypothesis.extra.array_api extra <array-api>`,
  and work much like the existing :doc:`strategies for NumPy <numpy>`.

6.20.1

-------------------
  
  This patch fixes :issue:`961`, where calling ``given()`` inline on a
  bound method would fail to handle the ``self`` argument correctly.

6.20.0

-------------------
  
  This release allows :func:`~hypothesis.strategies.slices` to generate ``step=None``,
  and fixes an off-by-one error where the ``start`` index could be equal to ``size``.
  This works fine for all Python sequences and Numpy arrays, but is undefined behaviour
  in the `Array API standard <https://data-apis.org/>`__ (see :pull:`3065`).

6.19.0

-------------------
  
  This release makes :doc:`stateful testing <stateful>` more likely to tell you
  if you do something unexpected and unsupported:
  
  - The :obj:`~hypothesis.HealthCheck.return_value` health check now applies to
  :func:`~hypothesis.stateful.rule` and :func:`~hypothesis.stateful.initialize`
  rules, if they don't have ``target`` bundles, as well as
  :func:`~hypothesis.stateful.invariant`.
  - Using a :func:`~hypothesis.stateful.consumes` bundle as a ``target`` is
  deprecated, and will be an error in a future version.
  
  If existing code triggers these new checks, check for related bugs and
  misunderstandings - these patterns *never* had any effect.

6.18.0

-------------------
  
  This release teaches :func:`~hypothesis.strategies.from_type` a neat trick:
  when resolving an :obj:`python:typing.Annotated` type, if one of the annotations
  is a strategy object we use that as the inferred strategy.  For example:
  
  .. code-block:: python
  
  PositiveInt = Annotated[int, st.integers(min_value=1)]
  
  If there are multiple strategies, we use the last outer-most annotation.
  See :issue:`2978` and :pull:`3082` for discussion.
  
  *Requires Python 3.9 or later for*
  :func:`get_type_hints(..., include_extras=False) <typing.get_type_hints>`.

6.17.4

-------------------
  
  This patch makes unique :func:`~hypothesis.extra.numpy.arrays` much more
  efficient, especially when there are only a few valid elements - such as
  for eight-bit integers (:issue:`3066`).

6.17.3

-------------------
  
  This patch fixes the repr of :func:`~hypothesis.extra.numpy.array_shapes`.

6.17.2

-------------------
  
  This patch wraps some internal helper code in our proxies decorator to prevent
  mutations of method docstrings carrying over to other instances of the respective
  methods.

6.17.1

-------------------
  
  This patch moves some internal helper code in preparation for :issue:`3065`.
  There is no user-visible change, unless you depended on undocumented internals.

6.17.0

-------------------
  
  This release adds type annotations to the :doc:`stateful testing <stateful>` API.
  
  Thanks to Ruben Opdebeeck for this contribution!

6.16.0

-------------------
  
  This release adds the :class:`~hypothesis.strategies.DrawFn` type as a reusable
  type hint for the ``draw`` argument of
  :func:`composite <hypothesis.strategies.composite>` functions.
  
  Thanks to Ruben Opdebeeck for this contribution!

6.15.0

-------------------
  
  This release emits a more useful error message when :func:`given() <hypothesis.given>`
  is applied to a coroutine function, i.e. one defined using ``async def`` (:issue:`3054`).
  
  This was previously only handled by the generic :obj:`~hypothesis.HealthCheck.return_value`
  health check, which doesn't direct you to use either :ref:`a custom executor <custom-function-execution>`
  or a library such as :pypi:`pytest-trio` or :pypi:`pytest-asyncio` to handle it for you.

6.14.9

-------------------
  
  This patch fixes a regression in Hypothesis 6.14.8, where :func:`~hypothesis.strategies.from_type`
  failed to resolve types which inherit from multiple parametrised generic types,
  affecting the :pypi:`returns` package (:issue:`3060`).

6.14.8

-------------------
  
  This patch ensures that registering a strategy for a subclass of a a parametrised
  generic type such as ``class Lines(Sequence[str]):`` will not "leak" into unrelated
  strategies such as ``st.from_type(Sequence[int])`` (:issue:`2951`).
  Unfortunately this fix requires :pep:`560`, meaning Python 3.7 or later.

6.14.7

-------------------
  
  This patch fixes :issue:`3050`, where :pypi:`attrs` classes could
  cause an internal error in the :doc:`ghostwriter <ghostwriter>`.

6.14.6

-------------------
  
  This patch improves the error message for :issue:`3016`, where :pep:`585`
  builtin generics with self-referential forward-reference strings cannot be
  resolved to a strategy by :func:`~hypothesis.strategies.from_type`.

6.14.5

-------------------
  
  This patch fixes ``hypothesis.strategies._internal.types.is_a_new_type``.
  It was failing on Python ``3.10.0b4``, where ``NewType`` is a function.

6.14.4

-------------------
  
  This patch fixes :func:`~hypothesis.strategies.from_type` and
  :func:`~hypothesis.strategies.register_type_strategy` for
  :obj:`python:typing.NewType` on Python 3.10, which changed the
  underlying implementation (see :bpo:`44353` for details).

6.14.3

-------------------
  
  This patch updates our autoformatting tools, improving our code style without any API changes.

6.14.2

-------------------
  
  This patch ensures that we shorten tracebacks for tests which fail due
  to inconsistent data generation between runs (i.e. raise ``Flaky``).

6.14.1

-------------------
  
  This patch updates some internal type annotations.
  There is no user-visible change.

6.14.0

-------------------
  
  The :ref:`explain phase <phases>` now requires shrinking to be enabled,
  and will be automatically skipped for deadline-exceeded errors.

6.13.14

--------------------
  
  This patch improves the :func:`~hypothesis.strategies.tuples` strategy
  type annotations, to preserve the element types for up to length-five
  tuples (:issue:`3005`).
  
  As for :func:`~hypothesis.strategies.one_of`, this is the best we can do
  before a `planned extension <https://mail.python.org/archives/list/typing-sigpython.org/thread/LOQFV3IIWGFDB7F5BDX746EZJG4VVBI3/>`__
  to :pep:`646` is released, hopefully in Python 3.11.

6.13.13

--------------------
  
  This patch teaches :doc:`the Ghostwriter <ghostwriter>` how to find
  :doc:`custom ufuncs <numpy:reference/ufuncs>` from *any* module that defines them,
  and that ``yaml.unsafe_load()`` does not undo ``yaml.safe_load()``.

6.13.12

--------------------
  
  This patch reduces the amount of internal code excluded from our test suite's
  code coverage checks.
  
  There is no user-visible change.

6.13.11

--------------------
  
  This patch removes some old internal helper code that previously existed
  to make Python 2 compatibility easier.
  
  There is no user-visible change.

6.13.10

--------------------
  
  This release adjusts some internal code to help make our test suite more
  reliable.
  
  There is no user-visible change.

6.13.9

-------------------
  
  This patch cleans up some internal code related to filtering strategies.
  
  There is no user-visible change.

6.13.8

-------------------
  
  This patch slightly improves the performance of some internal code for
  generating integers.

6.13.7

-------------------
  
  This patch fixes a bug in :func:`~hypothesis.strategies.from_regex` that
  caused ``from_regex("", fullmatch=True)`` to unintentionally generate non-empty
  strings (:issue:`4982`).
  
  The only strings that completely match an empty regex pattern are empty
  strings.

6.13.6

-------------------
  
  This patch fixes a bug that caused :func:`~hypothesis.strategies.integers`
  to shrink towards negative values instead of positive values in some cases.

6.13.5

-------------------
  
  This patch fixes rare cases where ``hypothesis write --binary-op`` could
  print :doc:`reproducing instructions <reproducing>` from the internal
  search for an identity element.

6.13.4

-------------------
  
  This patch removes some unnecessary intermediate list-comprehensions,
  using the latest versions of :pypi:`pyupgrade` and :pypi:`shed`.

6.13.3

-------------------
  
  This patch adds a ``.hypothesis`` property to invalid test functions, bringing
  them inline with valid tests and fixing a bug where :pypi:`pytest-asyncio` would
  swallow the real error message and mistakenly raise a version incompatibility
  error.

6.13.2

-------------------
  
  Some of Hypothesis's numpy/pandas strategies use a ``fill`` argument to speed
  up generating large arrays, by generating a single fill value and sharing that
  value among many array slots instead of filling every single slot individually.
  
  When no ``fill`` argument is provided, Hypothesis tries to detect whether it is
  OK to automatically use the ``elements`` argument as a fill strategy, so that
  it can still use the faster approach.
  
  This patch fixes a bug that would cause that optimization to trigger in some
  cases where it isn't 100% guaranteed to be OK.
  
  If this makes some of your numpy/pandas tests run more slowly, try adding an
  explicit ``fill`` argument to the relevant strategies to ensure that Hypothesis
  always uses the faster approach.

6.13.1

-------------------
  
  This patch strengthens some internal import-time consistency checks for the
  built-in strategies.
  
  There is no user-visible change.

6.13.0

-------------------
  
  This release adds URL fragment generation to the :func:`~hypothesis.provisional.urls`
  strategy (:issue:`2908`). Thanks to Pax (R. Margret) for contributing this patch at the
  `PyCon US Mentored Sprints <https://us.pycon.org/2021/summits/mentored-sprints/>`__!

6.12.1

-------------------
  
  This patch fixes :issue:`2964`, where ``.map()`` and ``.filter()`` methods
  were omitted from the ``repr()`` of :func:`~hypothesis.strategies.just` and
  :func:`~hypothesis.strategies.sampled_from` strategies, since
  :ref:`version 5.43.7 <v5.43.7>`.

6.12.0

-------------------
  
  This release automatically rewrites some simple filters, such as
  ``integers().filter(lambda x: x > 9)`` to the more efficient
  ``integers(min_value=10)``, based on the AST of the predicate.
  
  We continue to recommend using the efficient form directly wherever
  possible, but this should be useful for e.g. :pypi:`pandera` "``Checks``"
  where you already have a simple predicate and translating manually
  is really annoying.  See :issue:`2701` for ideas about floats and
  simple text strategies.

6.11.0

-------------------
  
  :func:`hypothesis.target` now returns the ``observation`` value,
  allowing it to be conveniently used inline in expressions such as
  ``assert target(abs(a - b)) < 0.1``.

6.10.1

-------------------
  
  This patch fixes a deprecation warning if you're using recent versions
  of :pypi:`importlib-metadata` (:issue:`2934`), which we use to load
  :ref:`third-party plugins <entry-points>` such as `Pydantic's integration
  <https://pydantic-docs.helpmanual.io/hypothesis_plugin/>`__.
  On older versions of :pypi:`importlib-metadata`, there is no change and
  you don't need to upgrade.

6.10.0

-------------------
  
  This release teaches the :doc:`Ghostwriter <ghostwriter>` to read parameter
  types from Sphinx, Google, or Numpy-style structured docstrings, and improves
  some related heuristics about how to test scientific and numerical programs.

6.9.2

------------------
  
  This release improves the :doc:`Ghostwriter's <ghostwriter>` handling
  of exceptions, by reading ``:raises ...:`` entries in function docstrings
  and ensuring that we don't suppresss the error raised by test assertions.

6.9.1

------------------
  
  This patch updates our autoformatting tools, improving our code style without any API changes.

6.9.0

------------------
  
  This release teaches :func:`~hypothesis.strategies.from_type` how to see
  through :obj:`python:typing.Annotated`.  Thanks to Vytautas Strimaitis
  for reporting and fixing :issue:`2919`!

6.8.12

-------------------
  
  If :pypi:`rich` is installed, the :command:`hypothesis write` command
  will use it to syntax-highlight the :doc:`Ghostwritten <ghostwriter>`
  code.

6.8.11

-------------------
  
  This patch improves an error message from :func:`~hypothesis.strategies.from_type`
  when :func:`~hypothesis.strategies.builds` would be more suitable (:issue:`2930`).

6.8.10

-------------------
  
  This patch updates the type annotations for :func:`~hypothesis.extra.numpy.arrays` to reflect that
  ``shape: SearchStrategy[int]`` is supported.

6.8.9

------------------
  
  This patch fixes :func:`~hypothesis.strategies.from_type` with
  :mod:`abstract types <python:abc>` which have either required but
  non-type-annotated arguments to ``__init__``, or where
  :func:`~hypothesis.strategies.from_type` can handle some concrete
  subclasses but not others.

6.8.8

------------------
  
  This patch teaches :command:`hypothesis write` to check for possible roundtrips
  in several more cases, such as by looking for an inverse in the module which
  defines the function to test.

6.8.7

------------------
  
  This patch adds a more helpful error message if you try to call
  :func:`~hypothesis.strategies.sampled_from` on an :class:`~python:enum.Enum`
  which has no members, but *does* have :func:`~python:dataclasses.dataclass`-style
  annotations (:issue:`2923`).

6.8.6

------------------
  
  The :func:`~hypothesis.strategies.fixed_dictionaries` strategy now preserves
  dict iteration order instead of sorting the keys.  This also affects the
  pretty-printing of keyword arguments to :func:`given() <hypothesis.given>`
  (:issue:`2913`).

6.8.5

------------------
  
  This patch teaches :command:`hypothesis write` to default to ghostwriting
  tests with ``--style=pytest`` only if :pypi:`pytest` is installed, or
  ``--style=unittest`` otherwise.

6.8.4

------------------
  
  This patch adds type annotations for the :class:`~hypothesis.settings` decorator,
  to avoid an error when running mypy in strict mode.

6.8.3

------------------
  
  This patch improves the :doc:`Ghostwriter's <ghostwriter>` handling
  of strategies to generate various fiddly types including frozensets,
  keysviews, valuesviews, regex matches and patterns, and so on.

6.8.2

------------------
  
  This patch fixes some internal typos.  There is no user-visible change.

6.8.1

------------------
  
  This patch lays more groundwork for filter rewriting (:issue:`2701`).
  There is no user-visible change... yet.

6.8.0

------------------
  
  This release :func:`registers <hypothesis.strategies.register_type_strategy>` the
  remaining builtin types, and teaches :func:`~hypothesis.strategies.from_type` to
  try resolving :class:`~python:typing.ForwardRef` and :class:`~python:typing.Type`
  references to built-in types.

6.7.0

------------------
  
  This release teaches :class:`~hypothesis.stateful.RuleBasedStateMachine` to avoid
  checking :func:`~hypothesis.stateful.invariant`\ s until all
  :func:`~hypothesis.stateful.initialize` rules have been run.  You can enable checking
  of specific invariants for incompletely initialized machines by using
  ``invariant(check_during_init=True)`` (:issue:`2868`).
  
  In previous versions, it was possible if awkward to implement this behaviour
  using :func:`~hypothesis.stateful.precondition` and an auxiliary variable.

6.6.1

------------------
  
  This patch improves the error message when :func:`~hypothesis.strategies.from_type`
  fails to resolve a forward-reference inside a :class:`python:typing.Type`
  such as ``Type["int"]`` (:issue:`2565`).

6.6.0

------------------
  
  This release makes it an explicit error to apply :func:`~hypothesis.stateful.invariant`
  to a :func:`~hypothesis.stateful.rule` or :func:`~hypothesis.stateful.initialize` rule
  in :doc:`stateful testing <stateful>`.  Such a combination had unclear semantics,
  especially in combination with :func:`~hypothesis.stateful.precondition`, and was never
  meant to be allowed (:issue:`2681`).

6.5.0

------------------
  
  This release adds :ref:`the explain phase <phases>`, in which Hypothesis
  attempts to explain *why* your test failed by pointing to suspicious lines
  of code (i.e. those which were always, and only, run on failing inputs).
  We plan to include "generalising" failing examples in this phase in a
  future release (:issue:`2192`).

6.4.3

------------------
  
  This patch fixes :issue:`2794`, where nesting :func:`~hypothesis.strategies.deferred`
  strategies within :func:`~hypothesis.strategies.recursive` strategies could
  trigger an internal assertion.  While it was always possible to get the same
  results from a more sensible strategy, the convoluted form now works too.

6.4.2

------------------
  
  This patch fixes several problems with ``mypy`` when `--no-implicit-reexport <https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-no-implicit-reexport>`_ was activated in user projects.
  
  Thanks to Nikita Sobolev for fixing :issue:`2884`!

6.4.1

------------------
  
  This patch fixes an exception that occurs when using type unions of
  the :pypi:`typing_extensions` ``Literal`` backport on Python 3.6.
  
  Thanks to Ben Anhalt for identifying and fixing this bug.

6.4.0

------------------
  
  This release fixes :doc:`stateful testing methods <stateful>` with multiple
  :func:`~hypothesis.stateful.precondition` decorators.  Previously, only the
  outer-most precondition was checked (:issue:`2681`).

6.3.4

------------------
  
  This patch refactors some internals of :class:`~hypothesis.stateful.RuleBasedStateMachine`.
  There is no change to the public API or behaviour.

6.3.3

------------------
  
  This patch moves some internal code, so that future work can avoid
  creating import cycles.  There is no user-visible change.

6.3.2

------------------
  
  This patch enables :func:`~hypothesis.strategies.register_type_strategy` for subclasses of
  :class:`python:typing.TypedDict`.  Previously, :func:`~hypothesis.strategies.from_type`
  would ignore the registered strategy (:issue:`2872`).
  
  Thanks to Ilya Lebedev for identifying and fixing this bug!

6.3.1

------------------
  
  This release lays the groundwork for automatic rewriting of simple filters,
  for example converting ``integers().filter(lambda x: x > 9)`` to
  ``integers(min_value=10)``.
  
  Note that this is **not supported yet**, and we will continue to recommend
  writing the efficient form directly wherever possible - predicate rewriting
  is provided mainly for the benefit of downstream libraries which would
  otherwise have to implement it for themselves (e.g. :pypi:`pandera` and
  :pypi:`icontract-hypothesis`).  See :issue:`2701` for details.

6.3.0

------------------
  
  The Hypothesis :pypi:`pytest` plugin now requires pytest version 4.6 or later.
  If the plugin detects an earlier version of pytest, it will automatically
  deactivate itself.
  
  `(4.6.x is the earliest pytest branch that still accepts community bugfixes.)
  <https://docs.pytest.org/en/stable/py27-py34-deprecation.html>`__
  
  Hypothesis-based tests should continue to work in earlier versions of
  pytest, but enhanced integrations provided by the plugin
  (such as ``--hypothesis-show-statistics`` and other command-line flags)
  will no longer be available in obsolete pytest versions.

6.2.0

------------------
  
  If you use :pypi:`pytest-html`, Hypothesis now includes the
  :ref:`summary statistics for each test <statistics>` in the HTML report,
  whether or not the ``--hypothesis-show-statistics`` argument was passed
  to show them in the command-line output.

6.1.1

------------------
  
  This patch updates our automatic code formatting to use :pypi:`shed`,
  which includes :pypi:`autoflake`, :pypi:`black`, :pypi:`isort`, and
  :pypi:`pyupgrade` (:issue:`2780`).

6.1.0

------------------
  
  This release teaches Hypothesis to distinguish between errors based on the
  `__cause__ or __context__ of otherwise identical exceptions
  <https://docs.python.org/3/library/exceptions.html>`__, which is particularly
  useful when internal errors can be wrapped by a library-specific or semantically
  appropriate exception such as:
  
  .. code-block:: python
  
  try:
  do_the_thing(foo, timeout=10)
  except Exception as err:
  raise FooError("Failed to do the thing") from err
  
  Earlier versions of Hypothesis only see the ``FooError``, while we can now
  distinguish a ``FooError`` raised because of e.g. an internal assertion from
  one raised because of a ``TimeoutExceeded`` exception.

6.0.4

------------------
  
  This release prevents a race condition inside :func:`~hypothesis.strategies.recursive` strategies.
  The race condition occurs when the same :func:`~hypothesis.strategies.recursive` strategy is shared among tests
  that are running in multiple threads (:issue:`2717`).

6.0.3

------------------
  
  This patch improves the type annotations for :func:`~hypothesis.strategies.one_of`,
  by adding overloads to handle up to five distinct arguments as
  :obj:`~python:typing.Union` before falling back to :obj:`~python:typing.Any`,
  as well as annotating the ``|`` (``__or__``) operator for strategies (:issue:`2765`).

6.0.2

------------------
  
  This release makes some small improvements to how filtered strategies work. It should improve the performance of shrinking filtered strategies,
  and may under some (probably rare) circumstances improve the diversity of generated examples.

6.0.1

------------------
  
  This patch fixes an interaction where our :ref:`test statistics <statistics>`
  handling made Pytest's ``--junit-xml`` output fail to validate against the
  strict ``xunit2`` schema (:issue:`1975`).

6.0.0

------------------
  
  Welcome to the next major version of Hypothesis!
  
  There are no new features here, as we release those in minor versions.
  Instead, 6.0 is a chance for us to remove deprecated features (many already
  converted into no-ops), and turn a variety of warnings into errors.
  
  If you were running on the last version of Hypothesis 5.x *without any
  Hypothesis deprecation warnings*, this will be a very boring upgrade.
  **In fact, nothing will change for you at all.**
  
  Changes
  ~~~~~~~
  - Many functions now use :pep:`3102` keyword-only arguments where passing positional
  arguments :ref:`was deprecated since 5.5 <v5.5.0>`.
  - :func:`hypothesis.extra.django.from_model` no longer accepts ``model`` as a
  keyword argument, where it could conflict with fields named "model".
  - :func:`~hypothesis.strategies.randoms` now defaults to ``use_true_random=False``.
  - :func:`~hypothesis.strategies.complex_numbers` no longer accepts
  ``min_magnitude=None``; either use ``min_magnitude=0`` or just omit the argument.
  - ``hypothesis.provisional.ip4_addr_strings`` and ``ip6_addr_strings`` are removed
  in favor of :func:`ip_addresses(v=...).map(str) <hypothesis.strategies.ip_addresses>`.
  - :func:`~hypothesis.strategies.register_type_strategy` no longer accepts generic
  types with type arguments, which were always pretty badly broken.
  - Using function-scoped pytest fixtures is now a health-check error, instead of a warning.
  
  .. tip::
  The :command:`hypothesis codemod` command can automatically refactor your code,
  particularly to convert positional to keyword arguments where those are now
  required.
  
  Hypothesis 5.x
  ==============

5.49.0

-------------------
  
  This release adds the
  :obj:`~hypothesis.HealthCheck.function_scoped_fixture` health check value,
  which can be used to suppress the existing warning that appears when
  :func:`given <hypothesis.given>` is applied to a test that uses pytest
  function-scoped fixtures.
  
  (This warning exists because function-scoped fixtures only run once per
  function, not once per example, which is usually unexpected and can cause
  subtle problems.)
  
  When this warning becomes a health check error in a future release, suppressing
  it via Python warning settings will no longer be possible.
  In the rare case that once-per-function behaviour is intended, it will still be
  possible to use :obj:`~hypothesis.HealthCheck.function_scoped_fixture` to
  opt out of the health check error for specific tests.

5.48.0

-------------------
  
  This release adds :func:`hypothesis.currently_in_test_context`, which can be used
  to check whether the calling code is currently running inside an
  :func:`given <hypothesis.given>` or :doc:`stateful <stateful>` test.
  
  This is most useful for third-party integrations and assertion helpers which may
  wish to use :func:`~hypothesis.assume` or :func:`~hypothesis.target`, without also
  requiring that the helper only be used from property-based tests (:issue:`2581`).

5.47.0

-------------------
  
  This release upgrades the import logic for :doc:`ghostwritten tests <ghostwriter>`,
  handling many cases where imports would previously be missing or from unexpected
  locations.

5.46.0

-------------------
  
  This release upgrades :func:`~hypothesis.strategies.from_type`, to infer
  strategies for type-annotated arguments even if they have defaults when
  it otherwise falls back to :func:`~hypothesis.strategies.builds`
  (:issue:`2708`).

5.45.0

-------------------
  
  This release adds the :ref:`codemods` extra, which you can use to
  check for and automatically fix issues such as use of deprecated
  Hypothesis APIs (:issue:`2705`).

5.44.0

-------------------
  
  This patch fixes :func:`~hypothesis.strategies.from_type` with
  the :pypi:`typing_extensions` ``Literal`` backport on Python 3.6.

5.43.9

-------------------
  
  This patch fixes :issue:`2722`, where certain orderings of
  :func:`~hypothesis.strategies.register_type_strategy`,
  :class:`~python:typing.ForwardRef`, and :func:`~hypothesis.strategies.from_type`
  could trigger an internal error.

5.43.8

-------------------
  
  This patch makes some strategies for collections with a uniqueness constraint
  much more efficient, including ``dictionaries(keys=sampled_from(...), values=..)``
  and ``lists(tuples(sampled_from(...), ...), unique_by=lambda x: x[0])``.
  (related to :issue:`2036`)

5.43.7

-------------------
  
  This patch extends our faster special case for
  :func:`~hypothesis.strategies.sampled_from` elements in unique
  :func:`~hypothesis.strategies.lists` to account for chains of
  ``.map(...)`` and ``.filter(...)`` calls (:issue:`2036`).

5.43.6

-------------------
  
  This patch improves the type annotations on :func:`~hypothesis.assume`
  and :func:`reproduce_failure() <hypothesis.reproduce_failure>`.

5.43.5

-------------------
  
  This patch updates our copyright headers to include 2021.  Happy new year!

5.43.4

-------------------
  
  This change fixes a documentation error in the
  :obj:`~hypothesis.settings.database` setting.
  
  The previous documentation suggested that callers could specify a database
  path string, or the special string ``":memory:"``, but this setting has
  never actually allowed string arguments.
  
  Permitted values are ``None``, and instances of
  :class:`~hypothesis.database.ExampleDatabase`.

5.43.3

-------------------
  
  This patch fixes :issue:`2696`, an internal error triggered when the
  :func:`example <hypothesis.example>` decorator was used and the
  :obj:`~hypothesis.settings.verbosity` setting was ``quiet``.

5.43.2

-------------------
  
  This patch improves the error message from the
  :func:`~hypothesis.extra.pandas.data_frames` strategy when both the ``rows``
  and ``columns`` arguments are given, but there is a missing entry in ``rows``
  and the corresponding column has no ``fill`` value (:issue:`2678`).

5.43.1

-------------------
  
  This patch improves the error message if :func:`~hypothesis.strategies.builds`
  is passed an :class:`~python:enum.Enum` which cannot be called without arguments,
  to suggest using :func:`~hypothesis.strategies.sampled_from` (:issue:`2693`).

5.43.0

-------------------
  
  This release adds new :func:`~hypothesis.strategies.timezones` and
  :func:`~hypothesis.strategies.timezone_keys` strategies (:issue:`2630`)
  based on the new :mod:`python:zoneinfo` module in Python 3.9.
  
  ``pip install hypothesis[zoneinfo]`` will ensure that you have the
  appropriate backports installed if you need them.

5.42.3

-------------------
  
  This patch fixes an internal error in :func:`~hypothesis.strategies.datetimes`
  with ``allow_imaginary=False`` where the ``timezones`` argument can generate
  ``tzinfo=None`` (:issue:`2662`).

5.42.2

-------------------
  
  This patch teaches :func:`hypothesis.extra.django.from_field` to infer
  more efficient strategies by inspecting (not just filtering by) field
  validators for numeric and string fields (:issue:`1116`).

5.42.1

-------------------
  
  This patch refactors :class:`hypothesis.settings` to use type-annotated
  keyword arguments instead of ``**kwargs``, which makes tab-completion
  much more useful - as well as type-checkers like :pypi:`mypy`.

5.42.0

-------------------
  
  This patch teaches the :func:`~hypothesis.extra.ghostwriter.magic` ghostwriter
  to recognise "en/de" function roundtrips other than the common encode/decode
  pattern, such as encrypt/decrypt or, encipher/decipher.

5.41.5

-------------------
  
  This patch adds a performance optimisation to avoid saving redundant
  seeds when using :ref:`the .fuzz_one_input hook <fuzz_one_input>`.

5.41.4

-------------------
  
  This patch fixes :issue:`2657`, where passing unicode patterns compiled with
  :obj:`python:re.IGNORECASE` to :func:`~hypothesis.strategies.from_regex` could
  trigger an internal error when casefolding a character creates a longer string
  (e.g. ``"\u0130".lower() -> "i\u0370"``).

5.41.3

-------------------
  
  This patch adds a final fallback clause to :ref:`our plugin logic <entry-points>`
  to fail with a warning rather than error on Python < 3.8 when neither the
  :pypi:`importlib_metadata` (preferred) or :pypi:`setuptools` (fallback)
  packages are available.

5.41.2

-------------------
  
  This patch fixes :func:`~hypothesis.provisional.urls` strategy ensuring that
  ``~`` (tilde) is treated as one of the url-safe characters (:issue:`2658`).

5.41.1

-------------------
  
  This patch improves our :ref:`CLI help and documentation <hypothesis-cli>`.

5.41.0

-------------------
  
  Hypothesis now shrinks examples where the error is raised while drawing from
  a strategy.  This makes complicated custom strategies *much* easier to debug,
  at the cost of a slowdown for use-cases where you catch and ignore such errors.

5.40.0

-------------------
  
  This release teaches :func:`~hypothesis.strategies.from_type` how to handle
  :class:`~python:typing.ChainMap`, :class:`~python:typing.Counter`,
  :class:`~python:typing.Deque`, :class:`~python:typing.Generator`,
  :class:`~python:typing.Match`, :class:`~python:typing.OrderedDict`,
  :class:`~python:typing.Pattern`, and :class:`~python:collections.abc.Set`
  (:issue:`2654`).

5.39.0

-------------------
  
  :func:`~hypothesis.strategies.from_type` now knows how to resolve :pep:`585`
  parameterized standard collection types, which are new in Python 3.9
  (:issue:`2629`).

5.38.1

-------------------
  
  This patch fixes :func:`~hypothesis.strategies.builds`, so that when passed
  :obj:`~hypothesis.infer` for an argument with a non-:obj:`~python:typing.Optional`
  type annotation and a default value of ``None`` to build a class which defines
  an explicit ``__signature__`` attribute, either ``None`` or that type may be
  generated.
  
  This is unlikely to happen unless you are using :pypi:`pydantic` (:issue:`2648`).

5.38.0

-------------------
  
  This release improves our support for :func:`st.composite <hypothesis.strategies.composite>`
  on a :obj:`python:classmethod` or :obj:`python:staticmethod` (:issue:`2578`).

5.37.5

-------------------
  
  This patch fixes :func:`~hypothesis.strategies.from_type` with
  :class:`Iterable[T] <python:typing.Iterable>` (:issue:`2645`).

5.37.4

-------------------
  
  This patch teaches the :func:`~hypothesis.extra.ghostwriter.magic` ghostwriter
  to recognise that pairs of functions like :func:`~python:colorsys.rgb_to_hsv`
  and :func:`~python:colorsys.hsv_to_rgb` should
  :func:`~hypothesis.extra.ghostwriter.roundtrip`.

5.37.3

-------------------
  
  This patch improves :func:`~hypothesis.strategies.builds` and
  :func:`~hypothesis.strategies.from_type` support for explicitly defined ``__signature__``
  attributes, from :ref:`version 5.8.3 <v5.8.3>`, to support generic types from the
  :mod:`python:typing` module.
  
  Thanks to Rónán Carrigan for identifying and fixing this problem!

5.37.2

-------------------
  
  This patch fixes :func:`~hypothesis.extra.lark.from_lark` with version
  0.10.1+ of the :pypi:`lark-parser` package.

5.37.1

-------------------
  
  This patch fixes some broken links in the :mod:`~hypothesis.extra.lark`
  extra documentation.

5.37.0

-------------------
  
  This release adds a new :class:`~hypothesis.extra.redis.RedisExampleDatabase`,
  along with the :class:`~hypothesis.database.ReadOnlyDatabase`
  and :class:`~hypothesis.database.MultiplexedDatabase` helpers, to support
  team workflows where failing examples can be seamlessly shared between everyone
  on the team - and your CI servers or buildbots.

5.36.2

-------------------
  
  This patch ensures that if the :ref:`"hypothesis" entry point <entry-points>`
  is callable, we call it after importing it.  You can still use non-callable
  entry points (like modules), which are only imported.
  
  We also prefer `importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`__
  or :pypi:`the backport <importlib_metadata>` over `pkg_resources
  <https://setuptools.readthedocs.io/en/latest/pkg_resources.html>`__,
  which makes ``import hypothesis`` around 200 milliseconds faster
  (:issue:`2571`).

5.36.1

-------------------
  
  This patch adds some helpful suggestions to error messages you might see
  while learning to use the :func:`example() <hypothesis.example>` decorator
  (:issue:`2611`) or the :func:`~hypothesis.strategies.one_of` strategy.

5.36.0

-------------------
  
  This release upgrades the :func:`~hypothesis.extra.numpy.from_dtype` strategy
  to pass optional ``**kwargs`` to the inferred strategy, and upgrades the
  :func:`~hypothesis.extra.numpy.arrays` strategy to accept an ``elements=kwargs``
  dict to pass through to :func:`~hypothesis.extra.numpy.from_dtype`.
  
  ``arrays(floating_dtypes(), shape, elements={"min_value": -10, "max_value": 10})``
  is a particularly useful pattern, as it allows for any floating dtype without
  triggering the roundoff warning for smaller types or sacrificing variety for
  larger types (:issue:`2552`).

5.35.4

-------------------
  
  This patch reformats our code with the latest :pypi:`black` to
  take advantage of the support for magic trailing commas.

5.35.3

-------------------
  
  This release significantly improves the performance of Hypothesis's internal
  implementation of automaton learning. However this code does not run as part
  of the user-accessible API so this has no user-visible impact.

5.35.2

-------------------
  
  This patch ensures that, when the ``generate`` :obj:`~hypothesis.settings.phases`
  is disabled, we can replay up to :obj:`~hypothesis.settings.max_examples` examples
  from the database - which is very useful when
  :ref:`using Hypothesis with a fuzzer <fuzz_one_input>`.
  
  Thanks to Afrida Tabassum for fixing :issue:`2585`!

5.35.1

-------------------
  
  This patch changes some internal :obj:`python:struct.Struct.format` strings
  from ``bytes`` to ``str``, to avoid :class:`python:BytesWarning` when running
  `python -bb <https://docs.python.org/3/using/cmdline.html#cmdoption-b>`__.
  
  Thanks to everyone involved in `pytest-xdist issue 596
  <https://github.com/pytest-dev/pytest-xdist/issues/596>`__,
  :bpo:`16349`, :bpo:`21071`, and :bpo:`41777` for their work on this -
  it was a remarkably subtle issue!

5.35.0

-------------------
  
  The :func:`~hypothesis.target` function now accepts integers as well as floats.

5.34.1

-------------------
  
  This patch adds explicit :obj:`~python:typing.Optional` annotations to our public API,
  to better support users who run :pypi:`mypy` with ``--strict`` or ``no_implicit_optional=True``.
  
  Thanks to Krzysztof Przybyła for bringing this to our attention and writing the patch!

5.34.0

-------------------
  
  This release drops support for Python 3.5, which `reached end of life upstream
  <https://devguide.python.org/#status-of-python-branches>`__ on 2020-09-13.

5.33.2

-------------------
  
  This patch fixes a problem with :func:`~hypothesis.strategies.builds` that was not able to
  generate valid data for annotated classes with constructors.
  
  Thanks to Nikita Sobolev for fixing :issue:`2603`!

5.33.1

-------------------
  
  This patch improves the error message from the :command:`hypothesis write`
  command if :pypi:`black` (required for the :doc:`ghostwriter <ghostwriter>`)
  is not installed.
  
  Thanks to Nikita Sobolev for fixing :issue:`2604`!

5.33.0

-------------------
  
  When reporting failing examples, or tried examples in verbose mode, Hypothesis now
  identifies which were from :func:`example(...) <hypothesis.example>` explicit examples.

5.32.1

-------------------
  
  This patch contains some internal refactoring.
  Thanks to Felix Sheldon for fixing :issue:`2516`!

5.32.0

-------------------
  
  An array drawn from :func:`~hypothesis.extra.numpy.arrays` will own its own memory; previously most arrays returned by
  this strategy were views.

5.31.0

-------------------
  
  :func:`~hypothesis.strategies.builds` will use the ``__signature__`` attribute of
  the target, if it exists, to retrieve type hints.
  Previously :func:`python:typing.get_type_hints`, was used by default.
  If argument names varied between the ``__annotations__`` and ``__signature__``,
  they would not be supplied to the target.
  
  This was particularly an issue for :pypi:`pydantic` models which use an
  `alias generator <https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator>`__.

5.30.1

-------------------
  
  This patch makes the :doc:`ghostwriter <ghostwriter>` much more robust when
  passed unusual modules.
  
  - improved support for non-resolvable type annotations
  - :func:`~hypothesis.extra.ghostwriter.magic` can now write
  :func:`~hypothesis.extra.ghostwriter.equivalent` tests
  - running :func:`~hypothesis.extra.ghostwriter.magic` on modules where some
  names in ``__all__`` are undefined skips such names, instead of raising an error
  - :func:`~hypothesis.extra.ghostwriter.magic` now knows to skip mocks
  - improved handling of import-time errors found by the ghostwriter CLI

5.30.0

-------------------
  
  :func:`~hypothesis.strategies.register_type_strategy` now supports
  :class:`python:typing.TypeVar`, which was previously hard-coded, and allows a
  variety of types to be generated for an unconstrained :class:`~python:typing.TypeVar`
  instead of just :func:`~hypothesis.strategies.text`.
  
  Thanks again to Nikita Sobolev for all your work on advanced types!

5.29.4

-------------------
  
  This release fixes some hard to trigger bugs in Hypothesis's automata learning
  code. This code is only run as part of the Hypothesis build process, and not
  for user code, so this release has no user visible impact.

5.29.3

-------------------
  
  This patch adds type annotations to the :doc:`hypothesis.database <database>`
  module.  There is no runtime change, but your typechecker might notice.

5.29.2

-------------------
  
  This patch tracks some additional information in Hypothesis internals,
  and has no user-visible impact.

5.29.1

-------------------
  
  This release fixes a bug in some Hypothesis internal support code for learning
  automata. This mostly doesn't have any user visible impact, although it slightly
  affects the learned shrink passes so shrinking may be subtly different.

5.29.0

-------------------
  
  This release adds support for :ref:`entry-points`, which allows for smoother
  integration of third-party Hypothesis extensions and external libraries.
  Unless you're publishing a library with Hypothesis integration, you'll
  probably only ever use this indirectly!

5.28.0

-------------------
  
  :func:`~hypothesis.strategies.from_type` can now resolve :class:`~python:typing.TypeVar`
  instances when the ``bound`` is a :class:`~python:typing.ForwardRef`, so long as that name
  is in fact defined in the same module as the typevar (no ``TYPE_CHECKING`` tricks, sorry).
  This feature requires Python 3.7 or later.
  
  Thanks to Zac Hatfield-Dodds and Nikita Sobolev for this feature!

5.27.0

-------------------
  
  This patch adds two new :doc:`ghostwriters <ghostwriter>` to test
  :wikipedia:`binary operations <Binary_operation>`, like :func:`python:operator.add`,
  and Numpy :doc:`ufuncs <reference/ufuncs>` and :doc:`gufuncs
  <numpy:reference/c-api/generalized-ufuncs>` like :data:`np.matmul() <numpy:numpy.matmul>`.

5.26.1

-------------------
  
  This release improves the performance of some methods in Hypothesis's internal
  automaton library. These are currently only lightly used by user code, but
  this may result in slightly faster shrinking.

5.26.0

-------------------
  
  :func:`~hypothesis.strategies.register_type_strategy` no longer accepts
  parametrised user-defined generic types, because the resolution logic
  was quite badly broken (:issue:`2537`).
  
  Instead of registering a strategy for e.g. ``MyCollection[int]``, you
  should register a *function* for ``MyCollection`` and `inspect the type
  parameters within that function <https://stackoverflow.com/q/48572831>`__.
  
  Thanks to Nikita Sobolev for the bug report, design assistance, and
  pull request to implement this feature!

5.25.0

-------------------
  
  Tired of writing tests?  Or new to Hypothesis and not sure where to start?
  
  This release is for you!  With our new :doc:`Ghostwriter functions <ghostwriter>`
  and :command:`hypothesis write ...` :ref:`command-line interface <hypothesis-cli>`,
  you can stop writing tests entirely... or take the source code Hypothesis
  writes for you as a starting point.
  
  This has been in the works for months, from :issue:`2118` to versions

5.24.4

-------------------
  
  This patch adds yet more internal functions to support a new feature
  we're working on, like :ref:`version 5.18.3 <v5.18.3>` and
  :ref:`version 5.23.6 <v5.23.6>`.  We promise it's worth the wait!

5.24.3

-------------------
  
  This release fixes a small internal bug in Hypothesis's internal automaton library.
  Fortunately this bug was currently impossible to hit in user facing code, so this
  has no user visible impact.

5.24.2

-------------------
  
  This release improves shrink quality by allowing Hypothesis to automatically learn new shrink passes
  for difficult to shrink tests.
  
  The automatic learning is not currently accessible in user code (it still needs significant work
  on robustness and performance before it is ready for that), but this release includes learned
  passes that should improve shrinking quality for tests which use any of the
  :func:`~hypothesis.strategies.text`, :func:`~hypothesis.strategies.floats`,
  :func:`~hypothesis.strategies.datetimes`, :func:`~hypothesis.strategies.emails`,
  and :func:`~hypothesis.strategies.complex_numbers` strategies.

5.24.1

-------------------
  
  This patch updates some docstrings, without changing runtime behaviour.

5.24.0

-------------------
  
  The :func:`~hypothesis.strategies.functions` strategy has a new argument
  ``pure=True``, which ensures that the same return value is generated for
  identical calls to the generated function (:issue:`2538`).
  
  Thanks to Zac Hatfield-Dodds and Nikita Sobolev for this feature!

5.23.12

--------------------
  
  This release removes a number of Hypothesis's internal "shrink passes" - transformations
  it makes to a generated test case during shrinking - which appeared to be redundant with
  other transformations.
  
  It is unlikely that you will see much impact from this. If you do, it will likely show up
  as a change in shrinking performance (probably slower, maybe faster), or possibly in
  worse shrunk results. If you encounter the latter, please let us know.

5.23.11

--------------------
  
  This release fixes a bug in some internal Hypothesis support code. It has no user visible impact.

5.23.10

--------------------
  
  This release improves the quality of shrunk test cases in some special cases.
  Specifically, it should get shrinking unstuck in some scenarios which require
  simultaneously changing two parts of the generated test case.

5.23.9

-------------------
  
  This release improves the performance of some internal support code. It has no user visible impact,
  as that code is not currently run during normal Hypothesis operation.

5.23.8

-------------------
  
  This release adds a heuristic to detect when shrinking has finished despite the fact
  that there are many more possible transformations to try. This will be particularly
  useful for tests where the minimum failing test case is very large despite there being
  many smaller test cases possible, where it is likely to speed up shrinking dramatically.
  
  In some cases it is likely that this will result in worse shrunk test cases. In those
  cases rerunning the test will result in further shrinking.

5.23.7

-------------------
  
  This release makes some performance improvements to shrinking. They should
  only be noticeable for tests that are currently particularly slow to shrink.

5.23.6

-------------------
  
  This patch adds some more internal functions to support a new
  feature we're working on, like :ref:`version 5.18.3 <v5.18.3>`.
  There is still no user-visible change... yet.

5.23.5

-------------------
  
  This release makes some changes to internal support code that is not currently used in production Hypothesis.
  It has no user visible effect at present.

5.23.4

-------------------
  
  This release improves shrinking quality in some special cases.

5.23.3

-------------------
  
  This release fixes :issue:`2507`, where lazy evaluation meant that the
  values drawn from a :func:`~hypothesis.strategies.sampled_from` strategy
  could depend on mutations of the sampled sequence that happened after
  the strategy was constructed.

5.23.2

-------------------
  
  This patch fixes :issue:`2462`, a bug in our handling of :meth:`unittest.TestCase.subTest`.
  Thanks to Israel Fruchter for fixing this at the EuroPython sprints!

5.23.1

-------------------
  
  This release improves the behaviour of the :func:`~hypothesis.strategies.characters` strategy
  when shrinking, by changing which characters are considered smallest to prefer more "normal" ascii characters
  where available.

5.23.0

-------------------
  
  The default ``print_blob`` setting is now smarter. It defaults to ``True`` in CI and
  ``False`` for local development.
  
  Thanks to Hugo van Kemenade for implementing this feature at the EuroPython sprints!

5.22.0

-------------------
  
  The :func:`~hypothesis.strategies.slices` strategy can now generate slices for empty sequences,
  slices with negative start and stop indices (from the end of the sequence),
  and ``step=None`` in place of ``step=1``.
  
  Thanks to Sangarshanan for implementing this feature at the EuroPython sprints!

5.21.0

-------------------
  
  This release ensures that tests which raise ``RecursionError`` are not
  reported as flaky simply because we run them from different initial
  stack depths (:issue:`2494`).

5.20.4

-------------------
  
  This release improves the performance of the ``sample`` method on objects obtained from :func:`~hypothesis.strategies.randoms`
  when ``use_true_random=False``. This should mostly only be noticeable when the sample size is a large fraction of the population size,
  but may also help avoid health check failures in some other cases.

5.20.3

-------------------
  
  This release makes some internal changes for testing purposes and should have no user visible effect.

5.20.2

-------------------
  
  This release fixes a small caching bug in Hypothesis internals that may under
  some circumstances have resulted in a less diverse set of test cases being
  generated than was intended.
  
  Fixing this problem revealed some performance problems that could occur during targeted property based testing, so this release also fixes those. Targeted property-based testing should now be significantly faster in some cases,
  but this may be at the cost of reduced effectiveness.

5.20.1

-------------------
  
  This patch updates our formatting to use :pypi:`isort` 5.
  There is no user-visible change.

5.20.0

-------------------
  
  The :func:`~hypothesis.extra.numpy.basic_indices` strategy can now generate
  bare indexers in place of length-one tuples. Thanks to Andrea for this patch!

5.19.3

-------------------
  
  This patch removes an internal use of ``distutils`` in order to avoid
  `this setuptools warning <https://github.com/pypa/setuptools/issues/2261>`__
  for some users.

5.19.2

-------------------
  
  This patch contains a small internal refactoring with no user-visible impact.
  
  Thanks to Andrea for writing this at
  `the SciPy 2020 Sprints <https://www.scipy2020.scipy.org/sprints-schedule>`__!

5.19.1

-------------------
  
  This release slightly improves shrinking behaviour. This should mainly only
  impact stateful tests, but may have some minor positive impact on shrinking
  collections (lists, sets, etc).

5.19.0

-------------------
  
  This release improves the :func:`~hypothesis.strategies.randoms` strategy by adding support
  for ``Random`` instances where Hypothesis generates the random values
  rather than having them be "truly" random.

5.18.3

-------------------
  
  This patch adds some internal functions to support a new feature
  we're working on.  There is no user-visible change... yet.

5.18.2

-------------------
  
  This patch improves our docs for the :obj:`~hypothesis.settings.derandomize` setting.

5.18.1

-------------------
  
  This release consists of some internal refactoring to the shrinker in preparation for future work. It has no user visible impact.

5.18.0

-------------------
  
  This release teaches Hypothesis to :ref:`shorten tracebacks <v3.79.2>` for
  :ref:`explicit examples <providing-explicit-examples>`, as we already do
  for generated examples, so that you can focus on your code rather than ours.
  
  If you have multiple failing explicit examples, they will now all be reported.
  To report only the first failure, you can use the :obj:`report_multiple_bugs=False
  <hypothesis.settings.report_multiple_bugs>` setting as for generated examples.

5.17.0

-------------------
  
  This patch adds strategy inference for the ``Literal``, ``NewType``, ``Type``,
  ``DefaultDict``, and ``TypedDict`` types from the :pypi:`typing_extensions`
  backport on PyPI.

5.16.3

-------------------
  
  This patch precomputes some of the setup logic for our
  :ref:`external fuzzer integration <fuzz_one_input>` and sets
  :obj:`deadline=None <hypothesis.settings.deadline>` in fuzzing mode,
  saving around 150us on each iteration.
  
  This is around two-thirds the runtime to fuzz an empty test with
  ``given(st.none())``, and nice to have even as a much smaller
  fraction of the runtime for non-trivial tests.

5.16.2

-------------------
  
  This patch fixes an internal error when warning about the use of function-scoped fixtures
  for parametrised tests where the parametrised value contained a ``%`` character.
  Thanks to Bryant for reporting and fixing this bug!

5.16.1

-------------------
  
  If you pass a :class:`python:list` or :class:`python:tuple` where a
  strategy was expected, the error message now mentions
  :func:`~hypothesis.strategies.sampled_from` as an example strategy.
  
  Thanks to the enthusiastic participants in the `PyCon Mentored Sprints
  <https://us.pycon.org/2020/hatchery/mentoredsprints/>`__ who suggested
  adding this hint.

5.16.0

-------------------
  
  :func:`~hypothesis.strategies.functions` can now infer the appropriate ``returns``
  strategy if you pass a ``like`` function with a return-type annotation.  Before,
  omitting the ``returns`` argument would generate functions that always returned None.

5.15.1

-------------------
  
  Fix :func:`~hypothesis.strategies.from_type` with generic types under Python 3.9.

5.15.0

-------------------
  
  This patch fixes an error that happens when multiple threads create new strategies.

5.14.0

-------------------
  
  Passing ``min_magnitude=None`` to :func:`~hypothesis.strategies.complex_numbers` is now
  deprecated - you can explicitly pass ``min_magnitude=0``, or omit the argument entirely.

5.13.1

-------------------
  
  This patch fixes an internal error in :func:`~hypothesis.strategies.from_type`
  for :class:`python:typing.NamedTuple` in Python 3.9.  Thanks to Michel Salim
  for reporting and fixing :issue:`2427`!

5.13.0

-------------------
  
  This release upgrades the test statistics available via the
  :ref:`--hypothesis-show-statistics <statistics>` option to include
  separate information on each of the :attr:`~hypothesis.settings.phases`
  (:issue:`1555`).

5.12.2

-------------------
  
  This patch teaches the :func:`~hypothesis.strategies.from_type` internals to
  return slightly more efficient strategies for some generic sets and mappings.

5.12.1

-------------------
  
  This patch adds a `` noqa`` comment for :pypi:`flake8` 3.8.0, which
  disagrees with :pypi:`mypy` about how to write the type of ``...``.

5.12.0

-------------------
  
  This release limits the maximum duration of the shrinking phase to five minutes,
  so that Hypothesis does not appear to hang when making very slow progress
  shrinking a failing example (:issue:`2340`).
  
  If one of your tests triggers this logic, we would really appreciate a bug
  report to help us improve the shrinker for difficult but realistic workloads.

5.11.0

-------------------
  
  This release improves the interaction between :func:`~hypothesis.assume`
  and the :func:`example() <hypothesis.example>` decorator, so that the
  following test no longer fails with ``UnsatisfiedAssumption`` (:issue:`2125`):
  
  .. code-block:: python
  
  given(value=floats(0, 1))
  example(value=0.56789)   used to make the test fail!
  pytest.mark.parametrize("threshold", [0.5, 1])
  def test_foo(threshold, value):
  assume(value < threshold)
  ...

5.10.5

-------------------
  
  If you have :pypi:`django` installed but don't use it, this patch will make
  ``import hypothesis`` a few hundred milliseconds faster (e.g. 0.704s -> 0.271s).
  
  Thanks to :pypi:`importtime-waterfall` for highlighting this problem and
  `Jake Vanderplas <https://twitter.com/jakevdp/status/1130983439862181888>`__ for
  the solution - it's impossible to misuse code from a module you haven't imported!

5.10.4

-------------------
  
  This patch improves the internals of :func:`~hypothesis.strategies.builds` type
  inference, to handle recursive forward references in certain dataclasses.
  This is useful for e.g. :pypi:`hypothesmith`'s forthcoming :pypi:`LibCST` mode.

5.10.3

-------------------
  
  This release reverses the order in which some operations are tried during shrinking.
  This should generally be a slight performance improvement, but most tests are unlikely to notice much difference.

5.10.2

-------------------
  
  This patch fixes :issue:`2406`, where use of :obj:`pandas:pandas.Timestamp`
  objects as bounds for the :func:`~hypothesis.strategies.datetimes` strategy
  caused an internal error.  This bug was introduced in :ref:`version 5.8.1 <v5.8.2>`.

5.10.1

-------------------
  
  This release is a small internal refactoring to how shrinking interacts with :ref:`targeted property-based testing <targeted-search>` that should have no user user visible impact.

5.10.0

-------------------
  
  This release improves our support for datetimes and times around DST transitions.
  
  :func:`~hypothesis.strategies.times` and :func:`~hypothesis.strategies.datetimes`
  are now sometimes generated with ``fold=1``, indicating that they represent the
  second occurrence of a given wall-time when clocks are set backwards.
  This may be set even when there is no transition, in which case the ``fold``
  value should be ignored.
  
  For consistency, timezones provided by the :pypi:`pytz` package can now
  generate imaginary times (such as the hour skipped over when clocks 'spring forward'
  to daylight saving time, or during some historical timezone transitions).
  All other timezones have always supported generation of imaginary times.
  
  If you prefer the previous behaviour, :func:`~hypothesis.strategies.datetimes`
  now takes an argument ``allow_imaginary`` which defaults to ``True`` but
  can be set to ``False`` for any timezones strategy.

5.9.1

------------------
  
  This patch fixes the rendering of :func:`~hypothesis.strategies.binary`
  docstring by using the proper backticks syntax.

5.9.0

------------------
  
  Failing tests which use :func:`~hypothesis.target` now report the highest
  score observed for each target alongside the failing example(s), even without
  :ref:`explicitly showing test statistics <statistics>`.
  
  This improves the debugging workflow for tests of accuracy, which assert that the
  total imprecision is within some error budget - for example, ``abs(a - b) < 0.5``.
  Previously, shrinking to a minimal failing example could often make errors seem
  smaller or more subtle than they really are (see `the threshold problem
  <https://hypothesis.works/articles/threshold-problem/>`__, and :issue:`2180`).

5.8.6

------------------
  
  This patch improves the docstring of :func:`~hypothesis.strategies.binary`,
  the :func:`python:repr` of :func:`~hypothesis.strategies.sampled_from` on
  an :class:`python:enum.Enum` subclass, and a warning in our pytest plugin.
  There is no change in runtime behaviour.

5.8.5

------------------
  
  This release (potentially very significantly) improves the performance of failing tests in some rare cases,
  mostly only relevant when using :ref:`targeted property-based testing <targeted-search>`,
  by stopping further optimisation of unrelated test cases once a failing example is found.

5.8.4

------------------
  
  This release fixes :issue:`2395`, where under some circumstances targeted property-based testing could cause Hypothesis to get caught in an infinite loop.

5.8.3

------------------
  
  This patch teaches :func:`~hypothesis.strategies.builds` and
  :func:`~hypothesis.strategies.from_type` to use the ``__signature__``
  attribute of classes where it has been set, improving our support

5.8.2

------------------
  
  This release improves the performance of the part of the core engine that
  deliberately generates duplicate values.

5.8.1

------------------
  
  This patch improves :func:`~hypothesis.strategies.dates` shrinking, to simplify
  year, month, and day like :func:`~hypothesis.strategies.datetimes` rather than
  minimizing the number of days since 2000-01-01.

5.8.0

------------------
  
  This release adds a :ref:`.hypothesis.fuzz_one_input <fuzz_one_input>`
  attribute to :func:`given <hypothesis.given>` tests, for easy integration
  with external fuzzers such as `python-afl <https://github.com/jwilk/python-afl>`__
  (supporting :issue:`171`).

5.7.2

------------------
  
  This patch fixes :issue:`2341`, ensuring that the printed output from a
  stateful test cannot use variable names before they are defined.

5.7.1

------------------
  
  This patch fixes :issue:`2375`, preventing incorrect failure when a function
  scoped fixture is overridden with a higher scoped fixture.

5.7.0

------------------
  
  This release allows the :func:`~hypothesis.extra.numpy.array_dtypes` strategy
  to generate Numpy dtypes which have `field titles in addition to field names
  <https://numpy.org/doc/stable/user/basics.rec.html#field-titles>`__.
  We expect this to expose latent bugs where code expects that
  ``set(dtype.names) == set(dtype.fields)``, though the latter may include titles.

5.6.1

------------------
  
  This makes ``model`` a positional-only argument to
  :func:`~hypothesis.extra.django.from_model`, to support models
  with a field literally named "model" (:issue:`2369`).

5.6.0

------------------
  
  This release adds an explicit warning for tests that are both decorated with
  :func:`given(...) <hypothesis.given>` and request a
  :doc:`function-scoped pytest fixture <pytest:fixture>`, because such fixtures
  are only executed once for *all* Hypothesis test cases and that often causes
  trouble (:issue:`377`).
  
  It's *very* difficult to fix this on the :pypi:`pytest` side, so since 2015
  our advice has been "just don't use function-scoped fixtures with Hypothesis".
  Now we detect and warn about the issue at runtime!

5.5.5

------------------
  
  This release cleans up the internal machinery for :doc:`stateful`,
  after we dropped the legacy APIs in Hypothesis 5.0 (:issue:`2218`).
  There is no user-visible change.

5.5.4

------------------
  
  This patch fixes :issue:`2351`, :func:`~hypothesis.extra.numpy.arrays` would
  raise a confusing error if we inferred a strategy for ``datetime64`` or
  ``timedelta64`` values with varying time units.
  
  We now infer an internally-consistent strategy for such arrays, and have a more
  helpful error message if an inconsistent strategy is explicitly specified.

5.5.3

------------------
  
  This patch improves the signature of :func:`~hypothesis.strategies.builds` by
  specifying ``target`` as a positional-only argument on Python 3.8 (see :pep:`570`).
  The semantics of :func:`~hypothesis.strategies.builds` have not changed at all -
  this just clarifies the documentation.

5.5.2

------------------
  
  This release makes Hypothesis faster at generating test cases that contain
  duplicated values in their inputs.

5.5.1

------------------
  
  This patch has some tiny internal code clean-ups, with no user-visible change.

5.5.0

------------------
  
  :gh-file:`Our style guide <guides/api-style.rst>` suggests that optional
  parameters should usually be keyword-only arguments (see :pep:`3102`) to
  prevent confusion based on positional arguments - for example,
  :func:`hypothesis.strategies.floats` takes up to *four* boolean flags
  and many of the Numpy strategies have both ``dims`` and ``side`` bounds.
  
  This release converts most optional parameters in our API to use
  keyword-only arguments - and adds a compatibility shim so you get
  warnings rather than errors everywhere (:issue:`2130`).

5.4.2

------------------
  
  This patch fixes compatibility with Python 3.5.2 (:issue:`2334`).
  Note that :doc:`we only test the latest patch of each minor version <supported>`,
  though as in this case we usually accept pull requests for older patch versions.

5.4.1

------------------
  
  This patch improves the repr of :func:`~hypothesis.strategies.from_type`,
  so that in most cases it will display the strategy it resolves to rather
  than ``from_type(...)``.  The latter form will continue to be used where
  resolution is not immediately successful, e.g. invalid arguments or
  recursive type definitions involving forward references.

5.4.0

------------------
  
  This release removes support for Python 3.5.0 and 3.5.1, where the
  :mod:`python:typing` module was quite immature (e.g. missing
  :func:`~python:typing.overload` and :obj:`~python:typing.Type`).
  
  Note that Python 3.5 will reach its end-of-life in September 2020,
  and new releases of Hypothesis may drop support somewhat earlier.
  
  .. note::
  ``pip install hypothesis`` should continue to give you the latest compatible version.
  If you have somehow ended up with an incompatible version, you need to update your
  packaging stack to ``pip >= 9.0`` and ``setuptools >= 24.2`` - see `here for details
  <https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires>`__.
  Then ``pip uninstall hypothesis && pip install hypothesis`` will get you back to
  a compatible version.

5.3.1

------------------
  
  This patch does some minor internal cleanup; there is no user-visible change.

5.3.0

------------------
  
  The standard library :mod:`ipaddress` module is new in Python 3, and this release
  adds the new :func:`~hypothesis.strategies.ip_addresses` strategy to generate
  :class:`~python:ipaddress.IPv4Address`\ es and/or
  :class:`~python:ipaddress.IPv6Address`\ es (depending on the ``v`` and ``network``
  arguments).
  
  If you use them in type annotations, :func:`~hypothesis.strategies.from_type` now
  has strategies registered for :mod:`ipaddress` address, network, and interface types.
  
  The provisional strategies for IP address strings are therefore deprecated.

5.2.1

------------------
  
  This patch reverts :ref:`version 5.2 <v5.2.0>`, due to a
  `strange issue <https://github.com/numpy/numpy/issues/15363>`__
  where indexing an array of strings can raise an error instead of
  returning an item which contains certain surrogate characters.

5.2.0

------------------
  
  This release allows :func:`~hypothesis.extra.numpy.from_dtype` to generate
  Unicode strings which cannot be encoded in UTF-8, but are valid in Numpy
  arrays (which use UTF-32).

5.1.6

------------------
  
  This patch fixes :issue:`2320`, where ``from_type(Set[Hashable])`` could raise
  an internal error because ``Decimal("snan")`` is of a hashable type, but raises
  an error when hashed.  We now ensure that set elements and dict keys in generic
  types can actually be hashed.

5.1.5

------------------
  
  This patch fixes an internal error when running in an :pypi:`IPython` repl or
  :pypi:`Jupyter` notebook on Windows (:issue:`2319`), and an internal error on
  Python 3.5.1 (:issue:`2318`).

5.1.4

------------------
  
  This patch fixes a bug where errors in third-party extensions such as
  :pypi:`hypothesis-trio` or :pypi:`hypothesis-jsonschema` were incorrectly
  considered to be Hypothesis internal errors, which could result in
  confusing error messages.
  
  Thanks to Vincent Michel for reporting and fixing the bug!

5.1.3

------------------
  
  This release converts the type hint comments on our public API to
  :pep:`484` type annotations.
  
  Thanks to Ivan Levkivskyi for :pypi:`com2ann` - with the refactoring
  tools from :ref:`5.0.1 <v5.0.1>` it made this process remarkably easy!

5.1.2

------------------
  
  This patch makes :func:`~hypothesis.stateful.multiple` iterable, so that
  output like ``a, b = state.some_rule()`` is actually executable and
  can be used to reproduce failing examples.
  
  Thanks to Vincent Michel for reporting and fixing :issue:`2311`!

5.1.1

------------------
  
  This patch contains many small refactorings to replace our Python 2
  compatibility functions with their native Python 3 equivalents.
  Since Hypothesis is now Python 3 only, there is no user-visible change.

5.1.0

------------------
  
  This release teaches :func:`~hypothesis.strategies.from_type` how to generate
  :class:`python:datetime.timezone`.  As a result, you can now generate
  :class:`python:datetime.tzinfo` objects without having :pypi:`pytz` installed.
  
  If your tests specifically require :pypi:`pytz` timezones, you should be using
  :func:`hypothesis.extra.pytz.timezones` instead of ``st.from_type(tzinfo)``.

5.0.1

------------------
  
  This patch contains mostly-automated refactorings to remove code
  that we only needed to support Python 2.  Since Hypothesis is now
  Python 3 only (hurray!), there is no user-visible change.
  
  Our sincere thanks to the authors of :pypi:`autoflake`, :pypi:`black`,
  :pypi:`isort`, and :pypi:`pyupgrade`, who have each and collectively
  made this kind of update enormously easier.


```