### PR TITLE
Fix get-object.py

### DIFF
--- a/bin/get-object.py
+++ b/bin/get-object.py
@@ -81,7 +81,7 @@ def main(type, id, public_id, account_id, namespace_id, readwrite):
         elif namespace_id:
             qu = qu.filter(cls.namespace_id == namespace_id)
 
-        qu.one()  # noqa: F841
+        obj = qu.one()  # noqa: F841
 
         banner = """The object you queried is accessible as `obj`.
 Note that the db session is read-only, unless if you start this script with --readwrite"""


### PR DESCRIPTION
I have removed unused obj variable by mistake during refactors, as you can see it's meant to be used in IPython console as a reference to the object you want to work on.