### PR TITLE
Use SELECT FOR UPDATE when updating calendar rows using API

### DIFF
--- a/inbox/webhooks/google_notifications.py
+++ b/inbox/webhooks/google_notifications.py
@@ -91,6 +91,7 @@ def event_update(calendar_public_id):
                 calendar = (
                     db_session.query(Calendar)
                     .filter(Calendar.public_id == calendar_public_id)
+                    .with_for_update()
                     .one()
                 )
                 calendar.handle_webhook_notification()

--- a/inbox/webhooks/microsoft_notifications.py
+++ b/inbox/webhooks/microsoft_notifications.py
@@ -120,6 +120,7 @@ def event_update(calendar_public_id):
             calendar = (
                 db_session.query(Calendar)
                 .filter(Calendar.public_id == calendar_public_id)
+                .with_for_update()
                 .one()
             )
         except NoResultFound:


### PR DESCRIPTION
` OperationalError: (_mysql_exceptions.OperationalError) (1213, 'Deadlock found when trying to get lock; try restarting transaction') [SQL: UPDATE calendar SET updated_at=%s, webhook_last_ping=%s WHERE calendar.id = %s]`

Currently we are getting regular deadlocks inside API pods because Sync pods also do updates to calendar rows and they can currently run in parallel. This is only happening for Google but it could easily become problem with Outlook as well. The solution is to acquire EXCLUSIVE lock earlier in API as currently SELECT acquires SHARED lock and then we immediately do UPDATE (inside `handle_webhook_notification()`) which upgrades lock from SHARED to EXCLUSIVE and leads to deadlock with sync pods. Note that it means that transactions in API and sync pods around the same calendar row run serially but that's what we want, also the API transaction is pretty small one.

I have test driven this in production and it indeed eliminates deadlocks.