### PR TITLE
Skip email messages without needed properties, recover from missing INTERNALDATE

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -845,7 +845,7 @@ class CrispinClient:
                     "Missing one of FLAGS or BODY[] for UID, skipping",
                     folder=self.selected_folder[0],
                     uid=uid,
-                    keys=list(imap_message.keys()),
+                    keys=list(imap_message),
                 )
                 continue
 

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -1,10 +1,22 @@
 """ IMAPClient wrapper for the Nylas Sync Engine."""
 import contextlib
+import datetime
 import imaplib
 import re
 import ssl
 import time
-from typing import Any, Callable, DefaultDict, Dict, List, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import imapclient
 import imapclient.exceptions
@@ -70,17 +82,18 @@ GmailFlags = namedtuple("GmailFlags", "flags labels modseq")
 #     labels: List[str]
 #     modseq: Optional[int]
 GMetadata = namedtuple("GMetadata", "g_msgid g_thrid size")
-RawMessage = namedtuple(
-    "RawMessage", "uid internaldate flags body g_thrid g_msgid g_labels"
-)
-# class RawMessage(NamedTuple):
-#     uid: int
-#     internaldate: datetime.datetime
-#     flags: Tuple[bytes, ...]
-#     body: bytes
-#     g_msgid: int
-#     g_thrid: int
-#     g_labels: List[str]
+
+
+class RawMessage(NamedTuple):
+    uid: int
+    internaldate: Optional[datetime.datetime]
+    flags: Tuple[bytes, ...]
+    body: bytes
+    g_msgid: Optional[int]
+    g_thrid: Optional[int]
+    g_labels: Optional[List[str]]
+
+
 RawFolder = namedtuple("RawFolder", "display_name role")
 # class RawFolder(NamedTuple):
 #     display_name: str

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -852,6 +852,9 @@ class CrispinClient:
             raw_messages.append(
                 RawMessage(
                     uid=int(uid),
+                    # we can recover from missing INTERNALDATE by parsing BODY[]
+                    # and relying on Date and Received headers. This is done in
+                    # inbox.models.message.Message._parse_metadata.
                     internaldate=imap_message.get(b"INTERNALDATE"),
                     flags=imap_message[b"FLAGS"],
                     body=imap_message[b"BODY[]"],

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -826,8 +826,14 @@ class CrispinClient:
             if uid not in uid_set:
                 continue
             imap_message = imap_messages[uid]
-            if list(imap_message) == [b"SEQ"]:
-                log.error("No data returned for UID, skipping", uid=uid)
+            if not set(imap_message).issuperset({b"INTERNALDATE", b"FLAGS", b"BODY[]"}):
+                assert self.selected_folder
+                log.warning(
+                    "Missing one of INTERNALDATE, FLAGS or BODY[] for UID, skipping",
+                    folder=self.selected_folder[0],
+                    uid=uid,
+                    keys=list(imap_message.keys()),
+                )
                 continue
 
             raw_messages.append(

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -839,10 +839,10 @@ class CrispinClient:
             if uid not in uid_set:
                 continue
             imap_message = imap_messages[uid]
-            if not set(imap_message).issuperset({b"INTERNALDATE", b"FLAGS", b"BODY[]"}):
+            if not set(imap_message).issuperset({b"FLAGS", b"BODY[]"}):
                 assert self.selected_folder
                 log.warning(
-                    "Missing one of INTERNALDATE, FLAGS or BODY[] for UID, skipping",
+                    "Missing one of FLAGS or BODY[] for UID, skipping",
                     folder=self.selected_folder[0],
                     uid=uid,
                     keys=list(imap_message.keys()),
@@ -852,7 +852,7 @@ class CrispinClient:
             raw_messages.append(
                 RawMessage(
                     uid=int(uid),
-                    internaldate=imap_message[b"INTERNALDATE"],
+                    internaldate=imap_message.get(b"INTERNALDATE"),
                     flags=imap_message[b"FLAGS"],
                     body=imap_message[b"BODY[]"],
                     # TODO: use data structure that isn't

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -418,6 +418,8 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
                 logstash_tag="truncated_message_id",
             )
 
+        # received_date is passed from INTERNALDATE on IMAP protocol level,
+        # fallback to Date and Received headers from BODY[] if not present.
         self.received_date = (
             received_date
             if received_date

--- a/inbox/util/misc.py
+++ b/inbox/util/misc.py
@@ -92,7 +92,7 @@ def get_internaldate(date, received):
     """ Get the date from the headers. """
     if date is None:
         assert received
-        other, date = received.split(";")
+        _, date = received.split(";")
 
     # All in UTC
     parsed_date = parsedate_tz(date)

--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -304,10 +304,10 @@ def test_internaldate(generic_client, constants):
         ]
 
 
-def test_missing_internaldate(generic_client, constants):
+def test_missing_flags(generic_client, constants):
     expected_resp = (
         "{seq} (UID {uid} MODSEQ ({modseq}) "
-        "FLAGS {flags} "
+        'INTERNALDATE "{internaldate}" '
         "BODY[] {{{body_size}}}".format(**constants).encode(),
         constants["body"],
     )

--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -304,6 +304,20 @@ def test_internaldate(generic_client, constants):
         ]
 
 
+def test_missing_internaldate(generic_client, constants):
+    expected_resp = (
+        "{seq} (UID {uid} MODSEQ ({modseq}) "
+        "FLAGS {flags} "
+        "BODY[] {{{body_size}}}".format(**constants).encode(),
+        constants["body"],
+    )
+    generic_client.selected_folder = ("Name", None)
+    patch_imap4(generic_client, [expected_resp, b")"])
+
+    uid = constants["uid"]
+    assert generic_client.uids([uid]) == []
+
+
 def test_deleted_folder_on_select(monkeypatch, generic_client, constants):
     """ Test that a 'select failed EXAMINE' error specifying that a folder
         doesn't exist is converted into a FolderMissingError. (Yahoo style)

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -1,0 +1,29 @@
+import datetime
+
+import pytest
+
+from inbox.util.misc import get_internaldate
+
+received_header_value = """
+    from a39-221.smtp-out.amazonses.com (a39-221.smtp-out.amazonses.com. [54.240.39.221])
+    by mx.google.com with ESMTPS id z21-20020ac875d5000000b00343288592dcsi12759qtq.455.2022.09.29.12.07.35
+    for <test@example.com>
+    (version=TLS1_2 cipher=ECDHE-ECDSA-AES128-GCM-SHA256 bits=128/128);
+    Thu, 29 Sep 2022 12:07:35 -0700 (PDT)
+"""
+received_date = datetime.datetime(2022, 9, 29, 19, 7, 35)
+
+date_header_value = "Thu, 29 Sep 2022 19:07:34 +0000"
+date_date = datetime.datetime(2022, 9, 29, 19, 7, 34)
+
+
+@pytest.mark.parametrize(
+    "date,received,expected",
+    [
+        (None, received_header_value, received_date),
+        (date_header_value, received_header_value, date_date),
+        (date_header_value, None, date_date),
+    ],
+)
+def test_get_internaldate(date, received, expected):
+    assert get_internaldate(date, received) == expected


### PR DESCRIPTION
We have a related rollbar.

This does two things:
* It checks we have absolutely minimal info on IMAP protocol level i.e. `FLAGS`, and `BODY[]` to actually recover a mail message. We cannot proceed without those. E.g. Microsoft likes to return deleted email message uids without `BODY[]`.
* It makes `INTERNALDATE` optional (it's always there on Gmail but not always there on Microsoft and generic IMAP). We already have logic in [inbox.models.message.Message._parse_metadata](https://github.com/closeio/sync-engine/blob/1f9a2e584d2f650c7bd8cc8e3f33103f47f68ed7/inbox/models/message.py#L421-L427) to recover it from parsed `BODY[]`.