### PR TITLE
Microsoft: Calendar.new_event_watch returns datetime.datetime

### DIFF
--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -297,18 +297,18 @@ class GoogleEventSync(EventSync):
                 return
 
             if account.needs_new_calendar_list_watch():
-                expir = self.provider.watch_calendar_list(account)
-                if expir is not None:
-                    account.new_calendar_list_watch(expir)
+                calendar_list_expiration = self.provider.watch_calendar_list(account)
+                if calendar_list_expiration is not None:
+                    account.new_calendar_list_watch(calendar_list_expiration)
 
             cals_to_update = (
                 cal for cal in account.namespace.calendars if cal.needs_new_watch()
             )
             for cal in cals_to_update:
                 try:
-                    expir = self.provider.watch_calendar(account, cal)
-                    if expir is not None:
-                        cal.new_event_watch(expir)
+                    event_list_expiration = self.provider.watch_calendar(account, cal)
+                    if event_list_expiration is not None:
+                        cal.new_event_watch(event_list_expiration)
                 except HTTPError as exc:
                     if exc.response.status_code == 404:
                         self.log.warning(

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import Column, DateTime, ForeignKey, String
 
@@ -73,23 +73,23 @@ class GmailAccount(OAuthAccount, ImapAccount):
 
         return ActionLog
 
-    def new_calendar_list_watch(self, expiration):
-        # Google gives us back expiration timestamps in milliseconds
-        expiration = datetime.fromtimestamp(int(expiration) / 1000.0)
+    def new_calendar_list_watch(self, expiration: datetime) -> None:
         self.gpush_calendar_list_expiration = expiration
         self.gpush_calendar_list_last_ping = datetime.utcnow()
 
     def handle_gpush_notification(self):
         self.gpush_calendar_list_last_ping = datetime.utcnow()
 
-    def should_update_calendars(self, max_time_between_syncs, poll_frequency):
+    def should_update_calendars(
+        self, max_time_between_syncs: timedelta, poll_frequency: timedelta
+    ) -> bool:
         """
-        max_time_between_syncs: a timedelta object. The maximum amount of
-        time we should wait until we sync, even if we haven't received
-        any push notifications
+        Arguments:
+            max_time_between_syncs: The maximum amount of time we should wait
+                until we sync, even if we haven't received any push notifications.
 
-        poll_frequency: a timedelta object. Amount of time we should wait until
-        we sync if we don't have working push notifications.
+            poll_frequency: Amount of time we should wait until
+                we sync if we don't have working push notifications.
         """
         now = datetime.utcnow()
         return (
@@ -112,7 +112,7 @@ class GmailAccount(OAuthAccount, ImapAccount):
             )
         )
 
-    def needs_new_calendar_list_watch(self):
+    def needs_new_calendar_list_watch(self) -> bool:
         return (
             self.gpush_calendar_list_expiration is None
             or self.gpush_calendar_list_expiration < datetime.utcnow()

--- a/inbox/models/calendar.py
+++ b/inbox/models/calendar.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import (
     Boolean,
@@ -67,11 +67,7 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin, DeletedA
         self.read_only = calendar.read_only
         self.description = calendar.description
 
-    def new_event_watch(self, expiration):
-        """
-        Google gives us expiration as a timestamp in milliseconds
-        """
-        expiration = datetime.fromtimestamp(int(expiration) / 1000.0)
+    def new_event_watch(self, expiration: datetime) -> None:
         self.gpush_expiration = expiration
         self.gpush_last_ping = datetime.utcnow()
 
@@ -100,7 +96,7 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin, DeletedA
 
         return True
 
-    def needs_new_watch(self):
+    def needs_new_watch(self) -> bool:
         if not self.can_sync():
             return False
 
@@ -108,7 +104,9 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin, DeletedA
             self.gpush_expiration is None or self.gpush_expiration < datetime.utcnow()
         )
 
-    def should_update_events(self, max_time_between_syncs, poll_frequency):
+    def should_update_events(
+        self, max_time_between_syncs: timedelta, poll_frequency: timedelta
+    ) -> bool:
         """
         max_time_between_syncs: a timedelta object. The maximum amount of
         time we should wait until we sync, even if we haven't received

--- a/tests/webhooks/test_gpush_calendar_notifications.py
+++ b/tests/webhooks/test_gpush_calendar_notifications.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import limitlion
 import pytest
+import pytz
 from gevent import sleep
 
 from inbox.models.calendar import Calendar
@@ -33,7 +34,7 @@ UPDATE_HEADERS = {
     "X-Goog-Resource-URI": "resource/location",
 }
 
-WATCH_EXPIRATION = 1426325213000  # 3/14/15 - utc TS in milliseconds
+WATCH_EXPIRATION = datetime(2015, 3, 14)
 
 
 @pytest.fixture
@@ -66,7 +67,7 @@ def test_should_update_logic_push(db, watched_account, watched_calendar):
     the watch is expired.
     """
     # Watch should be not-expired
-    expiration = WATCH_EXPIRATION + 20 * 365 * 24 * 60 * 60 * 1000
+    expiration = WATCH_EXPIRATION + timedelta(days=20 * 365)
     watched_account.new_calendar_list_watch(expiration)
     watched_calendar.new_event_watch(expiration)
 
@@ -150,7 +151,7 @@ def test_needs_new_watch_logic(db, watched_account, watched_calendar):
     assert watched_account.needs_new_calendar_list_watch()
     assert watched_calendar.needs_new_watch()
 
-    expiration = WATCH_EXPIRATION + 20 * 365 * 24 * 60 * 60 * 1000
+    expiration = WATCH_EXPIRATION + timedelta(days=20 * 365)
     watched_account.new_calendar_list_watch(expiration)
     watched_calendar.new_event_watch(expiration)
 


### PR DESCRIPTION
This changes `watch_calendar()` and `watch_calendar_list()` so they return `Optional[datetime.datetime]` instead of Google specific `Optional[int]` (where it meant UNIX timestamp in milliseconds). This will help sharing logic between Microsoft and Google.