### PR TITLE
Demote connection errors to warnings

### DIFF
--- a/inbox/auth/generic.py
+++ b/inbox/auth/generic.py
@@ -78,7 +78,7 @@ class GenericAuthHandler(AuthHandler):
             elif auth_requires_app_password(exc):
                 raise AppPasswordError(exc)
             else:
-                log.error(
+                log.warning(
                     "IMAP login failed for an unknown reason. Check auth_is_invalid",
                     account_id=account.id,
                     error=exc,

--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -194,7 +194,7 @@ class OAuthAuthHandler(AuthHandler):
             ):
                 raise exc from original_exc
 
-            log.error(
+            log.warning(
                 "Error during IMAP XOAUTH2 login", account_id=account.id, error=exc,
             )
             if not isinstance(exc, ImapSupportDisabledError):


### PR DESCRIPTION
These are caused by transient connection errors (not even authentication errors), I studied a lot of accounts that report those and they are syncing their email
just fine as we retry reconnection. There's no need for a Rollbar in those cases.