### PR TITLE
Microsoft: Extract is_default_calendar

### DIFF
--- a/inbox/api/kellogs.py
+++ b/inbox/api/kellogs.py
@@ -20,6 +20,7 @@ from inbox.models import (
     Thread,
     When,
 )
+from inbox.models.calendar import is_default_calendar
 from inbox.models.event import InflatedEvent, RecurringEvent, RecurringEventOverride
 
 log = get_logger()
@@ -356,7 +357,7 @@ def _encode(obj, namespace_public_id=None, expand=False, is_n1=False):
             "description": obj.description,
             "read_only": obj.read_only,
             "uid": obj.uid,
-            "default": obj.default,
+            "default": is_default_calendar(obj),
         }
 
     elif isinstance(obj, When):

--- a/inbox/api/kellogs.py
+++ b/inbox/api/kellogs.py
@@ -356,6 +356,7 @@ def _encode(obj, namespace_public_id=None, expand=False, is_n1=False):
             "description": obj.description,
             "read_only": obj.read_only,
             "uid": obj.uid,
+            "default": obj.default,
         }
 
     elif isinstance(obj, When):

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -262,7 +262,7 @@ class GoogleEventSync(EventSync):
 
         try:
             if URL_PREFIX:
-                self._refresh_gpush_subscriptions()
+                self._refresh_webhook_subscriptions()
             else:
                 self.log.warning(
                     "Cannot use Google push notifications (URL_PREFIX not "
@@ -288,7 +288,7 @@ class GoogleEventSync(EventSync):
                 "Access to provider calendar API not enabled; bypassing sync"
             )
 
-    def _refresh_gpush_subscriptions(self) -> None:
+    def _refresh_webhook_subscriptions(self) -> None:
         with session_scope(self.namespace_id) as db_session:
             account = db_session.query(Account).get(self.account_id)
 

--- a/migrations/versions/254_add_calendar_default.py
+++ b/migrations/versions/254_add_calendar_default.py
@@ -2,7 +2,7 @@
 
 Revision ID: 52783469ee6c
 Revises: 32df3d8ff73e
-Create Date: 2020-09-22 13:03:12.879960
+Create Date: 2022-10-01 13:03:12.879960
 
 """
 

--- a/migrations/versions/254_add_calendar_default.py
+++ b/migrations/versions/254_add_calendar_default.py
@@ -1,0 +1,31 @@
+"""add calendar default
+
+Revision ID: 52783469ee6c
+Revises: 32df3d8ff73e
+Create Date: 2020-09-22 13:03:12.879960
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "7bb5c0ca93de"
+down_revision = "52783469ee6c"
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+
+def upgrade():
+    op.add_column(
+        "calendar",
+        sa.Column(
+            "default",
+            mysql.TINYINT(display_width=1),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column("calendar", "default")

--- a/tests/api/test_calendars.py
+++ b/tests/api/test_calendars.py
@@ -26,7 +26,8 @@ def test_get_google_calendar(db, default_namespace, api_client, uid, default):
     assert calendar_item["default"] == default
 
 
-def test_get_outlook_calendar(db, outlook_namespace, api_client):
+def test_get_outlook_calendar(db, outlook_namespace, make_api_client):
+    api_client = make_api_client(db, outlook_namespace)
     cal = Calendar(
         namespace_id=outlook_namespace.id, uid="uid", name="Holidays", default=False,
     )

--- a/tests/api/test_calendars.py
+++ b/tests/api/test_calendars.py
@@ -1,3 +1,4 @@
+import pytest
 from sqlalchemy import true
 
 from inbox.models import Calendar
@@ -7,10 +8,14 @@ from tests.util.base import add_fake_event, db, default_namespace
 __all__ = ["db", "default_namespace"]
 
 
-def test_get_calendar(db, default_namespace, api_client):
+@pytest.mark.parametrize(
+    "uid,default",
+    [("inboxapptest@gmail.com", True), ("other", False),],  # same as email address
+)
+def test_get_calendar(db, default_namespace, api_client, uid, default):
     cal = Calendar(
         namespace_id=default_namespace.id,
-        uid="uid",
+        uid=uid,
         provider_name="WTF",
         name="Holidays",
     )
@@ -24,6 +29,7 @@ def test_get_calendar(db, default_namespace, api_client):
     assert calendar_item["description"] is None
     assert calendar_item["read_only"] is False
     assert calendar_item["object"] == "calendar"
+    assert calendar_item["default"] == default
 
 
 def test_handle_not_found_calendar(api_client):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,20 @@ from inbox.util.testutils import dump_dns_queries  # noqa; noqa
 
 
 @fixture
-def api_client(db, default_namespace):
-    from inbox.api.srv import app
+def make_api_client():
+    def _make_api_client(db, namespace):
+        from inbox.api.srv import app
 
-    app.config["TESTING"] = True
-    with app.test_client() as c:
-        yield TestAPIClient(c, default_namespace.public_id)
+        app.config["TESTING"] = True
+        with app.test_client() as c:
+            return TestAPIClient(c, namespace.public_id)
+
+    return _make_api_client
+
+
+@fixture
+def api_client(db, default_namespace, make_api_client):
+    return make_api_client(db, default_namespace)
 
 
 @fixture


### PR DESCRIPTION
We need to know in sync-engine if your Calendar is default/primary or not. This is because when syncing we always start by syncing your default calendar as it's most likely the one you care about.

In case of Google you can know if a calendar is default/primary by comparing it's uid with account email address. In case of Microsoft calendar uids are opaque and Ms Graph API has dedicated default field that carries this information.