### PR TITLE
Only build with system-provided python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,6 @@ jobs:
 
   build:
     parameters:
-      python_version:
-        type: enum
-        description: Python version
-        enum: ["3.7", "3.8", "3.9"]
       platform_suffix:
         type: enum
         default: ""
@@ -72,7 +68,7 @@ jobs:
 
       - run:
           name: build sync-engine image
-          command: docker-compose build --build-arg BUILD_WEEK=$(date +"%Y-%V") --build-arg PYTHON_VERSION=<< parameters.python_version >> app
+          command: docker-compose build --build-arg BUILD_WEEK=$(date +"%Y-%V") app
 
       - when:
           condition: << parameters.run_tests >>
@@ -103,10 +99,10 @@ jobs:
                   PROJECT_SHA="$CIRCLE_SHA1"
                   docker login -u $DOCKER_USER -p $DOCKER_PASS
                   # tag and push both sync-engine:master and sync-engine:<sha1>
-                  docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-py<< parameters.python_version >><< parameters.platform_suffix >>"
-                  docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-py<< parameters.python_version >><< parameters.platform_suffix >>"
-                  docker push "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}-py<< parameters.python_version >><< parameters.platform_suffix >>"
-                  docker push "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}-py<< parameters.python_version >><< parameters.platform_suffix >>"
+                  docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}<< parameters.platform_suffix >>"
+                  docker tag "${PROJECT}_app" "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}<< parameters.platform_suffix >>"
+                  docker push "${PROJECT_NAMESPACE}/${PROJECT}:branch-${PROJECT_VSN}<< parameters.platform_suffix >>"
+                  docker push "${PROJECT_NAMESPACE}/${PROJECT}:${PROJECT_SHA}<< parameters.platform_suffix >>"
 
       - when:
           condition: << parameters.run_tests >>
@@ -124,19 +120,9 @@ workflows:
     jobs:
       - static-code-analysis
       - build:
-          name: build_py3.7
-          python_version: "3.7"
-          push_image: false
+          name: build
       - build:
-          name: build_py3.8
-          python_version: "3.8"
-      - build:
-          name: build_py3.9
-          python_version: "3.9"
-          push_image: false
-      - build:
-          name: build_arm_py3.8
-          python_version: "3.8"
+          name: build_arm
           resource_class: "arm.medium"
           platform_suffix: "-arm64"
           run_tests: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:20.04
-ARG PYTHON_VERSION=3.8
 
 RUN groupadd -g 5000 sync-engine \
   && useradd -d /home/sync-engine -m -u 5000 -g 5000 sync-engine
@@ -17,7 +16,8 @@ RUN echo $BUILD_WEEK && apt-get update \
     gcc \
     g++ \
     git \
-    python-dev \
+    python3-dev \
+    python3-distutils \
     wget \
     gettext-base \
     language-pack-en \
@@ -34,17 +34,6 @@ RUN echo $BUILD_WEEK && apt-get update \
     telnet \
     vim \
     libffi-dev \
-    software-properties-common \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN if [ "${PYTHON_VERSION}" != "3.8" ] ; \
-  then \
-    add-apt-repository ppa:deadsnakes/ppa; \
-  fi \
-  && apt-get update \
-  && apt-get install -y \
-       python"${PYTHON_VERSION}"-dev \
-       python"${PYTHON_VERSION}"-distutils \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /etc/inboxapp && \
@@ -64,13 +53,13 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN curl -O https://bootstrap.pypa.io/pip/get-pip.py && \
-  python"${PYTHON_VERSION}" get-pip.py && \
-  python"${PYTHON_VERSION}" -m pip install pip==22.1.2 virtualenv==20.15.1 && \
-  python"${PYTHON_VERSION}" -m virtualenv /opt/venv && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install setuptools==57.5.0 && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip install -e . && \
-  /opt/venv/bin/python"${PYTHON_VERSION}" -m pip check
+  python3 get-pip.py && \
+  python3 -m pip install pip==22.1.2 virtualenv==20.15.1 && \
+  python3 -m virtualenv /opt/venv && \
+  /opt/venv/bin/python3 -m pip install setuptools==57.5.0 && \
+  /opt/venv/bin/python3 -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt && \
+  /opt/venv/bin/python3 -m pip install -e . && \
+  /opt/venv/bin/python3 -m pip check
 
 RUN ln -s /opt/app/bin/wait-for-it.sh /opt/venv/bin/
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ Note that passwords and OAuth tokens are stored unencrypted in the local MySQL d
 
 To run the test suite execute the following command: `docker-compose run app pytest`
 
-If you wish to run it on different Python version pass `PYTHON_VERSION` to build,
-i.e. `docker-compose build --build-arg PYTHON_VERSION=3.9 app`. The list of supported Python
-versions can be found here: https://github.com/closeio/sync-engine/blob/master/.circleci/config.yml#L37
 ## License
 
 This code is free software, licensed under the The GNU Affero General Public License (AGPL). See the `LICENSE` file for more details.

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -3,7 +3,6 @@ astor==0.8.1
 attrs==20.2.0
 black==19.10b0
 click==7.1.2
-importlib-metadata; python_version < '3.8'
 isort==5.4.2
 flake8==3.9.2
 flake8-bugbear==21.4.3


### PR DESCRIPTION
This will reduce maintenance effort required for keeping dependencies up to date and alert-free.

Note that new images are build without `-py3.x` suffix.