### PR TITLE
Fix is_default_calendar for special 'inbox' calendars

### DIFF
--- a/inbox/models/calendar.py
+++ b/inbox/models/calendar.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Optional
 
 from sqlalchemy import (
     Boolean,
@@ -139,19 +140,26 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin, DeletedA
         )
 
 
-def is_default_calendar(calendar: Calendar) -> bool:
+def is_default_calendar(calendar: Calendar) -> Optional[bool]:
     """
     Determine if this is a default/primary user calendar.
+
+    For calendars that are special "inbox" calendars which
+    store events created from ICS attachments found in mail
+    this is always None.
 
     For Google calendars the default calendar's uid is the same as account
     email address. In case of Microsoft uids are opaque and one needs
     to store it in the database on the default field.
 
     Arguments:
-        calendar: The google or microsoft calendar
+        calendar: The google, microsoft or "inbox" calendar
     """
     from inbox.models.backends.gmail import GmailAccount
     from inbox.models.backends.outlook import OutlookAccount
+
+    if calendar.uid == "inbox":
+        return None
 
     if isinstance(calendar.namespace.account, GmailAccount):
         return calendar.uid == calendar.namespace.account.email_address

--- a/tests/api/test_calendars.py
+++ b/tests/api/test_calendars.py
@@ -44,6 +44,20 @@ def test_get_outlook_calendar(db, outlook_namespace, make_api_client):
     assert calendar_item["default"] is False
 
 
+def test_inbox_calendar(db, outlook_namespace, make_api_client):
+    api_client = make_api_client(db, outlook_namespace)
+    cal = db.session.query(Calendar).filter_by(uid="inbox").one()
+    cal_id = cal.public_id
+    calendar_item = api_client.get_data(f"/calendars/{cal_id}")
+
+    assert calendar_item["account_id"] == outlook_namespace.public_id
+    assert calendar_item["name"] == "Emailed events"
+    assert calendar_item["description"] == "Emailed events"
+    assert calendar_item["read_only"] is True
+    assert calendar_item["object"] == "calendar"
+    assert calendar_item["default"] is None
+
+
 def test_handle_not_found_calendar(api_client):
     resp_data = api_client.get_raw("/calendars/foo")
     assert resp_data.status_code == 404


### PR DESCRIPTION
While introducing `default` on Calendars to tell apart default and non default calendars
in calendar sync I forgot we have a special `inbox` Calendar for events created from ICS
files in mailbox. This is currently rollbaring.