### PR TITLE
Warning on instantiating IMAP connection

### DIFF
--- a/inbox/auth/base.py
+++ b/inbox/auth/base.py
@@ -65,7 +65,7 @@ class AuthHandler:
         try:
             return create_imap_connection(host, port, use_timeout)
         except (IMAPClient.Error, OSError) as exc:
-            log.error(
+            log.warning(
                 "Error instantiating IMAP connection",
                 account_id=account.id,
                 host=host,


### PR DESCRIPTION
After investigating I confirmed that this happens only on generic IMAP (not Google or Microsoft) where customers maintain their own IMAP servers. The most common failure here is DNS expiring, but there are also timeouts. Given this is not our fault we should not Rollbar.