### PR TITLE
Microsoft: Set sync_events in account creation/updates using API

### DIFF
--- a/inbox/api/srv.py
+++ b/inbox/api/srv.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, Dict, Union
 
 from flask import Flask, g, jsonify, make_response, request
 from flask_restful import reqparse
@@ -176,7 +176,7 @@ def _get_account_data_for_generic_account(data):
     )
 
 
-def _get_account_data_for_google_account(data):
+def _get_account_data_for_google_account(data: Dict[str, Any]) -> GoogleAccountData:
     email_address = data["email_address"]
     scopes = data.get("scopes", " ".join(GOOGLE_EMAIL_SCOPES))
     client_id = data.get("client_id")
@@ -209,7 +209,9 @@ def _get_account_data_for_google_account(data):
     )
 
 
-def _get_account_data_for_microsoft_account(data):
+def _get_account_data_for_microsoft_account(
+    data: Dict[str, Any]
+) -> MicrosoftAccountData:
     email_address = data["email_address"]
     scopes = data["scopes"]
     client_id = data.get("client_id")
@@ -218,6 +220,7 @@ def _get_account_data_for_microsoft_account(data):
     authalligator = data.get("authalligator")
 
     sync_email = data.get("sync_email", True)
+    sync_calendar = data.get("sync_calendar", False)
 
     if authalligator:
         secret_type = SecretType.AuthAlligator
@@ -235,6 +238,7 @@ def _get_account_data_for_microsoft_account(data):
         client_id=client_id,
         scope=scopes,
         sync_email=sync_email,
+        sync_events=sync_calendar,
     )
 
 

--- a/inbox/auth/google.py
+++ b/inbox/auth/google.py
@@ -48,14 +48,16 @@ class GoogleAuthHandler(OAuthAuthHandler):
         ]
     )
 
-    def create_account(self, account_data):
+    def create_account(self, account_data: GoogleAccountData) -> GmailAccount:
         namespace = Namespace()
         account = GmailAccount(namespace=namespace)
         account.create_emailed_events_calendar()
         account.sync_should_run = False
         return self.update_account(account, account_data)
 
-    def update_account(self, account, account_data):
+    def update_account(
+        self, account: GmailAccount, account_data: GoogleAccountData
+    ) -> GmailAccount:
         account.email_address = account_data.email
 
         if account_data.secret_type:

--- a/inbox/auth/microsoft.py
+++ b/inbox/auth/microsoft.py
@@ -21,6 +21,7 @@ class MicrosoftAccountData:
     scope = attr.ib()
 
     sync_email = attr.ib()
+    sync_events = attr.ib()
 
 
 class MicrosoftAuthHandler(OAuthAuthHandler):
@@ -48,14 +49,16 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
         ]
     )
 
-    def create_account(self, account_data):
+    def create_account(self, account_data: MicrosoftAccountData) -> OutlookAccount:
         namespace = Namespace()
         account = OutlookAccount(namespace=namespace)
         account.create_emailed_events_calendar()
         account.sync_should_run = False
         return self.update_account(account, account_data)
 
-    def update_account(self, account, account_data):
+    def update_account(
+        self, account: OutlookAccount, account_data: MicrosoftAccountData
+    ) -> OutlookAccount:
         account.email_address = account_data.email
 
         if account_data.secret_type:
@@ -65,6 +68,7 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
             raise OAuthError("No valid auth info.")
 
         account.sync_email = account_data.sync_email
+        account.sync_events = account_data.sync_events
 
         account.client_id = account_data.client_id
         account.scope = account_data.scope
@@ -97,6 +101,7 @@ class MicrosoftAuthHandler(OAuthAuthHandler):
                     client_id=self.OAUTH_CLIENT_ID,
                     scope=auth_response["scope"],
                     sync_email=True,
+                    sync_events=False,
                 )
             except OAuthError:
                 print("\nInvalid authorization code, try again...\n")


### PR DESCRIPTION
This adds an ability to turn on/off calendar_syncing in Microsoft accounts just like we currently do for Google accounts.

Note that in the payload we use `sync_calendars` where the actual field in the database is called `sync_events`. This is how we currently do that in Google as well.