### PR TITLE
Microsoft: Account model new columns

### DIFF
--- a/inbox/models/backends/calendar_sync_account.py
+++ b/inbox/models/backends/calendar_sync_account.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from typing import Optional
 
 from sqlalchemy import Column, DateTime
 
@@ -6,10 +7,42 @@ from sqlalchemy import Column, DateTime
 class CalendarSyncAccountMixin:
 
     last_calendar_list_sync = Column(DateTime)
-    webhook_calendar_list_last_ping = Column("gpush_calendar_list_last_ping", DateTime)
-    webhook_calendar_list_expiration = Column(
+    old_webhook_calendar_list_last_ping = Column(
+        "gpush_calendar_list_last_ping", DateTime
+    )
+    new_webhook_calendar_list_last_ping = Column(
+        "webhook_calendar_list_last_ping", DateTime
+    )
+    old_webhook_calendar_list_expiration = Column(
         "gpush_calendar_list_expiration", DateTime
     )
+    new_webhook_calendar_list_expiration = Column(
+        "webhook_calendar_list_expiration", DateTime
+    )
+
+    @property
+    def webhook_calendar_list_last_ping(self) -> Optional[datetime]:
+        return (
+            self.new_webhook_calendar_list_last_ping
+            or self.old_webhook_calendar_list_last_ping
+        )
+
+    @webhook_calendar_list_last_ping.setter
+    def webhook_calendar_list_last_ping(self, value: datetime) -> None:
+        self.old_webhook_calendar_last_last_ping = value
+        self.new_webhook_calendar_list_last_ping = value
+
+    @property
+    def webhook_calendar_list_expiration(self) -> Optional[datetime]:
+        return (
+            self.new_webhook_calendar_list_expiration
+            or self.old_webhook_calendar_list_expiration
+        )
+
+    @webhook_calendar_list_expiration.setter
+    def webhook_calendar_list_expiration(self, value: datetime) -> None:
+        self.old_webhook_calendar_list_expiration = value
+        self.new_webhook_calendar_list_expiration = value
 
     def new_calendar_list_watch(self, expiration: datetime) -> None:
         self.webhook_calendar_list_expiration = expiration

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -27,10 +27,6 @@ class GmailAccount(CalendarSyncAccountMixin, OAuthAccount, ImapAccount):
     scope = Column(String(512))
 
     @property
-    def email_scopes(self):
-        return GOOGLE_EMAIL_SCOPES
-
-    @property
     def contacts_scopes(self):
         return GOOGLE_CONTACTS_SCOPES
 

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -27,6 +27,10 @@ class GmailAccount(CalendarSyncAccountMixin, OAuthAccount, ImapAccount):
     scope = Column(String(512))
 
     @property
+    def email_scopes(self):
+        return GOOGLE_EMAIL_SCOPES
+
+    @property
     def contacts_scopes(self):
         return GOOGLE_CONTACTS_SCOPES
 

--- a/migrations/versions/256_add_account_webhook_columns.py
+++ b/migrations/versions/256_add_account_webhook_columns.py
@@ -1,0 +1,30 @@
+"""Add account webhook columns
+
+Revision ID: 93cc6f4ce113
+Revises: 9ea81ca0f64b
+Create Date: 2022-11-09 11:12:26.241416
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "93cc6f4ce113"
+down_revision = "9ea81ca0f64b"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    op.add_column(
+        "gmailaccount",
+        sa.Column("webhook_calendar_list_last_ping", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "gmailaccount",
+        sa.Column("webhook_calendar_list_expiration", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("gmailaccount", "webhook_calendar_list_expiration")
+    op.drop_column("gmailaccount", "webhook_calendar_list_last_ping")

--- a/migrations/versions/256_add_account_webhook_columns.py
+++ b/migrations/versions/256_add_account_webhook_columns.py
@@ -24,6 +24,13 @@ def upgrade():
         sa.Column("webhook_calendar_list_expiration", sa.DateTime(), nullable=True),
     )
 
+    op.execute(
+        "UPDATE gmailaccount SET webhook_calendar_list_last_ping = gpush_calendar_list_last_ping WHERE gpush_calendar_list_last_ping IS NOT NULL;"
+    )
+    op.execute(
+        "UPDATE gmailaccount SET webhook_calendar_list_expiration = gpush_calendar_list_expiration WHERE gpush_calendar_list_expiration IS NOT NULL;"
+    )
+
 
 def downgrade():
     op.drop_column("gmailaccount", "webhook_calendar_list_expiration")


### PR DESCRIPTION
This is similar to https://github.com/closeio/sync-engine/pull/408



This adds the final columns:

    gpush_calendar_list_last_ping -> webhook_calendar_list_last_ping
    gpush_calendar_list_expiration  -> webhook_calendar_list_expiration

The columns are hidden behind Python property getter and setter. We write to both new and old column and when reading we prefer the newer column.

This will be followed by a PR that removes old columns.
