### PR TITLE
Microsoft: Calendar gone when subscribing

### DIFF
--- a/inbox/events/abstract.py
+++ b/inbox/events/abstract.py
@@ -109,3 +109,7 @@ class AbstractEventsProvider(abc.ABC):
             return token_manager.get_token(
                 acc, force_refresh=force_refresh, scopes=scopes
             )
+
+
+class CalendarGoneException(Exception):
+    pass


### PR DESCRIPTION
Sometimes calendar can be deleted between the point in time we see it in the calendar list and when we subscribe to changes in that calendar. If this happens with Microsoft we get a Rollbar currently. The code we already had handled it for Google by looking at the HTTP response code but you get different exceptions for Google and Microsoft. I've hidden both cases behind CalendarGoneException, as the code that handles this case should not be aware of the fact that providers use HTTP.