### PR TITLE
Fix event ownership transfer for Google Calendar

### DIFF
--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -522,13 +522,18 @@ def parse_event_response(event: Dict[str, Any], read_only_calendar: bool) -> Eve
 
     # Ownership, read_only information
     creator = event.get("creator")
+    organizer = event.get("organizer")
+    is_owner = bool(organizer and organizer.get("self"))
 
-    if creator:
+    owner = ""
+    if organizer:
+        owner = email.utils.formataddr(
+            (organizer.get("displayName", ""), organizer.get("email", ""))
+        )
+    elif creator:
         owner = email.utils.formataddr(
             (creator.get("displayName", ""), creator.get("email", ""))
         )
-    else:
-        owner = ""
 
     participants = []
     attendees = event.get("attendees", [])
@@ -542,9 +547,6 @@ def parse_event_response(event: Dict[str, Any], read_only_calendar: bool) -> Eve
                 "notes": attendee.get("comment"),
             }
         )
-
-    organizer = event.get("organizer")
-    is_owner = bool(organizer and organizer.get("self"))
 
     # FIXME @karim: The right thing here would be to use Google's ACL API.
     # There's some obscure cases, like an autoimported event which guests can

--- a/tests/events/test_google_events.py
+++ b/tests/events/test_google_events.py
@@ -1,3 +1,4 @@
+import email
 import json
 from unittest import mock
 
@@ -607,6 +608,58 @@ def test_override_creation():
     assert isinstance(event, RecurringEventOverride)
     assert event.master_event_uid == "tn7krk4cekt8ag3pk6gapqqbro"
     assert event.original_start_time == arrow.get(2012, 10, 23, 0, 0, 0)
+
+
+def test_owner_from_organizer():
+    event_dict = {
+        "created": "2012-10-09T22:35:50.000Z",
+        "creator": {
+            "displayName": "Eben Freeman",
+            "email": "freemaneben@gmail.com",
+            "self": True,
+        },
+        "end": {"dateTime": "2012-10-22T19:00:00-07:00"},
+        "etag": '"3336842760746000"',
+        "htmlLink": "https://www.google.com/calendar/event?eid=FOO",
+        "iCalUID": "4qpljm0446jgh9925evicmh4ke@google.com",
+        "id": "4qpljm0446jgh9925evicmh4ke",
+        "kind": "calendar#event",
+        "organizer": {
+            "displayName": "MITOC BOD",
+            "email": "mitoc-bod@mit.edu",
+            "self": False,
+        },
+        "attendees": [
+            {
+                "displayName": "MITOC BOD",
+                "email": "mitoc-bod@mit.edu",
+                "responseStatus": "accepted",
+            },
+            {
+                "displayName": "Eben Freeman",
+                "email": "freemaneben@gmail.com",
+                "responseStatus": "accepted",
+            },
+        ],
+        "originalStartTime": {
+            "dateTime": "2012-10-22T17:00:00-07:00",
+            "timeZone": "America/Los_Angeles",
+        },
+        "recurringEventId": "tn7krk4cekt8ag3pk6gapqqbro",
+        "reminders": {"useDefault": True},
+        "sequence": 0,
+        "start": {
+            "dateTime": "2012-10-22T18:00:00-07:00",
+            "timeZone": "America/Los_Angeles",
+        },
+        "status": "confirmed",
+        "summary": "BOD Meeting",
+        "updated": "2014-06-21T21:42:09.072Z",
+    }
+    event = parse_event_response(event_dict, False)
+    owner_name, owner_email = email.utils.parseaddr(event.owner)
+    assert (owner_name, owner_email) == ("MITOC BOD", "mitoc-bod@mit.edu")
+    assert owner_email != event_dict["creator"]["email"]
 
 
 def test_cancelled_override_creation():


### PR DESCRIPTION
We extracted event ownership (`Event.owner`) info for Google Calendar events from `creator`, which doesn't change after transferring ownership. Oddly, we were computing `is_owner` from `organizer`, which is correct.

This PR uses `organizer` data to compute `owner`. In theory, it shouldn't be necessary to check `creator` (old behavior), but I left that check in case there's no `organizer` data (for some unknown reason).

https://github.com/closeio/sync-engine/blob/cdfdf6ab363cd2b17af9d5b0f745615c8fdc1f2a/inbox/events/google.py#L528-L536