### PR TITLE
Update urllib3 to 1.26.10

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -80,7 +80,7 @@ tldextract==3.1.2
 structlog==21.4.0
 traitlets==4.3.3
 typing_extensions==4.0.1
-urllib3==1.26.7
+urllib3==1.26.10
 vobject==0.9.6.1
 wcwidth==0.2.5
 WebOb==1.8.7


### PR DESCRIPTION
This updates urllib3 to the latest version.

Changes include:

```
1.26.10 Latest

Removed support for Python 3.5
Fixed an issue where a ProxyError recommending configuring the proxy as HTTP instead of HTTPS could appear even when an HTTPS proxy wasn't configured.

1.26.9

Changed urllib3[brotli] extra to favor installing Brotli libraries that are still receiving updates like brotli and brotlicffi instead of brotlipy. This change does not impact behavior of urllib3, only which dependencies are installed.
Fixed a socket leaking when HTTPSConnection.connect() raises an exception.
Fixed server_hostname being forwarded from PoolManager to HTTPConnectionPool
when requesting an HTTP URL. Should only be forwarded when requesting an HTTPS URL.

1.26.8

Added extra message tourllib3.exceptions.ProxyError when urllib3 detects that a proxy is configured to use HTTPS but the proxy itself appears to only use HTTP.
Added a mention of the size of the connection pool when discarding a connection due to the pool being full.
Added explicit support for Python 3.11.
Deprecated the Retry.MAX_BACKOFF class property in favor of Retry.DEFAULT_MAX_BACKOFF to better match the rest of the default parameter names. Retry.MAX_BACKOFF is removed in v2.0.
Changed location of the vendored ssl.match_hostname function from urllib3.packages.ssl_match_hostname to urllib3.util.ssl_match_hostname to ensure Python 3.10+ compatibility after being repackaged by downstream distributors.
Fixed absolute imports, all imports are now relative.
```

Reviewers: @squeaky-pl @jpmelos 
