### PR TITLE
Microsoft: Events provider webhook support

### DIFF
--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -38,7 +38,7 @@ URL_PREFIX = config.get("API_URL", "")
 WEBHOOK_ENABLED_CLIENT_IDS = config.get("WEBHOOK_ENABLED_CLIENT_IDS", [])
 
 CALENDAR_LIST_WEBHOOK_URL = URL_PREFIX + "/w/calendar_list_update/{}"
-EVENTS_LIST_WEHOOK_URL = URL_PREFIX + "/w/calendar_update/{}"
+EVENTS_LIST_WEBHOOK_URL = URL_PREFIX + "/w/calendar_update/{}"
 
 WATCH_CALENDARS_URL = CALENDARS_URL + "/watch"
 WATCH_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/{}/events/watch"
@@ -357,7 +357,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
         """
         token = self._get_access_token_for_push_notifications(account)
         watch_url = WATCH_EVENTS_URL.format(urllib.parse.quote(calendar.uid))
-        receiving_url = EVENTS_LIST_WEHOOK_URL.format(
+        receiving_url = EVENTS_LIST_WEBHOOK_URL.format(
             urllib.parse.quote(calendar.public_id)
         )
 

--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -106,7 +106,7 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
 
         expiration = cast(MsGraphSubscription, response)["expirationDateTime"]
 
-        return ciso8601.parse_datetime(expiration)
+        return ciso8601.parse_datetime(expiration).replace(microsecond=0)
 
     def watch_calendar(
         self, account: Account, calendar: Calendar
@@ -129,4 +129,4 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
 
         expiration = cast(MsGraphSubscription, response)["expirationDateTime"]
 
-        return ciso8601.parse_datetime(expiration)
+        return ciso8601.parse_datetime(expiration).replace(microsecond=0)

--- a/inbox/events/microsoft/graph_types.py
+++ b/inbox/events/microsoft/graph_types.py
@@ -251,3 +251,15 @@ class MsGraphChangeNotificationCollection(TypedDict):
     """
 
     value: List[MsGraphChangeNotification]
+
+
+class MsGraphSubscription(TypedDict):
+    """
+    A subscription allows a client app to receive change notifications
+    about changes to data in Microsoft Graph.
+
+    https://learn.microsoft.com/en-us/graph/api/resources/subscription
+    """
+
+    id: str
+    expirationDateTime: str

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -267,8 +267,7 @@ class WebhookEventSync(EventSync):
                 self._refresh_webhook_subscriptions()
             else:
                 self.log.warning(
-                    "Cannot use Google push notifications (URL_PREFIX not "
-                    "configured)"
+                    "Cannot use webhook notifications (URL_PREFIX not configured)"
                 )
         except AccessNotEnabledError:
             self.log.warning(

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -325,8 +325,7 @@ class SyncService:
                             provider_class=GoogleEventsProvider,
                         )
                     elif acc.provider == "microsoft":
-                        # FIXME: Use WebhookEventSync for incremental
-                        event_sync = EventSync(
+                        event_sync = WebhookEventSync(
                             acc.email_address,
                             acc.verbose_provider,
                             acc.id,


### PR DESCRIPTION
This provides webhook support for events provider.

I also tested this end to end by deploying the image to a pod where my outlook sync is running. All looks good. In practice the time it takes to sync between me changing something in Outlook and CRM is less than 15 seconds with this PR.