### PR TITLE
Downgrade some parsing errors to warnings

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -83,6 +83,11 @@ def _trim_filename(s, namespace_id, max_len=255):
     return s
 
 
+class MessageTooBigException(Exception):
+    def __init__(self, body_length):
+        super().__init__(f"message length ({body_length}) is over the parsing limit")
+
+
 class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMixin):
     @property
     def API_OBJECT_NAME(self):
@@ -303,15 +308,24 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
         try:
             body_length = len(body_string)
             if body_length > MAX_MESSAGE_BODY_PARSE_LENGTH:
-                raise Exception(
-                    f"message length ({body_length}) is over the parsing limit"
-                )
+                raise MessageTooBigException(body_length)
             parsed = mime.from_string(body_string)  # type: MimePart
             # Non-persisted instance attribute used by EAS.
             msg.parsed_body = parsed
             msg._parse_metadata(
                 parsed, body_string, received_date, account.id, folder_name, mid
             )
+        except (mime.DecodingError, MessageTooBigException) as e:
+            parsed = None
+            msg.parsed_body = ""
+            log.warning(
+                "Error parsing message metadata",
+                folder_name=folder_name,
+                account_id=account.id,
+                error=e,
+                mid=mid,
+            )
+            msg._mark_error()
         except Exception as e:
             parsed = None
             # Non-persisted instance attribute used by EAS.

--- a/tests/general/test_message_parsing.py
+++ b/tests/general/test_message_parsing.py
@@ -1,7 +1,6 @@
 # flake8: noqa: F401, F811
 """Sanity-check our construction of a Message object from raw synced data."""
 import datetime
-import sys
 from unittest.mock import patch
 
 import pytest
@@ -580,4 +579,4 @@ def test_long_message_body(db, default_account, raw_message_too_long):
     with patch("inbox.models.message.log") as mock:
         m = create_from_synced(db, default_account, raw_message_too_long)
         assert m.decode_error
-        assert "over the parsing limit" in mock.error.call_args[1]["error"].args[0]
+        assert "over the parsing limit" in mock.warning.call_args[1]["error"].args[0]


### PR DESCRIPTION
We cannot really recover from those two (completely screwed Mime encoding and too big message) so downgrade those to warnings.