### PR TITLE
Microsoft: Calendar model new columns

### DIFF
--- a/inbox/models/calendar.py
+++ b/inbox/models/calendar.py
@@ -46,16 +46,31 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin, DeletedA
 
     old_webhook_last_ping = Column("gpush_last_ping", DateTime)
     new_webhook_last_ping = Column("webhook_last_ping", DateTime)
-    webhook_subscription_expiration = Column("gpush_expiration", DateTime)
+    old_webhook_subscription_expiration = Column("gpush_expiration", DateTime)
+    new_webhook_subscription_expiration = Column(
+        "webhook_subscription_expiration", DateTime
+    )
 
     @property
     def webhook_last_ping(self) -> Optional[datetime]:
         return self.new_webhook_last_ping or self.old_webhook_last_ping
 
     @webhook_last_ping.setter
-    def webhook_last_ping(self, value: datetime):
+    def webhook_last_ping(self, value: datetime) -> None:
         self.old_webhook_last_ping = value
         self.new_webhook_last_ping = value
+
+    @property
+    def webhook_subscription_expiration(self) -> Optional[datetime]:
+        return (
+            self.new_webhook_subscription_expiration
+            or self.old_webhook_subscription_expiration
+        )
+
+    @webhook_subscription_expiration.setter
+    def webhook_subscription_expiration(self, value: datetime) -> None:
+        self.old_webhook_subscription_expiration = value
+        self.new_webhook_subscription_expiration = value
 
     __table_args__ = (
         UniqueConstraint("namespace_id", "provider_name", "name", "uid", name="uuid"),

--- a/inbox/models/calendar.py
+++ b/inbox/models/calendar.py
@@ -44,8 +44,18 @@ class Calendar(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin, DeletedA
 
     last_synced = Column(DateTime, nullable=True)
 
-    webhook_last_ping = Column("gpush_last_ping", DateTime)
+    old_webhook_last_ping = Column("gpush_last_ping", DateTime)
+    new_webhook_last_ping = Column("webhook_last_ping", DateTime)
     webhook_subscription_expiration = Column("gpush_expiration", DateTime)
+
+    @property
+    def webhook_last_ping(self) -> Optional[datetime]:
+        return self.new_webhook_last_ping or self.old_webhook_last_ping
+
+    @webhook_last_ping.setter
+    def webhook_last_ping(self, value: datetime):
+        self.old_webhook_last_ping = value
+        self.new_webhook_last_ping = value
 
     __table_args__ = (
         UniqueConstraint("namespace_id", "provider_name", "name", "uid", name="uuid"),

--- a/migrations/versions/255_add_calendar_webhook_columns.py
+++ b/migrations/versions/255_add_calendar_webhook_columns.py
@@ -23,6 +23,13 @@ def upgrade():
         sa.Column("webhook_subscription_expiration", sa.DateTime(), nullable=True),
     )
 
+    op.execute(
+        "UPDATE calendar SET webhook_last_ping = gpush_last_ping WHERE gpush_last_ping IS NOT NULL;"
+    )
+    op.execute(
+        "UPDATE calendar SET webhook_subscription_expiration = gpush_expiration WHERE gpush_expiration IS NOT NULL;"
+    )
+
 
 def downgrade():
     op.drop_column("calendar", "webhook_subscription_expiration")

--- a/migrations/versions/255_add_calendar_webhook_columns.py
+++ b/migrations/versions/255_add_calendar_webhook_columns.py
@@ -1,0 +1,29 @@
+"""Add calendar webhook columns
+
+Revision ID: 9ea81ca0f64b
+Revises: 7bb5c0ca93de
+Create Date: 2022-11-09 10:11:17.902582
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "9ea81ca0f64b"
+down_revision = "7bb5c0ca93de"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    op.add_column(
+        "calendar", sa.Column("webhook_last_ping", sa.DateTime(), nullable=True)
+    )
+    op.add_column(
+        "calendar",
+        sa.Column("webhook_subscription_expiration", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("calendar", "webhook_subscription_expiration")
+    op.drop_column("calendar", "webhook_last_ping")


### PR DESCRIPTION
This adds the final columns:
   * `gpush_last_ping` -> `webhook_last_ping`
   * `gpush_expiration` -> `webhook_subscription_expiration`
   
The columns are hidden behind Python property getter and setter. We write to both new and old column and when reading we prefer the newer column.

This will be followed by a PR that removes old columns.
  