### PR TITLE
Filter out bogus integer flags in GMail

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -71,16 +71,18 @@ __all__ = ["CrispinClient", "GmailCrispinClient"]
 
 
 # Unify flags API across IMAP and Gmail
-Flags = namedtuple("Flags", "flags modseq")
-# class Flags(NamedTuple):
-#     flags: Tuple[bytes, ...]
-#     modseq: Optional[int]
+class Flags(NamedTuple):
+    flags: Tuple[bytes, ...]
+    modseq: Optional[int]
+
+
 # Flags includes labels on Gmail because Gmail doesn't use \Draft.
-GmailFlags = namedtuple("GmailFlags", "flags labels modseq")
-# class GmailFlags(NamedTuple):
-#     flags: Tuple[bytes, ...]
-#     labels: List[str]
-#     modseq: Optional[int]
+class GmailFlags(NamedTuple):
+    flags: Tuple[bytes, ...]
+    labels: List[str]
+    modseq: Optional[int]
+
+
 GMetadata = namedtuple("GMetadata", "g_msgid g_thrid size")
 
 
@@ -1102,7 +1104,7 @@ class GmailCrispinClient(CrispinClient):
         uid_set = set(uids)
         return {
             uid: GmailFlags(
-                ret[b"FLAGS"],
+                tuple(flag for flag in ret[b"FLAGS"] if isinstance(flag, bytes)),
                 self._decode_labels(ret[b"X-GM-LABELS"]),
                 ret[b"MODSEQ"][0] if b"MODSEQ" in ret else None,
             )
@@ -1132,7 +1134,7 @@ class GmailCrispinClient(CrispinClient):
                     continue
                 ret = data_for_uid[uid]
             results[uid] = GmailFlags(
-                ret[b"FLAGS"],
+                tuple(flag for flag in ret[b"FLAGS"] if isinstance(flag, bytes)),
                 self._decode_labels(ret[b"X-GM-LABELS"]),
                 ret[b"MODSEQ"][0],
             )

--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -188,6 +188,17 @@ def test_gmail_flags(gmail_client, constants):
     assert gmail_client.flags([uid]) == {uid: GmailFlags(flags, g_labels, modseq)}
 
 
+def test_gmail_bogus_integer_flags(gmail_client, constants):
+    expected_resp = (
+        "{seq} (FLAGS (123 asd) X-GM-LABELS () "
+        "UID {uid} MODSEQ ({modseq}))".format(**constants)
+    ).encode()
+    patch_imap4(gmail_client, [expected_resp])
+    uid = constants["uid"]
+    modseq = constants["modseq"]
+    assert gmail_client.flags([uid]) == {uid: GmailFlags((b"asd",), [], modseq)}
+
+
 def test_g_msgids(gmail_client, constants):
     expected_resp = (
         "{seq} (X-GM-MSGID {g_msgid} "


### PR DESCRIPTION
This is rollbaring for some accounts in production.

IMAP flags store additional metadata, like `b"\\Seen"` meaning that the email appears as opened in your mail program. Sometimes we get garbage flags that are integers, and this breaks code further down the road. We don't care about those and we can just filter them out.