### PR TITLE
Upgrade Mako to 1.2.2

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -45,7 +45,7 @@ jmespath==0.9.3
 limitlion==0.10.0
 lxml==4.9.1
 --no-binary lxml
-Mako==1.0.7
+Mako==1.2.2
 MarkupSafe==1.1.1
 matplotlib-inline==0.1.3 
 mysqlclient==1.3.14


### PR DESCRIPTION
This is to clear a security alert:

![191034016-79025d1e-73ac-4331-8b7b-0ac827f93714](https://user-images.githubusercontent.com/754356/191200052-44d42895-8732-451e-a1c8-bf4272ee7c79.png)


Mako's changes:

https://github.com/sqlalchemy/mako/releases

I don't see anything concerning. The most impactful changes are related to Python 2 to 3 still, and dropping Python 3.6 support.

Tests pass locally.