### PR TITLE
Microsoft: Event organizer can be None

### DIFF
--- a/inbox/events/microsoft/graph_types.py
+++ b/inbox/events/microsoft/graph_types.py
@@ -194,7 +194,7 @@ class MsGraphEvent(TypedDict):
     end: MsGraphDateTimeTimeZone
     lastModifiedDateTime: str
     showAs: MsGraphShowAs
-    organizer: MsGraphRecipient
+    organizer: Optional[MsGraphRecipient]
     sensitivity: MsGraphSensitivity
     subject: str
     isAllDay: bool

--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -581,10 +581,14 @@ def parse_event(
     busy = MS_GRAPH_SHOW_AS_TO_BUSY_MAP[event["showAs"]]
     sequence_number = 0
     status = "cancelled" if event["isCancelled"] else "confirmed"
-    organizer = event["organizer"].get("emailAddress", {})
+    organizer = event["organizer"]
     if organizer:
+        organizer_email_address = organizer.get("emailAddress", {})
         owner = email.utils.formataddr(
-            (organizer.get("name", ""), organizer.get("address", ""))
+            (
+                organizer_email_address.get("name", ""),
+                organizer_email_address.get("address", ""),
+            )
         )
     else:
         owner = ""

--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -1065,9 +1065,7 @@ single_instance_event = {
     },
     "locations": [],
     "attendees": [],
-    "organizer": {
-        "emailAddress": {"name": "Example <>", "address": "example_2@example.com"}
-    },
+    "organizer": None,
 }
 
 
@@ -1087,7 +1085,7 @@ def test_parse_event_singular():
     assert event.location == "https://teams.microsoft.com/l/meetup-join/xyz"
     assert event.busy is True
     assert event.status == "confirmed"
-    assert event.owner == '"Example <>" <example_2@example.com>'
+    assert event.owner == ""
     assert event.participants == []
     assert event.is_owner is True
     assert event.cancelled is False


### PR DESCRIPTION
While testing with real data I found that Microsoft Graph can return events with `"organizer"` set to `None`. We are rollbaring currently for those events.