### PR TITLE
Microsoft: null subjects

### DIFF
--- a/inbox/events/microsoft/graph_types.py
+++ b/inbox/events/microsoft/graph_types.py
@@ -198,7 +198,7 @@ class MsGraphEvent(TypedDict):
     showAs: MsGraphShowAs
     organizer: Optional[MsGraphRecipient]
     sensitivity: MsGraphSensitivity
-    subject: str
+    subject: Optional[str]
     isAllDay: bool
     isCancelled: bool
     isOrganizer: bool

--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -636,7 +636,7 @@ def parse_event(
 
     uid = event["id"]
     raw_data = json.dumps(event)
-    title = event["subject"]
+    title = event["subject"] or ""
     start = parse_msgraph_datetime_tz_as_utc(event["start"])
     end = parse_msgraph_datetime_tz_as_utc(event["end"])
     all_day = event["isAllDay"]


### PR DESCRIPTION
Empirically from looking at user data Microsoft Graph can return null event subjects
and it makes CRM barf because it's not possible with Google. We try to mimick Google so let's
make it empty string.