### PR TITLE
Don't use is to compare ints

### DIFF
--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -367,7 +367,7 @@ class SyncbackService(gevent.Greenlet):
                 account_id = namespace.account.id
             else:
                 assert (
-                    account_id is namespace.account.id
+                    account_id == namespace.account.id
                 ), "account_id and namespace.account.id do not match"
 
             if namespace.account.sync_state in ("invalid", "stopped"):


### PR DESCRIPTION
Something that was rollbaring since forever and I was scratching my head why.
The query in [here](https://github.com/closeio/sync-engine/blob/8fb0e4560b96bb574b62ed4a9249587198fef9ca/inbox/transactions/actions.py#L467-L476) always selects log entries from a single Namespace and Namespace to Account is 1 to 1 relation. So every log entry in the resultset belongs to the same account and would have the same `namespace.account_id`. But we were getting `AssertionError: account_id and namespace.account.id do not match`.

It was difficult to see but of course that's because we are comparing ints with `is` instead of `==`, and depending on where those are in memory it would raise or not. The fact that CPython interpreter tries to cache and reuse ints made this not so obvious as most of the time it would work just fine as they would be at the same memory address.