### PR TITLE
Microsoft: Rise timeout

### DIFF
--- a/inbox/events/microsoft/graph_client.py
+++ b/inbox/events/microsoft/graph_client.py
@@ -74,7 +74,7 @@ class MicrosoftGraphClient:
         params: Optional[Dict[str, str]] = None,
         json: Optional[Dict[str, str]] = None,
         max_retries=10,
-        timeout=10,
+        timeout=20,
     ) -> Dict[str, Any]:
         """
         Perform request.


### PR DESCRIPTION
For a couple of customers timeout of 10 seconds is too low. I checked
their calendars manually and 20 seconds is enough.