### PR TITLE
Microsoft: Handle subscription removed

### DIFF
--- a/inbox/events/microsoft/graph_types.py
+++ b/inbox/events/microsoft/graph_types.py
@@ -241,7 +241,7 @@ class MsGraphChangeNotification(TypedDict):
     https://learn.microsoft.com/en-us/graph/api/resources/changenotification
     """
 
-    changeType: MsGraphChangeType
+    changeType: NotRequired[MsGraphChangeType]
     clientState: str
     resource: str
     resourceData: MsGraphResourceData

--- a/inbox/webhooks/microsoft_notifications.py
+++ b/inbox/webhooks/microsoft_notifications.py
@@ -78,6 +78,7 @@ def validate_webhook_payload_factory(type: MsGraphType):
             if any(
                 notification["resourceData"]["@odata.type"] != type
                 for notification in change_notifications
+                if notification.get("changeType")
             ):
                 return f"Expected '@odata.type' to be '{type}'", 400
 
@@ -141,7 +142,7 @@ def handle_event_deletions(
     deleted_event_uids = [
         change_notification["resourceData"]["id"]
         for change_notification in change_notifications
-        if change_notification["changeType"] == "deleted"
+        if change_notification.get("changeType") == "deleted"
     ]
     if not deleted_event_uids:
         return

--- a/tests/webhooks/test_microsoft_notifications.py
+++ b/tests/webhooks/test_microsoft_notifications.py
@@ -122,6 +122,24 @@ def test_calendar_update(db, test_client, outlook_account):
     assert response.status_code == 200
 
 
+def test_subscription_removed(test_client, outlook_account):
+    response = test_client.post(
+        f"/w/microsoft/calendar_list_update/{outlook_account.public_id}",
+        json={
+            "value": [
+                {
+                    "resource": "",
+                    "resourceData": None,
+                    "lifecycleEvent": "subscriptionRemoved",
+                    "clientState": "good_s3cr3t",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+
+
 def test_event_update_404(test_client):
     response = test_client.post(
         "/w/microsoft/calendar_update/does_not_exist",


### PR DESCRIPTION
Apart from the changes Microsoft delivers the information about subscription expiring over webhook and I did not realize that. We already renew them in sync pods and we can just ignore those but I need to ensure we don't Rollbar when we get those webhooks.