### PR TITLE
Microsoft: Account model remove old webhook columns

### DIFF
--- a/inbox/models/backends/calendar_sync_account.py
+++ b/inbox/models/backends/calendar_sync_account.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Optional
 
 from sqlalchemy import Column, DateTime
 
@@ -7,42 +6,8 @@ from sqlalchemy import Column, DateTime
 class CalendarSyncAccountMixin:
 
     last_calendar_list_sync = Column(DateTime)
-    old_webhook_calendar_list_last_ping = Column(
-        "gpush_calendar_list_last_ping", DateTime
-    )
-    new_webhook_calendar_list_last_ping = Column(
-        "webhook_calendar_list_last_ping", DateTime
-    )
-    old_webhook_calendar_list_expiration = Column(
-        "gpush_calendar_list_expiration", DateTime
-    )
-    new_webhook_calendar_list_expiration = Column(
-        "webhook_calendar_list_expiration", DateTime
-    )
-
-    @property
-    def webhook_calendar_list_last_ping(self) -> Optional[datetime]:
-        return (
-            self.new_webhook_calendar_list_last_ping
-            or self.old_webhook_calendar_list_last_ping
-        )
-
-    @webhook_calendar_list_last_ping.setter
-    def webhook_calendar_list_last_ping(self, value: datetime) -> None:
-        self.old_webhook_calendar_last_last_ping = value
-        self.new_webhook_calendar_list_last_ping = value
-
-    @property
-    def webhook_calendar_list_expiration(self) -> Optional[datetime]:
-        return (
-            self.new_webhook_calendar_list_expiration
-            or self.old_webhook_calendar_list_expiration
-        )
-
-    @webhook_calendar_list_expiration.setter
-    def webhook_calendar_list_expiration(self, value: datetime) -> None:
-        self.old_webhook_calendar_list_expiration = value
-        self.new_webhook_calendar_list_expiration = value
+    webhook_calendar_list_last_ping = Column(DateTime)
+    webhook_calendar_list_expiration = Column(DateTime)
 
     def new_calendar_list_watch(self, expiration: datetime) -> None:
         self.webhook_calendar_list_expiration = expiration

--- a/migrations/versions/258_remove_account_old_webhook_columns.py
+++ b/migrations/versions/258_remove_account_old_webhook_columns.py
@@ -1,0 +1,31 @@
+"""Remove account old webhook columns
+
+Revision ID: e9e932c6c55e
+Revises: 4af0d2f17967
+Create Date: 2022-11-10 14:45:07.831731
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e9e932c6c55e"
+down_revision = "4af0d2f17967"
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import mysql
+
+
+def upgrade():
+    op.drop_column("gmailaccount", "gpush_calendar_list_expiration")
+    op.drop_column("gmailaccount", "gpush_calendar_list_last_ping")
+
+
+def downgrade():
+    op.add_column(
+        "gmailaccount",
+        sa.Column("gpush_calendar_list_last_ping", mysql.DATETIME(), nullable=True),
+    )
+    op.add_column(
+        "gmailaccount",
+        sa.Column("gpush_calendar_list_expiration", mysql.DATETIME(), nullable=True),
+    )


### PR DESCRIPTION
Stacked PR: Review [https://github.com/closeio/sync-engine/pull/411 first](https://github.com/closeio/sync-engine/pull/411), than review last 2 commits after ------ 8< ------

This drops the old columns.