### PR TITLE
Fix running tests in Docker on M1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
       - 6379
 
   mysql:
-    image: mysql:5.7.31
+    image: mysql/mysql-server:8.0.27
     environment:
       MYSQL_ROOT_PASSWORD: nylas_it
+      MYSQL_ROOT_HOST: "%"
       MYSQL_USER: inboxtest
       MYSQL_PASSWORD: inboxtest
       MYSQL_DATABASE: synctest


### PR DESCRIPTION
- The `mysql` image doesn't have M1 support, so I changed it to `mysql/mysql-server`, and also to use the latest version.
- By default, you can only use the root password from within the container, so I had to add a `MYSQL_ROOT_HOST` setting to allow connecting from anywhere. Ideally, we wouldn't use the root password.

I was then able to run the tests locally. But it was still using Python 2.7.
```
docker-compose run -e 'NYLAS_ENV=test' app pytest
```