### PR TITLE
Update `authalligator-client`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
             -p inbox.s3 \
             -p inbox.actions \
             -p inbox.api \
+            -p inbox.auth \
             -p inbox.contacts \
             -p inbox.events \
             -p inbox.mailsync \

--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from flask import Flask, g, jsonify, make_response, request
 from flask_restful import reqparse
 from sqlalchemy.orm.exc import NoResultFound
@@ -240,6 +242,7 @@ def create_account():
     """ Create a new account """
     data = request.get_json(force=True)
 
+    auth_handler: Union[GenericAuthHandler, GoogleAuthHandler, MicrosoftAuthHandler]
     if data["type"] == "generic":
         auth_handler = GenericAuthHandler()
         account_data = _get_account_data_for_generic_account(data)
@@ -279,6 +282,7 @@ def modify_account(namespace_public_id):
         )
         account = namespace.account
 
+        auth_handler: Union[GenericAuthHandler, GoogleAuthHandler, MicrosoftAuthHandler]
         if isinstance(account, GenericAccount):
             auth_handler = GenericAuthHandler()
             account_data = _get_account_data_for_generic_account(data)

--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -18,7 +18,7 @@ from inbox.auth.microsoft import MicrosoftAccountData, MicrosoftAuthHandler
 from inbox.logging import get_logger
 from inbox.models import Account, Namespace
 from inbox.models.backends.generic import GenericAccount
-from inbox.models.backends.gmail import GOOGLE_EMAIL_SCOPE, GmailAccount
+from inbox.models.backends.gmail import GOOGLE_EMAIL_SCOPES, GmailAccount
 from inbox.models.backends.outlook import OutlookAccount
 from inbox.models.secret import SecretType
 from inbox.models.session import global_session_scope
@@ -175,7 +175,7 @@ def _get_account_data_for_generic_account(data):
 
 def _get_account_data_for_google_account(data):
     email_address = data["email_address"]
-    scopes = data.get("scopes", GOOGLE_EMAIL_SCOPE)
+    scopes = data.get("scopes", " ".join(GOOGLE_EMAIL_SCOPES))
     client_id = data.get("client_id")
 
     sync_email = data.get("sync_email", True)

--- a/inbox/auth/google.py
+++ b/inbox/auth/google.py
@@ -39,7 +39,7 @@ class GoogleAuthHandler(OAuthAuthHandler):
     OAUTH_ACCESS_TOKEN_URL = "https://accounts.google.com/o/oauth2/token"
     OAUTH_USER_INFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo"
 
-    OAUTH_SCOPE = " ".join(
+    OAUTH_AUTH_SCOPES = " ".join(
         [
             "email",  # email address
             "https://mail.google.com/",  # email
@@ -78,7 +78,7 @@ class GoogleAuthHandler(OAuthAuthHandler):
             "redirect_uri": self.OAUTH_REDIRECT_URI,
             "client_id": self.OAUTH_CLIENT_ID,
             "response_type": "code",
-            "scope": self.OAUTH_SCOPE,
+            "scope": self.OAUTH_AUTH_SCOPES,
             "access_type": "offline",
             "approval_prompt": "force",
         }

--- a/inbox/auth/google.py
+++ b/inbox/auth/google.py
@@ -39,7 +39,7 @@ class GoogleAuthHandler(OAuthAuthHandler):
     OAUTH_ACCESS_TOKEN_URL = "https://accounts.google.com/o/oauth2/token"
     OAUTH_USER_INFO_URL = "https://www.googleapis.com/oauth2/v1/userinfo"
 
-    OAUTH_AUTH_SCOPES = " ".join(
+    OAUTH_AUTH_SCOPE = " ".join(
         [
             "email",  # email address
             "https://mail.google.com/",  # email
@@ -78,7 +78,7 @@ class GoogleAuthHandler(OAuthAuthHandler):
             "redirect_uri": self.OAUTH_REDIRECT_URI,
             "client_id": self.OAUTH_CLIENT_ID,
             "response_type": "code",
-            "scope": self.OAUTH_AUTH_SCOPES,
+            "scope": self.OAUTH_AUTH_SCOPE,
             "access_type": "offline",
             "approval_prompt": "force",
         }

--- a/inbox/auth/microsoft.py
+++ b/inbox/auth/microsoft.py
@@ -36,7 +36,7 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
     )
     OAUTH_USER_INFO_URL = "https://outlook.office.com/api/v2.0/me"
 
-    OAUTH_SCOPE = " ".join(
+    OAUTH_AUTH_SCOPES = " ".join(
         [
             "https://outlook.office.com/IMAP.AccessAsUser.All",
             "https://outlook.office.com/SMTP.Send",
@@ -76,7 +76,7 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
             "redirect_uri": self.OAUTH_REDIRECT_URI,
             "client_id": self.OAUTH_CLIENT_ID,
             "response_type": "code",
-            "scope": self.OAUTH_SCOPE,
+            "scope": self.OAUTH_AUTH_SCOPES,
             "prompt": "select_account",
         }
         if email_address:

--- a/inbox/auth/microsoft.py
+++ b/inbox/auth/microsoft.py
@@ -36,7 +36,7 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
     )
     OAUTH_USER_INFO_URL = "https://outlook.office.com/api/v2.0/me"
 
-    OAUTH_AUTH_SCOPES = " ".join(
+    OAUTH_AUTH_SCOPE = " ".join(
         [
             "https://outlook.office.com/IMAP.AccessAsUser.All",
             "https://outlook.office.com/SMTP.Send",
@@ -76,7 +76,7 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
             "redirect_uri": self.OAUTH_REDIRECT_URI,
             "client_id": self.OAUTH_CLIENT_ID,
             "response_type": "code",
-            "scope": self.OAUTH_AUTH_SCOPES,
+            "scope": self.OAUTH_AUTH_SCOPE,
             "prompt": "select_account",
         }
         if email_address:

--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -108,6 +108,11 @@ class OAuthAuthHandler(AuthHandler):
         account_key = aa_data["account_key"]
 
         try:
+            log.info(
+                "requesting new access token from AuthAlligator",
+                force_refresh=force_refresh,
+                scopes=scopes,
+            )
             # TODO - handle force_refresh once it's supported
             # by AuthAlligator and its client.
             aa_response = aa_client.query_account(

--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -1,6 +1,8 @@
 import datetime
 import json
-import urllib
+import urllib.error
+import urllib.parse
+import urllib.request
 from typing import List, Optional, Tuple
 
 import pytz
@@ -23,7 +25,13 @@ log = get_logger()
 
 class OAuthAuthHandler(AuthHandler):
     # Defined by subclasses
-    OAUTH_ACCESS_TOKEN_URL = None
+    OAUTH_CLIENT_ID: Optional[str] = None
+    OAUTH_CLIENT_SECRET: Optional[str] = None
+    OAUTH_REDIRECT_URI: Optional[str] = None
+
+    OAUTH_AUTHENTICATE_URL: Optional[str] = None
+    OAUTH_ACCESS_TOKEN_URL: Optional[str] = None
+    OAUTH_USER_INFO_URL: Optional[str] = None
 
     AUTHALLIGATOR_AUTH_KEY = config.get("AUTHALLIGATOR_AUTH_KEY")
     AUTHALLIGATOR_SERVICE_URL = config.get("AUTHALLIGATOR_SERVICE_URL")
@@ -37,6 +45,7 @@ class OAuthAuthHandler(AuthHandler):
 
         client_id, client_secret = account.get_client_info()
 
+        assert self.OAUTH_ACCESS_TOKEN_URL, "OAUTH_ACCESS_TOKEN_URL is not defined"
         access_token_url = self.OAUTH_ACCESS_TOKEN_URL
 
         data = urllib.parse.urlencode(
@@ -207,6 +216,7 @@ class OAuthAuthHandler(AuthHandler):
 
     def _get_user_info(self, session_dict):
         access_token = session_dict["access_token"]
+        assert self.OAUTH_USER_INFO_URL, "OAUTH_USER_INFO_URL is not defined"
         request = urllib.request.Request(
             self.OAUTH_USER_INFO_URL,
             headers={"Authorization": f"Bearer {access_token}"},
@@ -240,6 +250,7 @@ class OAuthAuthHandler(AuthHandler):
             "Accept": "text/plain",
         }
         data = urllib.parse.urlencode(args)
+        assert self.OAUTH_ACCESS_TOKEN_URL, "OAUTH_ACCESS_TOKEN_URL is not defined"
         resp = requests.post(self.OAUTH_ACCESS_TOKEN_URL, data=data, headers=headers)
 
         session_dict = resp.json()

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -16,9 +16,9 @@ log = get_logger()
 
 PROVIDER = "gmail"
 
-GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar"
-GOOGLE_EMAIL_SCOPE = "https://mail.google.com/"
-GOOGLE_CONTACTS_SCOPE = "https://www.google.com/m8/feeds"
+GOOGLE_CALENDAR_SCOPES = ["https://www.googleapis.com/auth/calendar"]
+GOOGLE_EMAIL_SCOPES = ["https://mail.google.com/"]
+GOOGLE_CONTACTS_SCOPES = ["https://www.google.com/m8/feeds"]
 
 
 class GmailAccount(OAuthAccount, ImapAccount):
@@ -36,6 +36,22 @@ class GmailAccount(OAuthAccount, ImapAccount):
     last_calendar_list_sync = Column(DateTime)
     gpush_calendar_list_last_ping = Column(DateTime)
     gpush_calendar_list_expiration = Column(DateTime)
+
+    @property
+    def email_scopes(self):
+        return GOOGLE_EMAIL_SCOPES
+
+    @property
+    def contacts_scopes(self):
+        return GOOGLE_CONTACTS_SCOPES
+
+    @property
+    def calendar_scopes(self):
+        return GOOGLE_CALENDAR_SCOPES
+
+    @property
+    def scopes(self):
+        return [*self.calendar_scopes, *self.contacts_scopes, *self.email_scopes]
 
     @property
     def provider(self):

--- a/inbox/models/backends/oauth.py
+++ b/inbox/models/backends/oauth.py
@@ -4,7 +4,7 @@ refresh tokens.
 """
 from datetime import datetime, timedelta
 from hashlib import sha256
-from typing import Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from sqlalchemy import Column, ForeignKey
 from sqlalchemy.ext.declarative import declared_attr
@@ -68,6 +68,22 @@ token_manager = TokenManager()
 
 
 class OAuthAccount:
+    @property
+    def email_scopes(self) -> Optional[List[str]]:
+        return None
+
+    @property
+    def contacts_scopes(self) -> Optional[List[str]]:
+        return None
+
+    @property
+    def calendar_scopes(self) -> Optional[List[str]]:
+        return None
+
+    @property
+    def scopes(self) -> Optional[List[str]]:
+        return None
+
     @declared_attr
     def refresh_token_id(cls):
         return Column(ForeignKey(Secret.id), nullable=False)

--- a/inbox/models/backends/oauth.py
+++ b/inbox/models/backends/oauth.py
@@ -39,9 +39,14 @@ def log_token_usage(reason, refresh_token=None, access_token=None, account=None)
 
 class TokenManager:
     def __init__(self):
-        self._tokens = {}
+        self._tokens: Dict[str, str] = {}
 
-    def get_token(self, account, force_refresh=False):
+    def get_token(
+        self,
+        account: "OAuthAccount",
+        force_refresh: bool = False,
+        scopes: Optional[List[str]] = None,
+    ) -> str:
         if account.id in self._tokens:
             token, expiration = self._tokens[account.id]
             if not force_refresh and expiration > datetime.utcnow():
@@ -50,7 +55,9 @@ class TokenManager:
                 )
                 return token
 
-        new_token, expires_in = account.new_token(force_refresh=force_refresh)
+        new_token, expires_in = account.new_token(
+            force_refresh=force_refresh, scopes=scopes
+        )
         log_token_usage(
             "access token obtained", access_token=new_token, account=account
         )
@@ -58,7 +65,7 @@ class TokenManager:
         self.cache_token(account, new_token, expires_in)
         return new_token
 
-    def cache_token(self, account, token, expires_in):
+    def cache_token(self, account: "OAuthAccount", token: str, expires_in: int) -> None:
         expires_in -= 10
         expiration = datetime.utcnow() + timedelta(seconds=expires_in)
         self._tokens[account.id] = token, expiration
@@ -150,7 +157,9 @@ class OAuthAccount:
         else:
             raise OAuthError("No valid tokens.")
 
-    def new_token(self, force_refresh=False):
+    def new_token(
+        self, force_refresh: bool = False, scopes: Optional[List[str]] = None
+    ) -> Tuple[str, int]:
         """
         Retrieves a new access token.
 
@@ -165,7 +174,7 @@ class OAuthAccount:
         """
         try:
             return self.auth_handler.acquire_access_token(
-                self, force_refresh=force_refresh
+                self, force_refresh=force_refresh, scopes=scopes
             )
         except Exception as e:
             log.error(

--- a/inbox/models/backends/outlook.py
+++ b/inbox/models/backends/outlook.py
@@ -6,6 +6,11 @@ from inbox.models.backends.oauth import OAuthAccount
 
 PROVIDER = "microsoft"
 
+MICROSOFT_EMAIL_SCOPES = [
+    "https://outlook.office.com/IMAP.AccessAsUser.All",
+    "https://outlook.office.com/SMTP.Send",
+]
+
 
 class OutlookAccount(ImapAccount, OAuthAccount):
     OAUTH_CLIENT_ID = config.get_required("MICROSOFT_OAUTH_CLIENT_ID")
@@ -27,6 +32,22 @@ class OutlookAccount(ImapAccount, OAuthAccount):
     o_id_token = Column(String(1024))  # `id_token`
     link = Column(String(256))
     locale = Column(String(8))
+
+    @property
+    def email_scopes(self):
+        return MICROSOFT_EMAIL_SCOPES
+
+    @property
+    def contacts_scopes(self):
+        return None
+
+    @property
+    def calendar_scopes(self):
+        return None
+
+    @property
+    def scopes(self):
+        return self.email_scopes
 
     @property
     def provider(self):

--- a/inbox/sendmail/smtp/postel.py
+++ b/inbox/sendmail/smtp/postel.py
@@ -199,7 +199,9 @@ class SMTPConnection:
     def _smtp_oauth2_try_refresh(self):
         with session_scope(self.account_id) as db_session:
             account = db_session.query(ImapAccount).get(self.account_id)
-            self.auth_token = token_manager.get_token(account, force_refresh=True)
+            self.auth_token = token_manager.get_token(
+                account, force_refresh=True, scopes=account.email_scopes
+            )
 
     def _try_xoauth2(self):
         auth_string = "user={}\1auth=Bearer {}\1\1".format(
@@ -292,7 +294,9 @@ class SMTPClient:
 
         if self.auth_type == "oauth2":
             try:
-                self.auth_token = token_manager.get_token(account)
+                self.auth_token = token_manager.get_token(
+                    account, force_refresh=False, scopes=account.email_scopes
+                )
             except OAuthError:
                 raise SendMailException(
                     "Could not authenticate with the SMTP server.", 403

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,7 +3,7 @@ aniso8601==2.0.0
 arrow==0.17.0
 asn1crypto==0.24.0
 attrs==21.2.0
-git+https://github.com/closeio/authalligator-client.git@fe93c9d2333d2949e44c48a2dd0a9a266734e026#egg=authalligator_client
+git+https://github.com/closeio/authalligator-client.git@f182905f0d6462363a1d597cb75cd1b4c3a907a7#egg=authalligator_client
 backcall==0.2.0
 jedi==0.18.1
 boto==2.49.0

--- a/tests/api/test_sending.py
+++ b/tests/api/test_sending.py
@@ -22,7 +22,7 @@ class MockTokenManager:
     def __init__(self, allow_auth=True):
         self.allow_auth = allow_auth
 
-    def get_token(self, account, force_refresh=True):
+    def get_token(self, account, force_refresh=True, scopes=None):
         if self.allow_auth:
             # return a fake token.
             return "foo"

--- a/tests/system/google_auth_helper.py
+++ b/tests/system/google_auth_helper.py
@@ -71,7 +71,7 @@ def google_auth(email, password):
         "redirect_uri": GmailAuthHandler.OAUTH_REDIRECT_URI,
         "client_id": GmailAuthHandler.OAUTH_CLIENT_ID,
         "response_type": "code",
-        "scope": GmailAuthHandler.OAUTH_AUTH_SCOPES,
+        "scope": GmailAuthHandler.OAUTH_AUTH_SCOPE,
         "access_type": "offline",
         "login_hint": email,
     }

--- a/tests/system/google_auth_helper.py
+++ b/tests/system/google_auth_helper.py
@@ -71,7 +71,7 @@ def google_auth(email, password):
         "redirect_uri": GmailAuthHandler.OAUTH_REDIRECT_URI,
         "client_id": GmailAuthHandler.OAUTH_CLIENT_ID,
         "response_type": "code",
-        "scope": GmailAuthHandler.OAUTH_SCOPE,
+        "scope": GmailAuthHandler.OAUTH_AUTH_SCOPES,
         "access_type": "offline",
         "login_hint": email,
     }

--- a/tests/system/outlook_auth_helper.py
+++ b/tests/system/outlook_auth_helper.py
@@ -119,7 +119,7 @@ def outlook_auth(email, password):
         "redirect_uri": OutlookAuthHandler.OAUTH_REDIRECT_URI,
         "client_id": OutlookAuthHandler.OAUTH_CLIENT_ID,
         "response_type": "code",
-        "scope": OutlookAuthHandler.OAUTH_SCOPE,
+        "scope": OutlookAuthHandler.OAUTH_AUTH_SCOPES,
         "access_type": "offline",
         "login_hint": email,
     }

--- a/tests/system/outlook_auth_helper.py
+++ b/tests/system/outlook_auth_helper.py
@@ -119,7 +119,7 @@ def outlook_auth(email, password):
         "redirect_uri": OutlookAuthHandler.OAUTH_REDIRECT_URI,
         "client_id": OutlookAuthHandler.OAUTH_CLIENT_ID,
         "response_type": "code",
-        "scope": OutlookAuthHandler.OAUTH_AUTH_SCOPES,
+        "scope": OutlookAuthHandler.OAUTH_AUTH_SCOPE,
         "access_type": "offline",
         "login_hint": email,
     }


### PR DESCRIPTION
Implements #338

- Update usage of `authalligator-client` (pending merge of https://github.com/closeio/authalligator-client/pull/12).
  - Removes usage of `verify` mutation since it wasn't really causing a forced refresh as the code was expecting. The mutation will be removed soon and a new `refresh` parameter will be added that truly allows forcing a token refresh.
- Add type annotations for the affected code path
- Define scope properties on `OAuthAccount` subclasses (eg: [Outlook accounts](https://github.com/closeio/sync-engine/blob/0ae9022ed7fd88d8dfc75a28e75c45a4a8027329/inbox/models/backends/outlook.py#L36-L38)).
  - Those are forwarded from an initial [`get_token`](https://github.com/closeio/sync-engine/blob/57426ee16cef81ebf0b2fe5ff946a04022551b25/inbox/auth/oauth.py#L176-L178) call until they reach [`_new_access_token_from_authalligator`](https://github.com/closeio/sync-engine/blob/57426ee16cef81ebf0b2fe5ff946a04022551b25/inbox/auth/oauth.py#L165-L171) (they are passed only when the tokens are requested to `authalligator`).
