### PR TITLE
Fix bytes in event RRULE for ics provider

### DIFF
--- a/inbox/events/ical.py
+++ b/inbox/events/ical.py
@@ -163,7 +163,7 @@ def events_from_ics(namespace, calendar, ics_str):
 
             recur = component.get("rrule")
             if recur:
-                recur = f"RRULE:{recur.to_ical()}"
+                recur = f"RRULE:{recur.to_ical().decode()}"
 
             participants = []
 

--- a/tests/events/test_ics_parsing.py
+++ b/tests/events/test_ics_parsing.py
@@ -200,6 +200,8 @@ def test_recurring_ical(db, default_account):
     assert isinstance(ev, RecurringEvent)
     assert isinstance(ev.recurring, list)
     assert ev.start_timezone == "America/Los_Angeles"
+    assert ev.recurrence == "'RRULE:FREQ=WEEKLY;WKST=SU'"
+    assert ev.rrule == "RRULE:FREQ=WEEKLY;WKST=SU"
 
 
 def test_event_no_end_time(db, default_account):


### PR DESCRIPTION
This is a problem I discovered when looking at the events in the database. This problem was introduced when I ported sync-engine from Python 2 to Python 3 and passed without being perceived. There's also a related Rollbar.

Events imported from ics provider (which means they were attachment files inside email messages) are wrongly serialized to the database with `b''` syntax i.e:

```sql
SELECT recurrence, rrule FROM event JOIN recurringevent r on r.id = event.id WHERE event.id = ******;
```

|recurrence|rrule|
|----------|-----|
|"RRULE:b'FREQ=DAILY;UNTIL=20220610T035959Z'"|RRULE:b'FREQ=DAILY;UNTIL=20220610T035959Z'|

recurrence field is supposed to contain Python serialized string, and rrule just the string itself.

This happens because `to_ical()` returns bytes that should be decoded before using it in fstring:

```python
In [16]: result["VEVENT"].get("rrule").to_ical()
Out[16]: b'FREQ=DAILY;UNTIL=20220610T035959Z'
```

This  also causes Rollbar at the time events are requested using API as those events cannot be serialized properly.
Also see failing tests here https://app.circleci.com/pipelines/github/closeio/sync-engine/1221/workflows/b303c258-f920-4d92-8c0c-a81f180dd669/jobs/6138

I reviewed other properties read from ics and they are correctly saved as strings without `b''`


* [ ] Deploy fix for future syncs
* [ ] Fix existing events that have this problem in the database