### PR TITLE
Microsoft: Calendar deletes

### DIFF
--- a/inbox/events/util.py
+++ b/inbox/events/util.py
@@ -1,9 +1,11 @@
 import string
 from collections import namedtuple
+from typing import List, NamedTuple
 
 import arrow
 from dateutil.parser import parse
 
+from inbox.models.calendar import Calendar
 from inbox.models.when import parse_as_when
 
 
@@ -103,10 +105,15 @@ def removed_participants(original_participants, update_participants):
     return ret
 
 
-# Container for a parsed API response. API calls return adds/updates/deletes
-# all together, but we want to handle deletions separately in our persistence
-# logic. deleted_uids should be a list of uids, and updated_objects should be a
-# list of (un-added, uncommitted) model instances.
-CalendarSyncResponse = namedtuple(
-    "CalendarSyncResponse", ["deleted_uids", "updated_objects"]
-)
+class CalendarSyncResponse(NamedTuple):
+    """
+    Container for a parsed API response.
+
+    API calls return adds/updates/deletes
+    all together, but we want to handle deletions separately in our persistence
+    logic. deleted_uids should be a list of uids, and updated_objects should be a
+    list of (un-added, uncommitted) model instances.
+    """
+
+    deleted_uids: List[str]
+    updated_objects: List[Calendar]

--- a/tests/events/microsoft/test_events_provider.py
+++ b/tests/events/microsoft/test_events_provider.py
@@ -379,6 +379,25 @@ def test_sync_calendars(provider):
 
 
 @responses.activate
+@pytest.mark.usefixtures("calendars_response")
+def test_sync_calendars_deletion(db, client, outlook_account):
+    deleted_calendar = Calendar(
+        uid="deleted_calendar_id",
+        public_id="fake_deleted_public_id",
+        namespace_id=outlook_account.namespace.id,
+    )
+    db.session.add(deleted_calendar)
+    db.session.commit()
+
+    provider = MicrosoftEventsProvider(outlook_account.id, outlook_account.namespace.id)
+    provider.client = client
+
+    deleted_uids, _ = provider.sync_calendars()
+
+    assert deleted_uids == [deleted_calendar.uid]
+
+
+@responses.activate
 @pytest.mark.usefixtures("events_responses", "instances_response")
 def test_sync_events(provider):
     events = provider.sync_events("fake_calendar_id")


### PR DESCRIPTION
This is implemented differently than in Google again. You cannot fetch deleted calendars with Microsoft (like we do in Google). We fetch them all anyway in each synchronization iteration and people typically have only a couple of calendars so one can just compare what comes from the API with what we have in the database.