### PR TITLE
Tweaks to how we document exceptions in suppress

### DIFF
--- a/inbox/actions/backends/generic.py
+++ b/inbox/actions/backends/generic.py
@@ -151,8 +151,8 @@ def remote_delete_folder(crispin_client, account_id, category_id):
         display_name = category.display_name
 
     with contextlib.suppress(IMAP4.error):
-        # Folder has already been deleted on remote. Treat delete as
-        # no-op.
+        # IMAP4.error: Folder has already been deleted on remote. Treat delete
+        # as no-op.
         crispin_client.conn.delete_folder(display_name)
 
     # TODO @karim: Make the main sync loop detect folder renames

--- a/inbox/actions/backends/gmail.py
+++ b/inbox/actions/backends/gmail.py
@@ -64,8 +64,8 @@ def remote_delete_label(crispin_client, account_id, category_id):
         display_name = category.display_name
 
     with contextlib.suppress(IMAP4.error):
-        # Label has already been deleted on remote. Treat delete as
-        # no-op.
+        # IMAP4.error: Label has already been deleted on remote. Treat delete
+        # as no-op.
         crispin_client.conn.delete_folder(display_name)
 
     # TODO @karim --- the main sync loop has a hard time detecting

--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -126,7 +126,8 @@ from inbox.util.misc import imap_folder_path
 from inbox.util.stats import statsd_client
 
 with contextlib.suppress(ImportError):
-    # Only important for EAS search failures, so shouldn't trigge test fail
+    # ImportError: Only important for EAS search failures, so shouldn't trigger
+    # test failure.
     from inbox.util.eas.codes import STORE_STATUS_CODES
 
 


### PR DESCRIPTION
(Note that this is merging into https://github.com/closeio/sync-engine/pull/314.)

---

While reviewing [the other PR](https://github.com/closeio/sync-engine/pull/314), I thought that maybe the comments in some `try...except` clauses lost an important part of their meaning in translation: they look like they apply to the code in question unconditionally, instead of only when an exception is raised.

What I propose here is a notation to make it clear that that comment only applies if an exception covered by the `suppress` manager is raised:

```python
with suppress(AnException):
    # AnException: A comment about when the exception is raised.
    the_code_here()
```

What do you think?