### PR TITLE
Bump lxml to address CVE-2021-43818

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -43,7 +43,7 @@ itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==0.9.3
 limitlion==0.10.0
-lxml==4.6.4
+lxml==4.6.5
 Mako==1.0.7
 MarkupSafe==1.1.1
 mysqlclient==1.3.14


### PR DESCRIPTION
```
4.6.5

==================
  
  Bugs fixed
  ----------
  
  * A vulnerability (GHSL-2021-1038) in the HTML cleaner allowed sneaking script
  content through SVG images (CVE-2021-43818).
  
  * A vulnerability (GHSL-2021-1037) in the HTML cleaner allowed sneaking script
  content through CSS imports and other crafted constructs (CVE-2021-43818).

```