### PR TITLE
Filter out empty folder names

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -376,7 +376,14 @@ class CrispinClient:
         IMAPClient parses this response into a list of
         (flags, delimiter, name) tuples.
         """
-        return self.conn.list_folders()
+
+        # As discovered in the wild list_folders() can return None as name,
+        # we cannot handle those folders anyway so just filter them out.
+        return [
+            (flags, delimiter, name)
+            for flags, delimiter, name in self.conn.list_folders()
+            if name
+        ]
 
     def select_folder_if_necessary(self, folder_name, uidvalidity_callback):
         # type: (str, Callable[[int, str, Dict[bytes, Any]], Dict[bytes, Any]]) -> Dict[bytes, Any]

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -382,7 +382,7 @@ class CrispinClient:
         return [
             (flags, delimiter, name)
             for flags, delimiter, name in self.conn.list_folders()
-            if name
+            if name is not None
         ]
 
     def select_folder_if_necessary(self, folder_name, uidvalidity_callback):


### PR DESCRIPTION
As discovered on one Outlook account you can get `None` as IMAP folder name, we cannot handle those so just skip them from syncing. The Outlook account in question has valid INBOX folder apart from malformed folder.