### PR TITLE
Don't explode metrics completely if one account is busted

### DIFF
--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -133,11 +133,11 @@ def make_account(db, config, *, cls):
 
 def delete_default_accounts(db):
     from inbox.models import Namespace
-    from inbox.models.backends.gmail import GmailAccount
+    from inbox.models.account import Account
 
     delete_messages(db.session)
     db.session.rollback()
-    db.session.query(GmailAccount).delete()
+    db.session.query(Account).delete()
     db.session.query(Namespace).delete()
     db.session.commit()
 


### PR DESCRIPTION
Previously having a single account in a half broken state would lead to the whole `/metrics` giving 500. This is dangerous. Let's just skip accounts that for some reason cannot be serialized, but raise an error which will end up in Rollbar.