### PR TITLE
Persist IPython history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - .:/opt/app
+      - ipython_data_local:/root/.ipython/profile_default
     user: root
     depends_on:
       - redis
@@ -43,3 +44,6 @@ services:
     working_dir: /src
     volumes:
       - .:/src
+
+volumes:
+  ipython_data_local: {}


### PR DESCRIPTION
While working on sync-engine I often drop to IPython shell, it would be tremendously useful to persist history.