### PR TITLE
Don't explode on missing inbox folder

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -517,7 +517,8 @@ class CrispinClient:
         List of folders to sync, in order of sync priority. Currently, that
         simply means inbox folder first.
 
-        In generic IMAP, the 'INBOX' folder is required.
+        In generic IMAP, the 'INBOX' folder should be there but there are
+        accounts without it in the wild.
 
         Returns
         -------
@@ -527,12 +528,12 @@ class CrispinClient:
         """
         have_folders = self.folder_names()  # type: DefaultDict[str, List[str]]
 
-        assert (
-            "inbox" in have_folders
-        ), f"Missing required 'inbox' folder for account_id: {self.account_id}"
-
         # Sync inbox folder first, then sent, then others.
-        to_sync = have_folders["inbox"]  # type: List[str]
+        to_sync: List[str] = []
+        if "inbox" in have_folders:
+            to_sync.extend(have_folders["inbox"])
+        else:
+            log.warning("Missing 'inbox' folder", account_id=self.account_id)
         to_sync.extend(have_folders.get("sent", []))
         for role, folder_names in have_folders.items():
             if role in ["inbox", "sent"]:


### PR DESCRIPTION
These one creates very noisy rollbars.

There are IMAP accounts in the wild that really don't have INBOX folder (where you normally receive your incoming mail). I've examined some of those accounts and it's still worth syncing them because they have other folders (e.g. Sent) we could sync.