### PR TITLE
Log IMAP uid when unknown Content-Disposition is discovered

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -460,7 +460,7 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
         if disposition not in (None, "inline", "attachment"):
             log.error(
                 "Unknown Content-Disposition",
-                message_public_id=self.public_id,
+                mid=mid,
                 bad_content_disposition=mimepart.content_disposition,
             )
             self._mark_error()


### PR DESCRIPTION
At this point the message is not yet saved in the database so its public_id
will always be `None`. One needs to fetch it using IMAP instead to find out
what's wrong and `mid` is the IMAP uid.