### PR TITLE
Rename-webhook-event-sync

### DIFF
--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, List, Tuple
+from typing import Any, List, Tuple, Type
 
 from requests.exceptions import HTTPError
 
@@ -44,7 +44,7 @@ class EventSync(BaseSyncMonitor):
         provider_name: str,
         account_id: int,
         namespace_id: int,
-        provider_class: AbstractEventsProvider,
+        provider_class: Type[AbstractEventsProvider],
         poll_frequency: int = POLL_FREQUENCY,
     ):
         bind_context(self, "eventsync", account_id)

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import OperationalError
 from inbox.config import config
 from inbox.contacts.remote_sync import ContactSync
 from inbox.error_handling import log_uncaught_errors
+from inbox.events.google import GoogleEventsProvider
 from inbox.events.remote_sync import EventSync, WebhookEventSync
 from inbox.heartbeat.status import clear_heartbeat_status
 from inbox.logging import get_logger
@@ -312,7 +313,7 @@ class SyncService:
                             acc.verbose_provider,
                             acc.id,
                             acc.namespace.id,
-                            GoogleEventsProvider,
+                            provider_class=GoogleEventsProvider,
                         )
                     else:
                         event_sync = EventSync(
@@ -320,6 +321,7 @@ class SyncService:
                             acc.verbose_provider,
                             acc.id,
                             acc.namespace.id,
+                            provider_class=GoogleEventsProvider,
                         )
                     self.event_sync_monitors[acc.id] = event_sync
                     event_sync.start()

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import OperationalError
 from inbox.config import config
 from inbox.contacts.remote_sync import ContactSync
 from inbox.error_handling import log_uncaught_errors
-from inbox.events.remote_sync import EventSync, GoogleEventSync
+from inbox.events.remote_sync import EventSync, WebhookEventSync
 from inbox.heartbeat.status import clear_heartbeat_status
 from inbox.logging import get_logger
 from inbox.mailsync.backends import module_registry
@@ -307,11 +307,12 @@ class SyncService:
 
                 if info.get("events", None) and acc.sync_events:
                     if USE_GOOGLE_PUSH_NOTIFICATIONS and acc.provider == "gmail":
-                        event_sync = GoogleEventSync(
+                        event_sync = WebhookEventSync(
                             acc.email_address,
                             acc.verbose_provider,
                             acc.id,
                             acc.namespace.id,
+                            GoogleEventsProvider,
                         )
                     else:
                         event_sync = EventSync(

--- a/tests/events/test_sync.py
+++ b/tests/events/test_sync.py
@@ -1,6 +1,7 @@
 # flake8: noqa: F401
 from datetime import datetime
 
+from inbox.events.google import GoogleEventsProvider
 from inbox.events.remote_sync import EventSync
 from inbox.events.util import CalendarSyncResponse
 from inbox.models import Calendar, Event, Transaction
@@ -122,7 +123,11 @@ def event_response_with_delete(calendar_uid, sync_from_time):
 def test_handle_changes(db, generic_account):
     namespace_id = generic_account.namespace.id
     event_sync = EventSync(
-        generic_account.email_address, "google", generic_account.id, namespace_id
+        generic_account.email_address,
+        "google",
+        generic_account.id,
+        namespace_id,
+        provider_class=GoogleEventsProvider,
     )
 
     # Sync calendars/events


### PR DESCRIPTION
This renames `GoogleEventSync` to `WebhookEventSync` and parameterizes the events provider.