### PR TITLE
Use .one() instead of .get()

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -376,8 +376,8 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 "saving new uids for existing messages",
                 count=len(previously_synced_messages),
             )
-            account = Account.get(self.account_id, db_session)
-            folder = Folder.get(self.folder_id, db_session)
+            account = db_session.query(Account).filter_by(id=self.account_id).one()
+            folder = db_session.query(Folder).filter_by(id=self.folder_id).one()
             for raw_message in previously_synced_messages:
                 message_obj = (
                     db_session.query(Message)
@@ -441,8 +441,8 @@ class GmailFolderSyncEngine(FolderSyncEngine):
             return
         new_uids = set()
         with self.syncmanager_lock, session_scope(self.namespace_id) as db_session:
-            account = Account.get(self.account_id, db_session)
-            folder = Folder.get(self.folder_id, db_session)
+            account = db_session.query(Account).filter_by(id=self.account_id).one()
+            folder = db_session.query(Folder).filter_by(id=self.folder_id).one()
             raw_messages = self.__deduplicate_message_object_creation(
                 db_session, raw_messages, account
             )

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -634,8 +634,8 @@ class FolderSyncEngine(Greenlet):
 
         new_uids = set()
         with self.syncmanager_lock, session_scope(self.namespace_id) as db_session:
-            account = Account.get(self.account_id, db_session)
-            folder = Folder.get(self.folder_id, db_session)
+            account = db_session.query(Account).filter_by(id=self.account_id).one()
+            folder = db_session.query(Folder).filter_by(id=self.folder_id).one()
             for msg in raw_messages:
                 uid = self.create_message(db_session, account, folder, msg)
                 if uid is not None:

--- a/inbox/models/account.py
+++ b/inbox/models/account.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     String,
-    bindparam,
     event,
     inspect,
 )
@@ -311,12 +310,6 @@ class Account(
             self._sync_status["sync_end_time"] = datetime.utcnow()
             return True
         return False
-
-    @classmethod
-    def get(cls, id_, session):
-        q = session.query(cls)
-        q = q.filter(cls.id == bindparam("id_"))
-        return q.params(id_=id_).first()
 
     @property
     def is_killed(self):

--- a/inbox/models/folder.py
+++ b/inbox/models/folder.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, ForeignKey, String, bindparam
+from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.orm import backref, relationship, synonym, validates
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from sqlalchemy.schema import UniqueConstraint
@@ -107,11 +107,5 @@ class Folder(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
             raise
 
         return obj
-
-    @classmethod
-    def get(cls, id_, session):
-        q = session.query(cls)
-        q = q.filter(cls.id == bindparam("id_"))
-        return q.params(id_=id_).first()
 
     __table_args__ = (UniqueConstraint("account_id", "name", "canonical_name"),)


### PR DESCRIPTION
The use of .get() here hides errors as this makes it possible for account and folder to be None
and they are strictly necessary for further logic to work.