### PR TITLE
Microsoft: Organizer attendee status

### DIFF
--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -433,6 +433,7 @@ MS_GRAPH_TO_SYNC_ENGINE_STATUS_MAP: Dict[MsGraphResponse, str] = {
     "notResponded": "noreply",
     "declined": "no",
     "accepted": "yes",
+    "organizer": "yes",
     "tentativelyAccepted": "maybe",
 }
 

--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -853,6 +853,21 @@ def test_get_event_location(event, location):
                 "notes": None,
             },
         ),
+        (
+            {
+                "status": {"response": "organizer", "time": "0001-01-01T00:00:00Z"},
+                "emailAddress": {
+                    "name": "Maria di Pomodoro | The future",
+                    "address": "m.pomodoro@thefuture.com",
+                },
+            },
+            {
+                "email": "m.pomodoro@thefuture.com",
+                "name": "Maria di Pomodoro | The future",
+                "status": "yes",
+                "notes": None,
+            },
+        ),
     ],
 )
 def test_get_event_participant(attendee, participant):


### PR DESCRIPTION
This is the part of the code responsible for converting Microsoft Graph event participant statuses to Google like event participant statuses. I forgot about `"organizer"` value which is documented here: https://learn.microsoft.com/en-us/graph/api/resources/responsestatus?view=graph-rest-1.0#properties and we have a Rollbar now.