### PR TITLE
Microsoft: Renames in Account model

### DIFF
--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -35,7 +35,9 @@ class GmailAccount(OAuthAccount, ImapAccount):
     # for Google webhook notifications:
     last_calendar_list_sync = Column(DateTime)
     webhook_calendar_list_last_ping = Column("gpush_calendar_list_last_ping", DateTime)
-    gpush_calendar_list_expiration = Column(DateTime)
+    webhook_calendar_list_expiration = Column(
+        "gpush_calendar_list_expiration", DateTime
+    )
 
     @property
     def email_scopes(self):
@@ -74,7 +76,7 @@ class GmailAccount(OAuthAccount, ImapAccount):
         return ActionLog
 
     def new_calendar_list_watch(self, expiration: datetime) -> None:
-        self.gpush_calendar_list_expiration = expiration
+        self.webhook_calendar_list_expiration = expiration
         self.webhook_calendar_list_last_ping = datetime.utcnow()
 
     def handle_gpush_notification(self):
@@ -116,8 +118,8 @@ class GmailAccount(OAuthAccount, ImapAccount):
 
     def needs_new_calendar_list_watch(self) -> bool:
         return (
-            self.gpush_calendar_list_expiration is None
-            or self.gpush_calendar_list_expiration < datetime.utcnow()
+            self.webhook_calendar_list_expiration is None
+            or self.webhook_calendar_list_expiration < datetime.utcnow()
         )
 
     def get_raw_message_contents(self, message):

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -79,7 +79,7 @@ class GmailAccount(OAuthAccount, ImapAccount):
         self.webhook_calendar_list_expiration = expiration
         self.webhook_calendar_list_last_ping = datetime.utcnow()
 
-    def handle_gpush_notification(self):
+    def handle_webhook_notification(self):
         self.webhook_calendar_list_last_ping = datetime.utcnow()
 
     def should_update_calendars(

--- a/inbox/webhooks/gpush_notifications.py
+++ b/inbox/webhooks/gpush_notifications.py
@@ -69,7 +69,7 @@ def calendar_update(account_public_id):
                 .filter(GmailAccount.public_id == account_public_id)
                 .one()
             )
-            account.handle_gpush_notification()
+            account.handle_webhook_notification()
             db_session.commit()
         return resp(200)
     except ValueError:

--- a/tests/webhooks/test_gpush_calendar_notifications.py
+++ b/tests/webhooks/test_gpush_calendar_notifications.py
@@ -98,7 +98,7 @@ def test_should_update_logic_push(db, watched_account, watched_calendar):
     assert watched_calendar.should_update_events(four_minutes, zero)
 
     # Received push notification - should update
-    watched_account.handle_gpush_notification()
+    watched_account.handle_webhook_notification()
     watched_calendar.handle_gpush_notification()
     assert watched_account.should_update_calendars(ten_minutes, zero)
     assert watched_calendar.should_update_events(ten_minutes, zero)


### PR DESCRIPTION
These renames prepare webhook related fields to be shared between Microsoft and Google.

This only renames SQLAlchemy model properties and does not touch db columns.
The migration that actually renames the underlying database columns will follow on another PR.