### PR TITLE
Microsoft: Attendees without email addresses

### DIFF
--- a/inbox/events/microsoft/graph_types.py
+++ b/inbox/events/microsoft/graph_types.py
@@ -1,5 +1,7 @@
 from typing import List, Literal, Optional, TypedDict
 
+from typing_extensions import NotRequired
+
 
 class MsGraphDateTimeTimeZone(TypedDict):
     """
@@ -84,7 +86,7 @@ MsGraphEventType = Literal["singleInstance", "occurrence", "exception", "seriesM
 
 
 class MsGraphEmailAddress(TypedDict):
-    address: str
+    address: NotRequired[str]
     name: str
 
 

--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -449,7 +449,7 @@ def get_event_participant(attendee: MsGraphAttendee) -> Dict[str, Any]:
         Sync-engine participant dictionary
     """
     return {
-        "email": attendee["emailAddress"]["address"],
+        "email": attendee["emailAddress"].get("address"),
         "name": attendee["emailAddress"]["name"],
         "status": MS_GRAPH_TO_SYNC_ENGINE_STATUS_MAP[attendee["status"]["response"]],
         "notes": None,

--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -868,6 +868,16 @@ def test_get_event_location(event, location):
                 "notes": None,
             },
         ),
+        (
+            {
+                "status": {
+                    "response": "tentativelyAccepted",
+                    "time": "2022-09-08T15:47:46Z",
+                },
+                "emailAddress": {"name": "Test User"},
+            },
+            {"email": None, "name": "Test User", "status": "maybe", "notes": None,},
+        ),
     ],
 )
 def test_get_event_participant(attendee, participant):


### PR DESCRIPTION
Another Rollbar. We can have attendees without email addresses, we skip those in CRM.