### PR TITLE
Remove unused stdlib and 3rdparty imports

### DIFF
--- a/bin/check-attachments.py
+++ b/bin/check-attachments.py
@@ -10,7 +10,6 @@ import datetime
 from collections import defaultdict
 
 import click
-import gevent
 from gevent.pool import Pool
 from sqlalchemy import true
 from sqlalchemy.sql.expression import func

--- a/bin/set-throttled.py
+++ b/bin/set-throttled.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 import optparse
 import sys
-import time
 
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.models.account import Account

--- a/inbox/client/client.py
+++ b/inbox/client/client.py
@@ -1,6 +1,5 @@
 import json
 import sys
-from base64 import b64encode
 from os import environ
 
 import requests

--- a/inbox/client/restful_models.py
+++ b/inbox/client/restful_models.py
@@ -1,6 +1,3 @@
-import base64
-import json
-
 from six import StringIO
 
 from .errors import FileUploadError

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -5,7 +5,7 @@ import re
 import sys
 import time
 from builtins import range
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple
 
 import imapclient
 import imapclient.exceptions

--- a/inbox/models/util.py
+++ b/inbox/models/util.py
@@ -3,7 +3,6 @@ import time
 from builtins import range
 from collections import OrderedDict
 
-import gevent
 import limitlion
 from future.utils import iteritems
 from sqlalchemy import desc, func

--- a/inbox/scheduling/event_queue.py
+++ b/inbox/scheduling/event_queue.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 from redis import StrictRedis
 

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -1,4 +1,3 @@
-import abc
 import codecs
 import contextlib
 import re

--- a/tests/api/test_event_when.py
+++ b/tests/api/test_event_when.py
@@ -1,6 +1,5 @@
 import json
 
-import arrow
 import pytest
 from future.utils import iteritems
 

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -177,9 +177,6 @@ def test_api_update_title(db, api_client, calendar, default_account):
     assert e_put_data["when"]["time"] == e_data["when"]["time"]
 
 
-import pytest
-
-
 def test_api_pessimistic_update(db, api_client, calendar, default_account):
     e_data = {
         "title": "",

--- a/tests/auth/test_generic_auth.py
+++ b/tests/auth/test_generic_auth.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 import socket
 
 import attr

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -3,9 +3,7 @@ well as a mock IMAPClient isntance that can be used to deterministically test
 aspects of IMAP sync.
 See https://hypothesis.readthedocs.org/en/latest/data.html for more information
 about how this works."""
-import os
 import string
-import tempfile
 
 import flanker
 from flanker import mime


### PR DESCRIPTION
Note that those are not all unused imports in the code base. Some of them need more work because the code relies on import side effects.