### PR TITLE
Bump gevent & friends

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -26,8 +26,8 @@ tld==0.12.6
 Flask==1.1.4
 Flask-RESTful==0.3.9
 gdata==2.0.18
-gevent==21.8.0
-greenlet==1.1.2
+gevent==22.10.2
+greenlet==2.0.1
 gunicorn==20.1.0
 guppy3==3.1.2
 hiredis==1.1.0


### PR DESCRIPTION
sync-engine uses `gevent` directly. `greenlet` is its dependency and needs to be updated at the same time.

gevent chanelog

```rst
22.10.2 (2022-10-31)
====================


Bugfixes
--------

- Update to greenlet 2.0. This fixes a deallocation issue that required
  a change in greenlet's ABI. The design of greenlet 2.0 is intended to
  prevent future fixes and enhancements from requiring an ABI change,
  making it easier to update gevent and greenlet independently.

  .. caution::

     greenlet 2.0 requires a modern-ish C++ compiler. This may mean
     certain older platforms are no longer supported.
     See :issue:`1909`.


----


22.10.1 (2022-10-14)
====================


Features
--------

- Update bundled libuv to 1.44.2.
  See :issue:`1913`.


Misc
----

- See :issue:`1898`., See :issue:`1910`., See :issue:`1915`.


----


22.08.0 (2022-10-08)
====================


Features
--------

- Windows: Test and provide binary wheels for PyPy3.7.

  Note that there may be issues with subprocesses, signals, and it may
  be slow.
  See :issue:`1798`.
- Upgrade embedded c-ares to 1.18.1.
  See :issue:`1847`.
- Upgrade bundled libuv to 1.42.0 from 1.40.0.
  See :issue:`1851`.
- Added preliminary support for Python 3.11 (rc2 and later).

  Some platforms may or may not have binary wheels at this time.

  .. important:: Support for legacy versions of Python, including 2.7
                 and 3.6, will be ending soon. The
                 maintenance burden has become too great and the
                 maintainer's time is too limited.

                 Ideally, there will be a release of gevent compatible
                 with a final release of greenlet 2.0 that still
                 supports those legacy versions, but that may not be
                 possible; this may be the final release to support them.

  :class:`gevent.threadpool.ThreadPool` can now optionally expire idle
  threads. This is used by default in the implicit thread pool used for
  DNS requests and other user-submitted tasks; other uses of a
  thread-pool need to opt-in to this.
  See :issue:`1867`.


Bugfixes
--------

- Truly disable the effects of compiling with ``-ffast-math``.
  See :issue:`1864`.


----


21.12.0 (2021-12-11)
====================


Features
--------

- Update autoconf files for Apple Silicon Macs. Note that while there
  are reports of compiling gevent on Apple Silicon Macs now, this is
  *not* a tested configuration. There may be some remaining issues with
  CFFI on some systems as well.
  See :issue:`1721`.
- Build and upload CPython 3.10 binary manylinux wheels.

  Unfortunately, this required us to stop building and uploading CPython
  2.7 binary manylinux wheels. Binary wheels for 2.7 continue to be
  available for Windows and macOS.
  See :issue:`1822`.
- Test and distribute musllinux_1_1 wheels.
  See :issue:`1837`.
- Update the tested versions of PyPy2 and PyPy3. For PyPy2, there should
  be no user visible changes, but for PyPy3, support has moved from
  Python 3.6 to Python 3.7.
  See :issue:`1843`.


Bugfixes
--------

- Try to avoid linking to two different Python runtime DLLs on Windows.
  See :issue:`1814`.
- Stop compiling manylinux wheels with ``-ffast-math.`` This was
  implicit in ``-Ofast``, but could alter the global state of the
  process. Analysis and fix thanks to Ilya Konstantinov.
  See :issue:`1820`.
- Fix hanging the interpreter on shutdown if gevent monkey patching
  occurred on a non-main thread in Python 3.9.8 and above. (Note that
  this is not a recommended practice.)
  See :issue:`1839`.


```


greenlet changelog

```rst
2.0.1 (2022-11-07)
==================

- Python 3.11: Fix a memory leak. See `issue 328
  <https://github.com/python-greenlet/greenlet/issues/328>`_ and
  `gevent issue 1924 <https://github.com/gevent/gevent/issues/1924>`_.


2.0.0.post0 (2022-11-03)
========================

- Add ``Programming Language :: Python :: 3.11`` to the PyPI
  classifier metadata.


2.0.0 (2022-10-31)
==================

- Nothing changed yet.


2.0.0rc5 (2022-10-31)
=====================

- Linux: Fix another group of rare crashes that could occur when shutting down an
  interpeter running multiple threads. See `issue 325 <https://github.com/python-greenlet/greenlet/issues/325>`_.


2.0.0rc4 (2022-10-30)
=====================

- Linux: Fix a rare crash that could occur when shutting down an
  interpreter running multiple threads, when some of those threads are
  in greenlets making calls to functions that release the GIL.


2.0.0rc3 (2022-10-29)
=====================

- Python 2: Fix a crash that could occur when raising an old-style
  instance object.


2.0.0rc2 (2022-10-28)
=====================

- Workaround `a CPython 3.8 bug
  <https://github.com/python/cpython/issues/81308>`_ that could cause
  the interpreter to crash during an early phase of shutdown with the
  message "Fatal Python error: Python memory allocator called without
  holding the GI." This only impacted CPython 3.8a3 through CPython
  3.9a5; the fix is only applied to CPython 3.8 releases (please don't
  use an early alpha release of CPython 3.9).


2.0.0rc1 (2022-10-27)
=====================

- Deal gracefully with greenlet switches that occur while deferred
  deallocation of objects is happening using CPython's "trash can"
  mechanism. Previously, if a large nested container held items that
  switched greenlets during delayed deallocation, and that second
  greenlet also invoked the trash can, CPython's internal state could
  become corrupt. This was visible as an assertion error in debug
  builds. Now, the relevant internal state is saved and restored
  during greenlet switches. See also `gevent issue 1909
  <https://github.com/gevent/gevent/issues/1909>`_.
- Rename the C API function ``PyGreenlet_GET_PARENT`` to
  ``PyGreenlet_GetParent`` for consistency. The old name remains
  available as a deprecated alias.



2.0.0a2 (2022-03-24)
====================

- Fix a crash on older versions of the Windows C runtime when an
  unhandled C++ exception was thrown inside a greenlet by another
  native extension. This is a bug in that extension, and the
  interpreter will still abort, but at least it does so deliberately.
  Thanks to Kirill Smelkov. See `PR 286
  <https://github.com/python-greenlet/greenlet/pull/286>`_.
- Musllinux wheels for aarch64 are now built, tested, and uploaded to
  PyPI. Thanks to Alexander Piskun.
- This version of greenlet is known to compile and pass tests on
  CPython 3.11.0a6. Earlier 3.11 releases will not work; later
  releases may or may not work. See `PR 294
  <https://github.com/python-greenlet/greenlet/pull/294>`_. Special
  thanks to Victor Stinner, Brandt Bucher and the CPython developers.


2.0.0a1 (2022-01-20)
====================

Platforms
---------

- Add experimental, untested support for 64-bit Windows on ARM using
  MSVC. See `PR 271 <https://github.com/python-greenlet/greenlet/pull/271>`_.

- Drop support for very old versions of GCC and MSVC.

- Compilation now requires a compiler that either supports C++11 or
  has some other intrinsic way to create thread local variables; for
  older GCC, clang and SunStudio we use ``__thread``, while for older
  MSVC we use ``__declspec(thread)``.

- Wheels compatible with the musllinux specification are built,
  tested, and uploaded to PyPI for x86_64. (This was retroactively
  done for version 1.1.2 as well.)

- This version of greenlet is known to compile and pass tests on
  CPython 3.11.0a4. Earlier or later 3.11 releases may or may not
  work. See `PR 280
  <https://github.com/python-greenlet/greenlet/pull/280>`_. Special
  thanks to Brandt Bucher and the CPython developers.

Fixes
-----

- Fix several leaks that could occur when using greenlets from
  multiple threads. For example, it is no longer necessary to call
  ``getcurrent()`` before exiting a thread to allow its main greenlet
  to be cleaned up. See `issue 252 <https://github.com/python-greenlet/greenlet/issues/251>`_.

- Fix the C API ``PyGreenlet_Throw`` to perform the same error
  checking that the Python API ``greenlet.throw()`` does. Previously,
  it did no error checking.

- Fix C++ exception handling on 32-bit Windows. This might have
  ramifications if you embed Python in your application and also use
  SEH on 32-bit windows, or if you embed Python in a C++ application.
  Please contact the maintainers if you have problems in this area.

  In general, C++ exception handling is expected to be better on most
  platforms. This work is ongoing.

Changes
-------

- The repr of some greenlets has changed. In particular, if the
  greenlet object was running in a thread that has exited, the repr
  now indicates that. *NOTE:* The repr of a greenlet is not part of
  the API and should not be relied upon by production code. It is
  likely to differ in other implementations such as PyPy.

- Main greenlets from threads that have exited are now marked as dead.


1.1.3.post0 (2022-10-10)
========================

- Add musllinux (Alpine) binary wheels.

.. important:: This preliminary support for Python 3.11 leaks memory.
               Please upgrade to greenlet 2 if you're using Python 3.11.

1.1.3 (2022-08-25)
==================

- Add support for Python 3.11. Please note that Windows binary wheels
  are not available at this time.

.. important:: This preliminary support for Python 3.11 leaks memory.
               Please upgrade to greenlet 2 if you're using Python 3.11.
```