### PR TITLE
Stop using six package

### DIFF
--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import urllib
 
 import pytz
 import requests
@@ -7,7 +8,6 @@ from authalligator_client.client import Client as AuthAlligatorApiClient
 from authalligator_client.enums import AccountErrorCode, ProviderType
 from authalligator_client.exceptions import AccountError
 from imapclient import IMAPClient
-from six.moves import urllib
 
 from inbox.basicauth import ConnectionError, ImapSupportDisabledError, OAuthError
 from inbox.config import config

--- a/inbox/client/client.py
+++ b/inbox/client/client.py
@@ -2,9 +2,9 @@ import contextlib
 import json
 import sys
 from os import environ
+from urllib.parse import urlencode
 
 import requests
-from six.moves.urllib.parse import urlencode
 
 from .errors import (
     APIClientError,

--- a/inbox/client/restful_models.py
+++ b/inbox/client/restful_models.py
@@ -1,4 +1,4 @@
-from six import StringIO
+from io import StringIO
 
 from .errors import FileUploadError
 from .restful_model_collection import RestfulModelCollection

--- a/inbox/client/util.py
+++ b/inbox/client/util.py
@@ -1,7 +1,6 @@
 from struct import unpack
+from urllib.parse import urlencode
 from uuid import uuid4
-
-from six.moves.urllib.parse import urlencode
 
 
 # From tornado.httputil


### PR DESCRIPTION
This is an artefact of Python 2 to 3 porting project. We are on Python 3 only now so we no longer need it.