### PR TITLE
Simplify running tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       python_version:
         type: enum
         description: Python version
-        enum: ["2.7", "3.6", "3.7", "3.8", "3.9"]
+        enum: ["3.7", "3.8", "3.9"]
       platform_suffix:
         type: enum
         default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
                   if [[ -z $SKIP_TESTS ]]; then
                     docker-compose run app bash -ec '
                       bin/wait-for-it.sh mysql:3306 \
-                      && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
+                      && pytest --cov-report= --cov=inbox tests/ \
                       && coverage html -d pythoncov
                     '
                   else

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ data, we encourage developers to add their own protection, such as only
 running sync-engine on a local machine or behind a controlled firewall.
 Note that passwords and OAuth tokens are stored unencrypted in the local MySQL data store on disk. This is intentional, for the same reason as above.
 
+
+## Running tests
+
+To run the test suite execute the following command: `docker-compose run app pytest`
+
+If you wish to run it on different Python version pass `PYTHON_VERSION` to build,
+i.e. `docker-compose build --build-arg PYTHON_VERSION=3.9 app`. The list of supported Python
+versions can be found here: https://github.com/closeio/sync-engine/blob/master/.circleci/config.yml#L37
 ## License
 
 This code is free software, licensed under the The GNU Affero General Public License (AGPL). See the `LICENSE` file for more details.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-norecursedirs = imap/network eas/network data system
+norecursedirs = inbox tests/imap/network tests/data tests/system
 timeout = 60
 
 filterwarnings =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,10 @@ from gevent import monkey
 
 monkey.patch_all(aggressive=False)
 
+import os
+
+os.environ["NYLAS_ENV"] = "test"
+
 from pytest import fixture
 
 from inbox.util.testutils import files  # noqa


### PR DESCRIPTION
You can now run tests without specifying tests/ manually and also you do not need to pass env variable.

`docker-compose run app pytest` should be enough.