### PR TITLE
Handle Python syntax upgrades in inbox module

### DIFF
--- a/inbox/api/err.py
+++ b/inbox/api/err.py
@@ -57,7 +57,7 @@ class InputError(APIException):
 
     def __init__(self, message):
         self.message = message
-        super(InputError, self).__init__(message)
+        super().__init__(message)
 
 
 class NotFoundError(APIException):
@@ -67,7 +67,7 @@ class NotFoundError(APIException):
 
     def __init__(self, message):
         self.message = message
-        super(NotFoundError, self).__init__(message)
+        super().__init__(message)
 
 
 class ConflictError(APIException):
@@ -75,7 +75,7 @@ class ConflictError(APIException):
 
     def __init__(self, message):
         self.message = message
-        super(ConflictError, self).__init__(message)
+        super().__init__(message)
 
 
 class AccountInvalidError(APIException):

--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -542,13 +542,13 @@ def filter_event_query(
         )
 
     if title is not None:
-        query = query.filter(event_cls.title.like("%{}%".format(title)))
+        query = query.filter(event_cls.title.like(f"%{title}%"))
 
     if description is not None:
-        query = query.filter(event_cls.description.like("%{}%".format(description)))
+        query = query.filter(event_cls.description.like(f"%{description}%"))
 
     if location is not None:
-        query = query.filter(event_cls.location.like("%{}%".format(location)))
+        query = query.filter(event_cls.location.like(f"%{location}%"))
 
     if busy is not None:
         query = query.filter(event_cls.busy == busy)

--- a/inbox/api/metrics_api.py
+++ b/inbox/api/metrics_api.py
@@ -253,7 +253,7 @@ def global_deltas():
 
     txns = redis_txn.zrangebyscore(
         TXN_REDIS_KEY,
-        "({}".format(start_pointer),  # don't include start pointer
+        f"({start_pointer}",  # don't include start pointer
         "+inf",
         withscores=True,
         score_cast_func=int,

--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -313,7 +313,7 @@ def delete_account(namespace_public_id):
             account.mark_for_deletion()
             db_session.commit()
     except NoResultFound:
-        raise NotFoundError("Couldn't find account `{0}` ".format(namespace_public_id))
+        raise NotFoundError(f"Couldn't find account `{namespace_public_id}` ")
 
     encoder = APIEncoder()
     return encoder.jsonify({})

--- a/inbox/api/update.py
+++ b/inbox/api/update.py
@@ -42,7 +42,7 @@ def update_thread(thread, request_data, db_session, optimistic):
     else:
         folder = parse_folder(request_data, db_session, thread.namespace_id)
     if request_data:
-        raise InputError("Unexpected attribute: {}".format(list(request_data)[0]))
+        raise InputError(f"Unexpected attribute: {list(request_data)[0]}")
 
     if accept_labels:
         if labels is not None:
@@ -128,7 +128,7 @@ def parse_folder(request_data, db_session, namespace_id):
             .one()
         )
     except NoResultFound:
-        raise InputError("The folder {} does not exist".format(folder_public_id))
+        raise InputError(f"The folder {folder_public_id} does not exist")
 
 
 def update_message_folder(message, db_session, category, optimistic):
@@ -182,7 +182,7 @@ def parse_labels(request_data, db_session, namespace_id):
             )
             labels.add(category)
         except NoResultFound:
-            raise InputError("The label {} does not exist".format(id_))
+            raise InputError(f"The label {id_} does not exist")
     return labels
 
 
@@ -205,7 +205,7 @@ def update_message_labels(
         if category.name in special_label_map:
             added_labels.append(special_label_map[category.name])
         elif category.name in ("drafts", "sent"):
-            raise InputError('The "{}" label cannot be changed'.format(category.name))
+            raise InputError(f'The "{category.name}" label cannot be changed')
         else:
             added_labels.append(category.display_name)
 
@@ -213,7 +213,7 @@ def update_message_labels(
         if category.name in special_label_map:
             removed_labels.append(special_label_map[category.name])
         elif category.name in ("drafts", "sent"):
-            raise InputError('The "{}" label cannot be changed'.format(category.name))
+            raise InputError(f'The "{category.name}" label cannot be changed')
         else:
             removed_labels.append(category.display_name)
 

--- a/inbox/api/wsgi.py
+++ b/inbox/api/wsgi.py
@@ -73,7 +73,7 @@ class NylasWSGIHandler(WSGIHandler):
         )
 
     def get_environ(self):
-        env = super(NylasWSGIHandler, self).get_environ()
+        env = super().get_environ()
         env["gunicorn.sock"] = self.socket
         env["RAW_URI"] = self.path
         return env
@@ -89,7 +89,7 @@ class NylasWSGIHandler(WSGIHandler):
             self.server.log.info("Socket error", exc=value)
             self.close_connection = True
         else:
-            super(NylasWSGIHandler, self).handle_error(type, value, tb)
+            super().handle_error(type, value, tb)
 
 
 class NylasWSGIWorker(GeventWorker):
@@ -105,7 +105,7 @@ class NylasWSGIWorker(GeventWorker):
         if MAX_BLOCKING_TIME:
             self.tracer = Tracer(max_blocking_time=MAX_BLOCKING_TIME)
             self.tracer.start()
-        super(NylasWSGIWorker, self).init_process()
+        super().init_process()
 
 
 class NylasGunicornLogger(gunicorn.glogging.Logger):
@@ -130,7 +130,7 @@ class RollbarWSGIWorker(NylasWSGIWorker):
     def init_process(self):
         maybe_enable_rollbar()
 
-        super(RollbarWSGIWorker, self).init_process()
+        super().init_process()
 
 
 __all__ = [

--- a/inbox/auth/base.py
+++ b/inbox/auth/base.py
@@ -37,7 +37,7 @@ def handler_from_provider(provider_name):
         return MicrosoftAuthHandler()
 
     raise NotSupportedError(
-        'Nylas does not support the email provider "{}".'.format(provider_name)
+        f'Nylas does not support the email provider "{provider_name}".'
     )
 
 
@@ -64,7 +64,7 @@ class AuthHandler:
         host, port = account.imap_endpoint
         try:
             return create_imap_connection(host, port, use_timeout)
-        except (IMAPClient.Error, socket.error) as exc:
+        except (IMAPClient.Error, OSError) as exc:
             log.error(
                 "Error instantiating IMAP connection", account_id=account.id, error=exc,
             )

--- a/inbox/auth/google.py
+++ b/inbox/auth/google.py
@@ -87,7 +87,7 @@ class GoogleAuthHandler(OAuthAuthHandler):
         url = url_concat(self.OAUTH_AUTHENTICATE_URL, url_args)
 
         print("To authorize Nylas, visit this URL and follow the directions:")
-        print("\n{}".format(url))
+        print(f"\n{url}")
 
         while True:
             auth_code = input("Enter authorization code: ").strip()

--- a/inbox/auth/microsoft.py
+++ b/inbox/auth/microsoft.py
@@ -84,7 +84,7 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
         url = url_concat(self.OAUTH_AUTHENTICATE_URL, url_args)
 
         print("To authorize Nylas, visit this URL and follow the directions:")
-        print("\n{}".format(url))
+        print(f"\n{url}")
 
         while True:
             auth_code = input("Enter authorization code: ").strip()

--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -191,7 +191,7 @@ class OAuthAuthHandler(AuthHandler):
         access_token = session_dict["access_token"]
         request = urllib.request.Request(
             self.OAUTH_USER_INFO_URL,
-            headers={"Authorization": "Bearer {}".format(access_token)},
+            headers={"Authorization": f"Bearer {access_token}"},
         )
         try:
             response = urllib.request.urlopen(request)
@@ -244,7 +244,7 @@ class OAuthRequestsWrapper(requests.auth.AuthBase):
         self.token = token
 
     def __call__(self, r):
-        r.headers["Authorization"] = "Bearer {}".format(self.token)
+        r.headers["Authorization"] = f"Bearer {self.token}"
         return r
 
 

--- a/inbox/basicauth.py
+++ b/inbox/basicauth.py
@@ -44,7 +44,7 @@ class GmailSettingError(ValidationError):
 
 class ImapSupportDisabledError(ValidationError):
     def __init__(self, reason=None):
-        super(ImapSupportDisabledError, self).__init__(reason)
+        super().__init__(reason)
         self.reason = reason
 
 

--- a/inbox/client/client.py
+++ b/inbox/client/client.py
@@ -268,9 +268,9 @@ class APIClient(json.JSONEncoder):
     def _get_resources(self, cls, extra=None, **filters):
         # FIXME @karim: remove this interim code when we've got rid
         # of the old accounts API.
-        postfix = "/{}".format(extra) if extra else ""
+        postfix = f"/{extra}" if extra else ""
         if cls.api_root != "a":
-            url = "{}/{}{}".format(self.api_server, cls.collection_name, postfix)
+            url = f"{self.api_server}/{cls.collection_name}{postfix}"
         else:
             url = "{}/a/{}/{}{}".format(
                 self.api_server, self.app_id, cls.collection_name, postfix
@@ -291,9 +291,9 @@ class APIClient(json.JSONEncoder):
         headers = headers or {}
         headers.update(self.session.headers)
 
-        postfix = "/{}".format(extra) if extra else ""
+        postfix = f"/{extra}" if extra else ""
         if cls.api_root != "a":
-            url = "{}/{}/{}{}".format(self.api_server, cls.collection_name, id, postfix)
+            url = f"{self.api_server}/{cls.collection_name}/{id}{postfix}"
         else:
             url = "{}/a/{}/{}/{}{}".format(
                 self.api_server, self.app_id, cls.collection_name, id, postfix
@@ -319,10 +319,10 @@ class APIClient(json.JSONEncoder):
 
     @nylas_excepted
     def _create_resource(self, cls, data, **kwargs):
-        url = "{}/{}/".format(self.api_server, cls.collection_name)
+        url = f"{self.api_server}/{cls.collection_name}/"
 
         if len(kwargs.keys()) > 0:
-            url = "{}?{}".format(url, urlencode(kwargs))
+            url = f"{url}?{urlencode(kwargs)}"
 
         session = self._get_http_session(cls.api_root)
 
@@ -341,7 +341,7 @@ class APIClient(json.JSONEncoder):
 
     @nylas_excepted
     def _create_resources(self, cls, data):
-        url = "{}/{}/".format(self.api_server, cls.collection_name)
+        url = f"{self.api_server}/{cls.collection_name}/"
         session = self._get_http_session(cls.api_root)
 
         if cls == File:
@@ -358,10 +358,10 @@ class APIClient(json.JSONEncoder):
     @nylas_excepted
     def _delete_resource(self, cls, id, data=None, **kwargs):
         name = cls.collection_name
-        url = "{}/{}/{}".format(self.api_server, name, id)
+        url = f"{self.api_server}/{name}/{id}"
 
         if len(kwargs.keys()) > 0:
-            url = "{}?{}".format(url, urlencode(kwargs))
+            url = f"{url}?{urlencode(kwargs)}"
         session = self._get_http_session(cls.api_root)
         if data:
             _validate(session.delete(url, json=data))
@@ -371,10 +371,10 @@ class APIClient(json.JSONEncoder):
     @nylas_excepted
     def _update_resource(self, cls, id, data, **kwargs):
         name = cls.collection_name
-        url = "{}/{}/{}".format(self.api_server, name, id)
+        url = f"{self.api_server}/{name}/{id}"
 
         if len(kwargs.keys()) > 0:
-            url = "{}?{}".format(url, urlencode(kwargs))
+            url = f"{url}?{urlencode(kwargs)}"
 
         session = self._get_http_session(cls.api_root)
 
@@ -389,7 +389,7 @@ class APIClient(json.JSONEncoder):
         for example /a/.../accounts/id/upgrade"""
         name = cls.collection_name
         if cls.api_root != "a":
-            url = "{}/{}/{}/{}".format(self.api_server, name, id, method_name)
+            url = f"{self.api_server}/{name}/{id}/{method_name}"
         else:
             # Management method.
             url = "{}/a/{}/{}/{}/{}".format(

--- a/inbox/client/restful_model_collection.py
+++ b/inbox/client/restful_model_collection.py
@@ -50,7 +50,7 @@ class RestfulModelCollection:
         filter = filter or {}
         reserved_keywords = ["from", "in"]
         for keyword in reserved_keywords:
-            escaped_keyword = "{}_".format(keyword)
+            escaped_keyword = f"{keyword}_"
             if escaped_keyword in filters:
                 filters[keyword] = filters.get(escaped_keyword)
                 del filters[escaped_keyword]

--- a/inbox/config.py
+++ b/inbox/config.py
@@ -38,7 +38,7 @@ class ConfigError(Exception):
         )
 
     def __str__(self):
-        return "{0} {1}".format(self.error, self.help)
+        return f"{self.error} {self.help}"
 
 
 class Configuration(dict):
@@ -47,7 +47,7 @@ class Configuration(dict):
 
     def get_required(self, key):
         if key not in self:
-            raise ConfigError("Missing config value for {0}.".format(key))
+            raise ConfigError(f"Missing config value for {key}.")
 
         return self[key]
 
@@ -104,7 +104,7 @@ def _update_config_from_env(config, env):
             with open(filename) as f:
                 # this also parses json, which is a subset of yaml
                 config.update(yaml.safe_load(f))
-        except (IOError, OSError) as e:  # noqa: B014
+        except OSError as e:  # noqa: B014
             if e.errno != errno.ENOENT:
                 raise
 

--- a/inbox/contacts/algorithms.py
+++ b/inbox/contacts/algorithms.py
@@ -43,13 +43,7 @@ def _get_participants(msg, excluded_emails=None):
     participants = msg.to_addr + msg.cc_addr + msg.bcc_addr
     return sorted(
         list(
-            set(
-                [
-                    email.lower()
-                    for _, email in participants
-                    if email not in excluded_emails
-                ]
-            )
+            {email.lower() for _, email in participants if email not in excluded_emails}
         )
     )
 
@@ -111,7 +105,7 @@ def calculate_group_scores(messages, user_email):
     molecules_dict = defaultdict(set)  # (emails, ...) -> {message ids, ...}
 
     def get_message_list_weight(message_ids):
-        return sum([message_ids_to_scores[m_id] for m_id in message_ids])
+        return sum(message_ids_to_scores[m_id] for m_id in message_ids)
 
     # Gather initial candidate social molecules
     for msg in messages:

--- a/inbox/contacts/icloud.py
+++ b/inbox/contacts/icloud.py
@@ -85,7 +85,7 @@ class ICloudContactsProvider:
 
         # Get addressbook home URL on user's specific iCloud shard/subdomain
         home_url = c.get_address_book_home(ICLOUD_CONTACTS_URL + principal)
-        self.log.info("Home URL for user's contacts: {}".format(home_url))
+        self.log.info(f"Home URL for user's contacts: {home_url}")
         self.log.debug("Requesting cards for user")
 
         # This request is limited to returning 5000 items
@@ -113,5 +113,5 @@ class ICloudContactsProvider:
             if new_contact:
                 all_contacts.append(new_contact)
 
-        self.log.info("Saving {} contacts from iCloud sync".format(len(all_contacts)))
+        self.log.info(f"Saving {len(all_contacts)} contacts from iCloud sync")
         return all_contacts

--- a/inbox/contacts/search.py
+++ b/inbox/contacts/search.py
@@ -38,7 +38,7 @@ def get_search_service():
         region_name="us-west-2",
         aws_access_key_id=config.get_required("AWS_ACCESS_KEY_ID"),
         aws_secret_access_key=config.get_required("AWS_SECRET_ACCESS_KEY"),
-        endpoint_url="https://{0}".format(search_service_url),
+        endpoint_url=f"https://{search_service_url}",
     )
 
 
@@ -48,7 +48,7 @@ def get_doc_service():
         region_name="us-west-2",
         aws_access_key_id=config.get_required("AWS_ACCESS_KEY_ID"),
         aws_secret_access_key=config.get_required("AWS_SECRET_ACCESS_KEY"),
-        endpoint_url="https://{0}".format(doc_service_url),
+        endpoint_url=f"https://{doc_service_url}",
     )
 
 
@@ -95,7 +95,7 @@ class ContactSearchClient:
         """ Make sure we always filter results by namespace and apply the
         correct query options. """
 
-        namespace_filter = "(and namespace_id:{})".format(self.namespace_id)
+        namespace_filter = f"(and namespace_id:{self.namespace_id})"
         if "query" not in kwargs:
             kwargs["query"] = namespace_filter
             kwargs["queryParser"] = "structured"

--- a/inbox/error_handling.py
+++ b/inbox/error_handling.py
@@ -21,7 +21,7 @@ class SyncEngineRollbarHandler(RollbarHandler):
         try:
             data = json.loads(record.msg)
         except ValueError:
-            return super(SyncEngineRollbarHandler, self).emit(record)
+            return super().emit(record)
 
         event = data.get("event")
         # Prevent uncaught exceptions from being duplicated in Rollbar.
@@ -40,7 +40,7 @@ class SyncEngineRollbarHandler(RollbarHandler):
             "title": event,
         }
 
-        return super(SyncEngineRollbarHandler, self).emit(record)
+        return super().emit(record)
 
 
 def log_uncaught_errors(logger=None, **kwargs):

--- a/inbox/events/ical.py
+++ b/inbox/events/ical.py
@@ -162,7 +162,7 @@ def events_from_ics(namespace, calendar, ics_str):
 
             recur = component.get("rrule")
             if recur:
-                recur = "RRULE:{}".format(recur.to_ical())
+                recur = f"RRULE:{recur.to_ical()}"
 
             participants = []
 
@@ -220,7 +220,7 @@ def events_from_ics(namespace, calendar, ics_str):
                 notes = None
                 try:
                     guests = attendee.params["X-NUM-GUESTS"]
-                    notes = "Guests: {}".format(guests)
+                    notes = f"Guests: {guests}"
                 except KeyError:
                     pass
 
@@ -488,7 +488,7 @@ def generate_icalendar_invite(event, invite_type="request"):
     icalendar_event = icalendar.Event()
 
     account = event.namespace.account
-    organizer = icalendar.vCalAddress("MAILTO:{}".format(account.email_address))
+    organizer = icalendar.vCalAddress(f"MAILTO:{account.email_address}")
     if account.name is not None and account.name != "":
         organizer.params["CN"] = account.name
 
@@ -501,7 +501,7 @@ def generate_icalendar_invite(event, invite_type="request"):
     else:
         icalendar_event["status"] = "CONFIRMED"
 
-    icalendar_event["uid"] = "{}@nylas.com".format(event.public_id)
+    icalendar_event["uid"] = f"{event.public_id}@nylas.com"
     icalendar_event["description"] = event.description or ""
     icalendar_event["summary"] = event.title or ""
     icalendar_event["last-modified"] = serialize_datetime(event.updated_at)
@@ -520,7 +520,7 @@ def generate_icalendar_invite(event, invite_type="request"):
         # We may have to patch the iCalendar module for this.
         assert email is not None and email != ""
 
-        attendee = icalendar.vCalAddress("MAILTO:{}".format(email))
+        attendee = icalendar.vCalAddress(f"MAILTO:{email}")
         name = participant.get("name", None)
         if name is not None:
             attendee.params["CN"] = name
@@ -570,11 +570,11 @@ def generate_invite_message(ical_txt, event, account, invite_type="request"):
     msg.headers["Reply-To"] = account.email_address
 
     if invite_type == "request":
-        msg.headers["Subject"] = "Invitation: {}".format(event.title)
+        msg.headers["Subject"] = f"Invitation: {event.title}"
     elif invite_type == "update":
-        msg.headers["Subject"] = "Updated Invitation: {}".format(event.title)
+        msg.headers["Subject"] = f"Updated Invitation: {event.title}"
     elif invite_type == "cancel":
-        msg.headers["Subject"] = "Cancelled: {}".format(event.title)
+        msg.headers["Subject"] = f"Cancelled: {event.title}"
 
     return msg
 
@@ -600,7 +600,7 @@ def send_invite(ical_txt, event, account, invite_type="request"):
         msg.headers["To"] = email
         final_message = msg.to_string()
 
-        mg_url = "https://api.mailgun.net/v3/{}/messages.mime".format(MAILGUN_DOMAIN)
+        mg_url = f"https://api.mailgun.net/v3/{MAILGUN_DOMAIN}/messages.mime"
         r = requests.post(
             mg_url,
             auth=("api", MAILGUN_API_KEY),
@@ -658,7 +658,7 @@ def _generate_rsvp(status, account, event):
     if event.title is not None:
         icalevent["summary"] = event.title
 
-    attendee = icalendar.vCalAddress("MAILTO:{}".format(account.email_address))
+    attendee = icalendar.vCalAddress(f"MAILTO:{account.email_address}")
     attendee.params["cn"] = account.name
     attendee.params["partstat"] = status
     icalevent.add("attendee", attendee, encode=0)
@@ -730,13 +730,13 @@ def send_rsvp(ical_data, event, body_text, status, account):
     assert status in ["yes", "no", "maybe"]
 
     if status == "yes":
-        msg.headers["Subject"] = "Accepted: {}".format(event.message.subject)
+        msg.headers["Subject"] = f"Accepted: {event.message.subject}"
     elif status == "maybe":
         msg.headers["Subject"] = "Tentatively accepted: {}".format(
             event.message.subject
         )
     elif status == "no":
-        msg.headers["Subject"] = "Declined: {}".format(event.message.subject)
+        msg.headers["Subject"] = f"Declined: {event.message.subject}"
 
     final_message = msg.to_string()
 

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -230,7 +230,7 @@ def handle_event_updates(namespace_id, calendar_id, events, log, db_session):
 
 class GoogleEventSync(EventSync):
     def __init__(self, *args, **kwargs):
-        super(GoogleEventSync, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         with session_scope(self.namespace_id) as db_session:
             account = db_session.query(Account).get(self.account_id)
             if (

--- a/inbox/heartbeat/store.py
+++ b/inbox/heartbeat/store.py
@@ -26,7 +26,7 @@ class HeartbeatStatusKey:
     def __init__(self, account_id, folder_id):
         self.account_id = account_id
         self.folder_id = folder_id
-        self.key = "{}:{}".format(self.account_id, self.folder_id)
+        self.key = f"{self.account_id}:{self.folder_id}"
 
     def __repr__(self):
         return self.key
@@ -53,7 +53,7 @@ class HeartbeatStatusKey:
 
     @classmethod
     def from_string(cls, string_key):
-        account_id, folder_id = [int(part) for part in string_key.split(":")]
+        account_id, folder_id = (int(part) for part in string_key.split(":"))
         return cls(account_id, folder_id)
 
 

--- a/inbox/ignition.py
+++ b/inbox/ignition.py
@@ -103,7 +103,7 @@ def engine(
         f, name = find_first_app_frame_and_name(
             ignores=["sqlalchemy", "inbox.ignition", "inbox.logging"]
         )
-        source = "{}:{}".format(name, f.f_lineno)
+        source = f"{name}:{f.f_lineno}"
 
         pool_tracker[dbapi_connection] = {
             "source": source,
@@ -138,12 +138,10 @@ class EngineManager:
 
                 # Perform some sanity checks on the configuration.
                 assert isinstance(key, int)
-                assert (
-                    key not in keys
-                ), "Shard key collision: key {} is repeated".format(key)
+                assert key not in keys, f"Shard key collision: key {key} is repeated"
                 assert (
                     schema_name not in schema_names
-                ), "Shard name collision: {} is repeated".format(schema_name)
+                ), f"Shard name collision: {schema_name} is repeated"
                 keys.add(key)
                 schema_names.add(schema_name)
 

--- a/inbox/instrumentation.py
+++ b/inbox/instrumentation.py
@@ -59,11 +59,11 @@ class ProfileCollector:
         if self._started is None:
             return ""
         elapsed = time.time() - self._started
-        lines = ["elapsed {}".format(elapsed), "granularity {}".format(self.interval)]
+        lines = [f"elapsed {elapsed}", f"granularity {self.interval}"]
         ordered_stacks = sorted(
             self._stack_counts.items(), key=lambda kv: kv[1], reverse=True
         )
-        lines.extend(["{} {}".format(frame, count) for frame, count in ordered_stacks])
+        lines.extend([f"{frame} {count}" for frame, count in ordered_stacks])
         return "\n".join(lines) + "\n"
 
     def reset(self):
@@ -253,14 +253,10 @@ class KillerGreenletTracer(GreenletTracer):
         max_blocking_time=MAX_BLOCKING_TIME_BEFORE_INTERRUPT,
     ):
         self._max_blocking_time = max_blocking_time
-        super(KillerGreenletTracer, self).__init__(
-            blocking_sample_period, sampling_interval, logging_interval
-        )
+        super().__init__(blocking_sample_period, sampling_interval, logging_interval)
 
     def _notify_greenlet_blocked(self, active_greenlet, current_time):
-        super(KillerGreenletTracer, self)._notify_greenlet_blocked(
-            active_greenlet, current_time
-        )
+        super()._notify_greenlet_blocked(active_greenlet, current_time)
         if self._last_switch_time is None:
             return
 

--- a/inbox/logging.py
+++ b/inbox/logging.py
@@ -70,7 +70,7 @@ def _record_module(logger, name, event_dict):
             "gunicorn.glogging",
         ]
     )
-    event_dict["module"] = "{}:{}".format(name, f.f_lineno)
+    event_dict["module"] = f"{name}:{f.f_lineno}"
     return event_dict
 
 
@@ -213,9 +213,7 @@ class BoundLogger(structlog.stdlib.BoundLogger):
         if env is not None:
             event_kw["env"] = env
 
-        return super(BoundLogger, self)._proxy_to_logger(
-            method_name, event, *event_args, **event_kw
-        )
+        return super()._proxy_to_logger(method_name, event, *event_args, **event_kw)
 
 
 structlog.configure(
@@ -268,7 +266,7 @@ class ConditionalFormatter(logging.Formatter):
 
         self._style._fmt = style
 
-        return super(ConditionalFormatter, self).format(record)
+        return super().format(record)
 
 
 def configure_logging(log_level=None):

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -142,7 +142,7 @@ class FolderSyncEngine(Greenlet):
                 )
             except NoResultFound:
                 raise MailsyncError(
-                    "Missing Folder '{}' on account {}".format(folder_name, account_id)
+                    f"Missing Folder '{folder_name}' on account {account_id}"
                 )
 
             self.folder_id = folder.id
@@ -739,9 +739,7 @@ class FolderSyncEngine(Greenlet):
             lastseenuid = common.lastseenuid(
                 self.account_id, db_session, self.folder_id
             )
-        latest_uids = crispin_client.conn.fetch(
-            "{}:*".format(lastseenuid + 1), ["UID"]
-        ).keys()
+        latest_uids = crispin_client.conn.fetch(f"{lastseenuid + 1}:*", ["UID"]).keys()
         new_uids = set(latest_uids) - {lastseenuid}
         if new_uids:
             for uid in sorted(new_uids):

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -81,7 +81,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
 
         assert "inbox" in {
             f.role for f in raw_folders
-        }, "Account {} has no detected inbox folder".format(account.email_address)
+        }, f"Account {account.email_address} has no detected inbox folder"
 
         local_folders = {
             f.name: f

--- a/inbox/mailsync/frontend.py
+++ b/inbox/mailsync/frontend.py
@@ -33,7 +33,7 @@ class ProfilingHTTPFrontend(HTTPFrontend):
         self.port = port
         self.profiler = ProfileCollector() if profile else None
         self.tracer = self.greenlet_tracer_cls()() if trace_greenlets else None
-        super(ProfilingHTTPFrontend, self).__init__()
+        super().__init__()
 
     def greenlet_tracer_cls(self):
         return GreenletTracer
@@ -47,7 +47,7 @@ class ProfilingHTTPFrontend(HTTPFrontend):
             self.tracer.start()
         if self.profiler is not None:
             self.profiler.start()
-        super(ProfilingHTTPFrontend, self).start()
+        super().start()
 
     def _create_app_impl(self, app):
         @app.route("/profile")
@@ -83,13 +83,13 @@ class SyncbackHTTPFrontend(ProfilingHTTPFrontend):
 class SyncHTTPFrontend(ProfilingHTTPFrontend):
     def __init__(self, sync_service, port, trace_greenlets, profile):
         self.sync_service = sync_service
-        super(SyncHTTPFrontend, self).__init__(port, trace_greenlets, profile)
+        super().__init__(port, trace_greenlets, profile)
 
     def greenlet_tracer_cls(self):
         return KillerGreenletTracer
 
     def _create_app_impl(self, app):
-        super(SyncHTTPFrontend, self)._create_app_impl(app)
+        super()._create_app_impl(app)
 
         @app.route("/unassign", methods=["POST"])
         def unassign_account():
@@ -103,7 +103,7 @@ class SyncHTTPFrontend(ProfilingHTTPFrontend):
         @app.route("/build-metadata", methods=["GET"])
         def build_metadata():
             filename = "/usr/share/python/cloud-core/metadata.txt"
-            with open(filename, "r") as f:
+            with open(filename) as f:
                 _, build_id = f.readline().rstrip("\n").split()
                 build_id = build_id[1:-1]  # Remove first and last single quotes.
                 _, git_commit = f.readline().rstrip("\n").split()

--- a/inbox/models/account.py
+++ b/inbox/models/account.py
@@ -202,7 +202,7 @@ class Account(
             [f.initial_sync_start is None for f in self.folders]
         ):
             return None
-        return min([f.initial_sync_start for f in self.folders])
+        return min(f.initial_sync_start for f in self.folders)
 
     @property
     def initial_sync_end(self):
@@ -210,7 +210,7 @@ class Account(
             [f.initial_sync_end is None for f in self.folders]
         ):
             return None
-        return max([f.initial_sync_end for f in self.folders])
+        return max(f.initial_sync_end for f in self.folders)
 
     @property
     def initial_sync_duration(self):

--- a/inbox/models/backends/generic.py
+++ b/inbox/models/backends/generic.py
@@ -141,7 +141,7 @@ class GenericAccount(ImapAccount):
 
     @property
     def provider_info(self):
-        provider_info = super(GenericAccount, self).provider_info
+        provider_info = super().provider_info
         provider_info["auth"] = "password"
         return provider_info
 

--- a/inbox/models/backends/imap.py
+++ b/inbox/models/backends/imap.py
@@ -135,7 +135,7 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
         """
         changed = False
-        new_flags = set(flag.decode() for flag in new_flags)
+        new_flags = {flag.decode() for flag in new_flags}
         col_for_flag = {
             "\\Draft": "is_draft",
             "\\Seen": "is_seen",
@@ -211,7 +211,7 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     @property
     def categories(self):
-        categories = set([lbl.category for lbl in self.labels])
+        categories = {lbl.category for lbl in self.labels}
         categories.add(self.folder.category)
         return categories
 

--- a/inbox/models/backends/oauth.py
+++ b/inbox/models/backends/oauth.py
@@ -153,7 +153,7 @@ class OAuthAccount:
             )
         except Exception as e:
             log.error(
-                "Error while getting access token: {}".format(e),
+                f"Error while getting access token: {e}",
                 force_refresh=force_refresh,
                 account_id=self.id,
                 exc_info=True,

--- a/inbox/models/category.py
+++ b/inbox/models/category.py
@@ -43,9 +43,7 @@ class CategoryNameString(StringWithTransform):
     """
 
     def __init__(self, *args, **kwargs):
-        super(CategoryNameString, self).__init__(
-            sanitize_name, MAX_INDEXABLE_LENGTH, collation="utf8mb4_bin"
-        )
+        super().__init__(sanitize_name, MAX_INDEXABLE_LENGTH, collation="utf8mb4_bin")
 
 
 class Category(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMixin):

--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -438,7 +438,7 @@ class Event(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMi
         for k in list(kwargs):
             if not hasattr(type(self), k):
                 del kwargs[k]
-        super(Event, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
 # For API querying performance - default sort order is event.start ASC
@@ -462,7 +462,7 @@ class RecurringEvent(Event):
     def __init__(self, **kwargs):
         self.start_timezone = kwargs.pop("original_start_tz", None)
         kwargs["recurrence"] = repr(kwargs["recurrence"])
-        super(RecurringEvent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         try:
             self.unwrap_rrule()
         except Exception as e:
@@ -537,7 +537,7 @@ class RecurringEvent(Event):
         return sorted(events, key=lambda e: e.start)
 
     def update(self, event):
-        super(RecurringEvent, self).update(event)
+        super().update(event)
         if isinstance(event, type(self)):
             self.rrule = event.rrule
             self.exdate = event.exdate
@@ -575,7 +575,7 @@ class RecurringEventOverride(Event):
         return unicode_safe_truncate(value, MAX_LENS[key])
 
     def update(self, event):
-        super(RecurringEventOverride, self).update(event)
+        super().update(event)
         if isinstance(event, type(self)):
             self.master_event_uid = event.master_event_uid
             self.original_start_time = event.original_start_time
@@ -600,8 +600,8 @@ class InflatedEvent(Event):
         # Give inflated events a UID consisting of the master UID and the
         # original UTC start time of the inflation.
         ts_id = instance_start.strftime("%Y%m%dT%H%M%SZ")
-        self.uid = "{}_{}".format(self.master.uid, ts_id)
-        self.public_id = "{}_{}".format(self.master.public_id, ts_id)
+        self.uid = f"{self.master.uid}_{ts_id}"
+        self.public_id = f"{self.master.public_id}_{ts_id}"
         self.set_start_end(instance_start)
 
     def set_start_end(self, start):
@@ -611,7 +611,7 @@ class InflatedEvent(Event):
         self.end = self.start + length
 
     def update(self, master):
-        super(InflatedEvent, self).update(master)
+        super().update(master)
         self.namespace_id = master.namespace_id
         self.calendar_id = master.calendar_id
 
@@ -628,7 +628,7 @@ class InflatedEvent(Event):
 
 
 def insert_warning(mapper, connection, target):
-    log.warn("InflatedEvent {} shouldn't be committed".format(target))
+    log.warn(f"InflatedEvent {target} shouldn't be committed")
     raise Exception("InflatedEvent should not be committed")
 
 

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -213,7 +213,7 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
 
         from inbox.sendmail.message import generate_message_id_header
 
-        self.nylas_uid = "{}-{}".format(self.public_id, self.version)
+        self.nylas_uid = f"{self.public_id}-{self.version}"
         self.message_id_header = generate_message_id_header(self.nylas_uid)
 
     categories = association_proxy(
@@ -304,7 +304,7 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
             body_length = len(body_string)
             if body_length > MAX_MESSAGE_BODY_PARSE_LENGTH:
                 raise Exception(
-                    "message length ({}) is over the parsing limit".format(body_length)
+                    f"message length ({body_length}) is over the parsing limit"
                 )
             parsed = mime.from_string(body_string)  # type: MimePart
             # Non-persisted instance attribute used by EAS.

--- a/inbox/models/session.py
+++ b/inbox/models/session.py
@@ -55,7 +55,7 @@ def new_session(engine, versioned=True):
         )
         funcname = frame.f_code.co_name
         modname = modname.replace(".", "-")
-        metric_name = "db.{}.{}.{}".format(engine.url.database, modname, funcname)
+        metric_name = f"db.{engine.url.database}.{modname}.{funcname}"
 
         @event.listens_for(session, "after_begin")
         def after_begin(session, transaction, connection):

--- a/inbox/models/util.py
+++ b/inbox/models/util.py
@@ -282,7 +282,7 @@ def _batch_delete(
 ):
     (column, id_) = column_id_filters
     count = engine.execute(
-        "SELECT COUNT(*) FROM {} WHERE {}={};".format(table, column, id_)
+        f"SELECT COUNT(*) FROM {table} WHERE {column}={id_};"
     ).scalar()
 
     if count == 0:
@@ -373,7 +373,7 @@ def _batch_delete(
     log.info("Completed batch deletion", time=end - start, table=table)
 
     count = engine.execute(
-        "SELECT COUNT(*) FROM {} WHERE {}={};".format(table, column, id_)
+        f"SELECT COUNT(*) FROM {table} WHERE {column}={id_};"
     ).scalar()
 
     if dry_run is False:
@@ -420,9 +420,7 @@ def purge_transactions(
 
             with session_scope_by_shard_id(shard_id, versioned=False) as db_session:
                 if dry_run:
-                    rowcount = db_session.execute(
-                        "{} OFFSET {}".format(query, offset)
-                    ).rowcount
+                    rowcount = db_session.execute(f"{query} OFFSET {offset}").rowcount
                     offset += rowcount
                 else:
                     rowcount = db_session.execute(query).rowcount
@@ -449,7 +447,7 @@ def purge_transactions(
         redis_txn.zremrangebyscore(
             TXN_REDIS_KEY,
             "-inf",
-            "({}".format(min_txn_id) if min_txn_id is not None else "+inf",
+            f"({min_txn_id}" if min_txn_id is not None else "+inf",
         )
         log.info(
             "Finished purging transaction entries from redis",

--- a/inbox/models/when.py
+++ b/inbox/models/when.py
@@ -62,7 +62,7 @@ class When(metaclass=abc.ABCMeta):
                 time = parse_utc(raw[key])
                 times.append(time)
             except (AttributeError, ValueError, TypeError):
-                raise ValueError("'{}' parameter invalid.".format(key))
+                raise ValueError(f"'{key}' parameter invalid.")
         return times
 
     def __init__(self, start, end=None):
@@ -70,7 +70,7 @@ class When(metaclass=abc.ABCMeta):
         self.end = end or start
 
     def __repr__(self):
-        return "{} ({} - {})".format(type(self), self.start, self.end)
+        return f"{type(self)} ({self.start} - {self.end})"
 
     @property
     def is_time(self):

--- a/inbox/providers.py
+++ b/inbox/providers.py
@@ -11,7 +11,7 @@ def provider_info(provider_name):
 
     """
     if provider_name not in providers:
-        raise NotSupportedError("Provider: {} not supported.".format(provider_name))
+        raise NotSupportedError(f"Provider: {provider_name} not supported.")
 
     return providers[provider_name]
 

--- a/inbox/scheduling/queue.py
+++ b/inbox/scheduling/queue.py
@@ -121,11 +121,11 @@ class QueueClient:
 
     @property
     def _queue(self):
-        return "unassigned_{}".format(self.zone)
+        return f"unassigned_{self.zone}"
 
     @property
     def _hash(self):
-        return "assigned_{}".format(self.zone)
+        return f"assigned_{self.zone}"
 
 
 class QueuePopulator:
@@ -157,9 +157,9 @@ class QueuePopulator:
         self.enqueue_new_accounts()
         self.unassign_disabled_accounts()
         statsd_client.gauge(
-            "syncqueue.queue.{}.length".format(self.zone), self.queue_client.qsize()
+            f"syncqueue.queue.{self.zone}.length", self.queue_client.qsize()
         )
-        statsd_client.incr("syncqueue.service.{}.heartbeat".format(self.zone))
+        statsd_client.incr(f"syncqueue.service.{self.zone}.heartbeat")
         gevent.sleep(self.poll_interval)
 
     def enqueue_new_accounts(self):

--- a/inbox/search/backends/imap.py
+++ b/inbox/search/backends/imap.py
@@ -28,7 +28,7 @@ class IMAPSearchClient:
         account = db_session.query(Account).get(self.account_id)
         try:
             conn = account.auth_handler.get_authenticated_imap_connection(account)
-        except (IMAPClient.Error, socket.error, IMAP4.error):
+        except (IMAPClient.Error, OSError, IMAP4.error):
             raise SearchBackendException(
                 (
                     "Unable to connect to the IMAP "

--- a/inbox/search/base.py
+++ b/inbox/search/base.py
@@ -15,7 +15,7 @@ class SearchBackendException(Exception):
         self.message = message
         self.http_code = http_code
         self.server_error = server_error
-        super(SearchBackendException, self).__init__(message, http_code, server_error)
+        super().__init__(message, http_code, server_error)
 
     def __str__(self):
         return self.message
@@ -28,4 +28,4 @@ class SearchStoreException(Exception):
 
     def __init__(self, err_code):
         self.err_code = err_code
-        super(SearchStoreException, self).__init__(err_code)
+        super().__init__(err_code)

--- a/inbox/security/oracles.py
+++ b/inbox/security/oracles.py
@@ -111,9 +111,7 @@ class _EncryptionOracle:
             )
 
         else:
-            raise ValueError(
-                "encryption_scheme not supported: {}".format(encryption_scheme)
-            )
+            raise ValueError(f"encryption_scheme not supported: {encryption_scheme}")
 
         return (ciphertext, encryption_scheme.value)
 
@@ -178,5 +176,5 @@ class _DecryptionOracle(_EncryptionOracle):
 
         else:
             raise ValueError(
-                "encryption_scheme not supported: {}".format(encryption_scheme_value)
+                f"encryption_scheme not supported: {encryption_scheme_value}"
             )

--- a/inbox/sendmail/base.py
+++ b/inbox/sendmail/base.py
@@ -38,9 +38,7 @@ class SendMailException(Exception):
         self.http_code = http_code
         self.server_error = server_error
         self.failures = failures
-        super(SendMailException, self).__init__(
-            message, http_code, server_error, failures
-        )
+        super().__init__(message, http_code, server_error, failures)
 
 
 def get_sendmail_client(account):
@@ -101,7 +99,7 @@ def create_draft_from_mime(account, raw_mime, db_session):
 
 
 def block_to_part(block, message, namespace):
-    inline_image_uri = r"cid:{}".format(block.public_id)
+    inline_image_uri = fr"cid:{block.public_id}"
     is_inline = re.search(inline_image_uri, message.body) is not None
     # Create a new Part object to associate to the message object.
     # (You can't just set block.message, because if block is an

--- a/inbox/sendmail/message.py
+++ b/inbox/sendmail/message.py
@@ -169,7 +169,7 @@ def create_email(
     utc_datetime = datetime.utcnow()
     day = utc_datetime.strftime("%a")
     date = utc_datetime.strftime("%d %b %Y %X")
-    date_header = "{day}, {date} +0000\r\n".format(day=day, date=date)
+    date_header = f"{day}, {date} +0000\r\n"
     msg.headers["Date"] = date_header
 
     rfcmsg = _rfc_transform(msg)
@@ -195,7 +195,7 @@ def _get_full_spec_without_validation(name, email):
     """
     if name:
         encoded_name = smart_quote(encode_string(name, maxlinelen=MAX_ADDRESS_LENGTH))
-        return "{0} <{1}>".format(encoded_name, email)
+        return f"{encoded_name} <{email}>"
     return str(email)
 
 
@@ -219,11 +219,11 @@ def add_nylas_headers(msg, nylas_uid):
     msg.headers["X-INBOX-ID"] = nylas_uid
     msg.headers["Message-Id"] = generate_message_id_header(nylas_uid)
     # Potentially also use `X-Mailer`
-    msg.headers["User-Agent"] = "NylasMailer/{0}".format(VERSION)
+    msg.headers["User-Agent"] = f"NylasMailer/{VERSION}"
 
 
 def generate_message_id_header(uid):
-    return "<{}@mailer.nylas.com>".format(uid)
+    return f"<{uid}@mailer.nylas.com>"
 
 
 def _rfc_transform(msg):

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -96,7 +96,7 @@ class StringWithTransform(TypeDecorator):
     impl = String
 
     def __init__(self, string_transform, *args, **kwargs):
-        super(StringWithTransform, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if string_transform is None:
             raise ValueError("Must provide a string_transform")
         if not callable(string_transform):

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -212,7 +212,7 @@ class SyncbackService(gevent.Greenlet):
         account_id = namespace.account.id
         semaphore = self.account_semaphores[account_id]
 
-        actions = set([entry.action for entry in log_entries])
+        actions = {entry.action for entry in log_entries}
         assert len(actions) == 1
         action = actions.pop()
 
@@ -370,7 +370,7 @@ class SyncbackService(gevent.Greenlet):
             if namespace.account.sync_state in ("invalid", "stopped"):
                 sync_state = namespace.account.sync_state
                 self.log.warning(
-                    "Skipping action for {} account".format(sync_state),
+                    f"Skipping action for {sync_state} account",
                     account_id=account_id,
                     action_log_id=log_entry.id,
                     action=log_entry.action,
@@ -389,10 +389,8 @@ class SyncbackService(gevent.Greenlet):
                         action_log_id=log_entry.id,
                         action=log_entry.action,
                     )
-                    statsd_client.incr("syncback.{}_failed.total".format(sync_state))
-                    statsd_client.incr(
-                        "syncback.{}_failed.{}".format(sync_state, account_id)
-                    )
+                    statsd_client.incr(f"syncback.{sync_state}_failed.total")
+                    statsd_client.incr(f"syncback.{sync_state}_failed.{account_id}")
                 continue
 
             # If there is a recently failed action, don't execute any actions
@@ -644,8 +642,8 @@ class SyncbackTask:
 
     def _log_to_statsd(self, action_log_status, latency=None):
         metric_names = [
-            "syncback.overall.{}".format(action_log_status),
-            "syncback.providers.{}.{}".format(self.provider, action_log_status),
+            f"syncback.overall.{action_log_status}",
+            f"syncback.providers.{self.provider}.{action_log_status}",
         ]
 
         for metric in metric_names:

--- a/inbox/util/blockstore.py
+++ b/inbox/util/blockstore.py
@@ -145,7 +145,7 @@ def _get_from_s3_bucket(data_sha256, bucket_name):
     key = bucket.get_key(data_sha256)
 
     if not key:
-        log.warning("No key with name: {} returned!".format(data_sha256))
+        log.warning(f"No key with name: {data_sha256} returned!")
         return
 
     return key.get_contents_as_string()
@@ -158,8 +158,8 @@ def _get_from_disk(data_sha256):
     try:
         with open(_data_file_path(data_sha256), "rb") as f:
             return f.read()
-    except IOError:
-        log.warning("No file with name: {}!".format(data_sha256))
+    except OSError:
+        log.warning(f"No file with name: {data_sha256}!")
         return
 
 
@@ -189,7 +189,7 @@ def _delete_from_disk(data_sha256):
     try:
         os.remove(_data_file_path(data_sha256))
     except OSError:
-        log.warning("No file with name: {}!".format(data_sha256))
+        log.warning(f"No file with name: {data_sha256}!")
 
 
 def delete_from_blockstore(*data_sha256_hashes):

--- a/inbox/util/db.py
+++ b/inbox/util/db.py
@@ -43,7 +43,7 @@ def drop_everything(engine, keep_tables=None, reset_columns=None):
                     if c["name"] in column_names:
                         assert c["default"]
 
-                        q = "UPDATE {0} SET {1}={2};".format(
+                        q = "UPDATE {} SET {}={};".format(
                             table_name, c["name"], c["default"]
                         )
                         conn.execute(q)

--- a/inbox/util/file.py
+++ b/inbox/util/file.py
@@ -10,7 +10,7 @@ from gevent.lock import BoundedSemaphore
 
 def safe_filename(filename):
     """ Strip filesystem-unfriendly characters from a filename. """
-    valid_chars = "-_.() {}{}".format(string.ascii_letters, string.digits)
+    valid_chars = f"-_.() {string.ascii_letters}{string.digits}"
     return "".join(c for c in filename if c in valid_chars)
 
 
@@ -105,7 +105,7 @@ class Lock:
     def acquire(self):
         got_gevent_lock = self.gevent_lock.acquire(blocking=self.block)
         if not got_gevent_lock:
-            raise IOError(
+            raise OSError(
                 "cannot acquire gevent lock; associated file is {}".format(
                     self.filename
                 )

--- a/inbox/util/html.py
+++ b/inbox/util/html.py
@@ -109,8 +109,8 @@ def plaintext2html(text, tabstop=4):
             last = m.groups()[-1]
             if last in ["\n", "\r", "\r\n"]:
                 last = "<br>"
-            return '{0}<a href="{1}">{2}</a>{3}'.format(prefix, url, url, last)
+            return f'{prefix}<a href="{url}">{url}</a>{last}'
 
     return "\n".join(
-        ["<p>{0}</p>".format(re.sub(re_string, do_sub, p)) for p in text.split("\n\n")]
+        [f"<p>{re.sub(re_string, do_sub, p)}</p>" for p in text.split("\n\n")]
     )

--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -116,7 +116,7 @@ def timed(fn):
             fn_logger = get_logger()
             # out = None
         fn_logger.info(
-            "[timer] {0} took {1:.3f} seconds.".format(
+            "[timer] {} took {:.3f} seconds.".format(
                 str(fn), float(time.time() - start_time)
             )
         )
@@ -139,7 +139,7 @@ def load_modules(base_name, base_path):
     modules = []
 
     for module_name in iter_module_names(base_path):
-        full_module_name = "{}.{}".format(base_name, module_name)
+        full_module_name = f"{base_name}.{module_name}"
 
         if full_module_name not in sys.modules:
             module = import_module(full_module_name)
@@ -202,9 +202,9 @@ def imap_folder_path(path, separator=".", prefix=""):
             # Check that the value we got for the prefix doesn't include
             # the separator too (i.e: `INBOX.` instead of `INBOX`).
             if prefix[-1] != separator:
-                res = "{}{}{}".format(prefix, separator, res)
+                res = f"{prefix}{separator}{res}"
             else:
-                res = "{}{}".format(prefix, res)
+                res = f"{prefix}{res}"
 
     return res
 

--- a/inbox/util/rdb.py
+++ b/inbox/util/rdb.py
@@ -97,7 +97,7 @@ class RemoteConsole(InteractiveConsole):
                 except EOFError:
                     self.terminate()
                     return
-                except IOError:
+                except OSError:
                     self.terminate()
                     return
                 else:
@@ -111,7 +111,7 @@ class RemoteConsole(InteractiveConsole):
         try:
             self.handle.close()
             self.socket.close()
-        except IOError:
+        except OSError:
             return
 
     def raw_input(self, prompt=""):

--- a/inbox/util/startup.py
+++ b/inbox/util/startup.py
@@ -62,13 +62,13 @@ def load_overrides(file_path, loaded_config=config):
         try:
             overrides = json.load(data_file)
         except ValueError:
-            sys.exit("Failed parsing configuration file at {}".format(file_path))
+            sys.exit(f"Failed parsing configuration file at {file_path}")
         if not overrides:
             log.debug("No config overrides found.")
             return
         assert isinstance(overrides, dict), "overrides must be dictionary"
         loaded_config.update(overrides)
-        log.debug("Imported config overrides {}".format(list(overrides)))
+        log.debug(f"Imported config overrides {list(overrides)}")
 
 
 def preflight():

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -122,7 +122,7 @@ def dump_dns_queries(monkeypatch):
         elif record_type == "ns":
             query_results["ns"][domain] = [str(rdata) for rdata in result]
         else:
-            raise RuntimeError("Unknown record type: {}".format(record_type))
+            raise RuntimeError(f"Unknown record type: {record_type}")
         return result
 
     monkeypatch.setattr("dns.resolver.Resolver.query", mock_query)
@@ -180,7 +180,7 @@ class MockIMAPClient:
             return [k for k, v in uid_dict.items() if b"\\Inbox," in v[b"X-GM-LABELS"]]
         if criteria[0] == "HEADER":
             name, value = criteria[1:]
-            headerstring = "{}: {}".format(name, value).lower()
+            headerstring = f"{name}: {value}".lower()
             # Slow implementation, but whatever
             return [
                 u for u, v in uid_dict.items() if headerstring in v[b"BODY[]"].lower()
@@ -190,7 +190,7 @@ class MockIMAPClient:
             assert len(criteria) == 2
             thrid = criteria[1]
             return [u for u, v in uid_dict.items() if v[criteria[0]] == thrid]
-        raise ValueError("unsupported test criteria: {!r}".format(criteria))
+        raise ValueError(f"unsupported test criteria: {criteria!r}")
 
     def select_folder(self, folder_name, readonly=False):
         self.selected_folder = folder_name

--- a/inbox/util/threading.py
+++ b/inbox/util/threading.py
@@ -56,12 +56,12 @@ def fetch_corresponding_thread(db_session, namespace_id, message):
             match_bcc = match.bcc_addr if match.bcc_addr else []
             message_bcc = message.bcc_addr if message.bcc_addr else []
 
-            match_emails = set(
-                [t[1].lower() for t in match.participants if t not in match_bcc]
-            )
-            message_emails = set(
-                [t[1].lower() for t in message.participants if t not in message_bcc]
-            )
+            match_emails = {
+                t[1].lower() for t in match.participants if t not in match_bcc
+            }
+            message_emails = {
+                t[1].lower() for t in message.participants if t not in message_bcc
+            }
 
             # A conversation takes place between two or more persons.
             # Are there more than two participants in common in this

--- a/inbox/util/url.py
+++ b/inbox/util/url.py
@@ -172,7 +172,7 @@ def url_concat(url, args, fragments=None):
 def resolve_hostname(addr):
     try:
         return socket.gethostbyname(addr)
-    except socket.error:
+    except OSError:
         return None
 
 

--- a/inbox/webhooks/gpush_notifications.py
+++ b/inbox/webhooks/gpush_notifications.py
@@ -75,7 +75,7 @@ def calendar_update(account_public_id):
     except ValueError:
         raise InputError("Invalid public ID")
     except NoResultFound:
-        raise NotFoundError("Couldn't find account `{0}`".format(account_public_id))
+        raise NotFoundError(f"Couldn't find account `{account_public_id}`")
 
 
 @app.route("/calendar_update/<calendar_public_id>", methods=["POST"])
@@ -84,7 +84,7 @@ def event_update(calendar_public_id):
     try:
         valid_public_id(calendar_public_id)
         allowed, tokens, sleep = limitlion.throttle(
-            "gcal:{}".format(calendar_public_id), rps=0.5
+            f"gcal:{calendar_public_id}", rps=0.5
         )
         if allowed:
             with global_session_scope() as db_session:
@@ -99,4 +99,4 @@ def event_update(calendar_public_id):
     except ValueError:
         raise InputError("Invalid public ID")
     except NoResultFound:
-        raise NotFoundError("Couldn't find calendar `{0}`".format(calendar_public_id))
+        raise NotFoundError(f"Couldn't find calendar `{calendar_public_id}`")


### PR DESCRIPTION
* Python 3 style `super()`
* use fstrings where it made sense
* Various exceptions (`IOError`,`socket.error`, ...) have been merged into `OSError` [as of Python 3.3](https://stackoverflow.com/questions/29347790/difference-between-ioerror-and-oserror#comment46881406_29347790)
* dont pass default `r` mode to `open()`
* `set` literal syntax and comprehensions

Note that this surfaces some raw SQL strings using variables without escaping I personally don't like. Not sure if we should do something with them but probably on another PR anyway.