### PR TITLE
Microsoft: Probe if subscriptions work in webhook_notifications_enabled

### DIFF
--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -203,6 +203,18 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
     def webhook_notifications_enabled(self, account: Account) -> bool:
         """
         Return True if webhook notifications are enabled for a given account.
+
+        This works by creating a dummy subscription and then immediately deleting
+        it. We found that in practice subscriptions don't work for
+        some accounts. There are some theories on the internet
+        why it does not work i.e.: Office365 administrator applying a restrictive
+        policy or some weird setup when the calendars might still be on on-premise
+        servers but everything else in Azure. Microsoft does not give a definite answer,
+        so we can only speculate.
+
+        For more context see:
+        * https://learn.microsoft.com/en-us/answers/questions/417261/error-on-adding-subscription-on-events-using-ms-gr.html
+        * https://stackoverflow.com/questions/65030751/ms-graph-adding-subscription-returns-extensionerror-and-serviceunavailable
         """
         try:
             dummy_subscription = self.client.subscribe_to_calendar_changes(

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -49,7 +49,9 @@ class EventSync(BaseSyncMonitor):
     ):
         bind_context(self, "eventsync", account_id)
         self.provider = provider_class(account_id, namespace_id)
-        self.log = logger.new(account_id=account_id, component="calendar sync")
+        self.log = logger.new(
+            account_id=account_id, component="calendar sync", provider=provider_name
+        )
 
         BaseSyncMonitor.__init__(
             self,
@@ -294,6 +296,7 @@ class WebhookEventSync(EventSync):
             account = db_session.query(Account).get(self.account_id)
 
             if not self.provider.webhook_notifications_enabled(account):
+                self.log.warning("Webhook notifications disabled")
                 return
 
             if account.needs_new_calendar_list_watch():

--- a/tests/events/microsoft/test_events_provider.py
+++ b/tests/events/microsoft/test_events_provider.py
@@ -224,6 +224,20 @@ def subscribe_responses():
 
 
 @pytest.fixture
+def subscribe_response_unavailable():
+    responses.post(
+        BASE_URL + "/subscriptions",
+        json={
+            "error": {
+                "code": "ExtensionError",
+                "message": "Operation: Create; Exception: [Status Code: ServiceUnavailable; Reason: Target resource '00034001-1143-5852-0000-000000000000' hosted on database 'f2492f38-40a7-4de1-ae51-48a6f2c9589b' is currently on backend 'Unknown']",
+            }
+        },
+        status=403,
+    )
+
+
+@pytest.fixture
 def subscribe_response_gone():
     responses.post(
         BASE_URL + "/subscriptions",
@@ -514,8 +528,14 @@ def test_watch_calendar_gone(provider, outlook_account):
 
 @responses.activate
 @pytest.mark.usefixtures("subscribe_responses")
-def test_webhook_notifications_enabled(provider, outlook_account):
+def test_webhook_notifications_enabled_avaialble(provider, outlook_account):
     assert provider.webhook_notifications_enabled(outlook_account)
+
+
+@responses.activate
+@pytest.mark.usefixtures("subscribe_response_unavailable")
+def test_webhook_notifications_enabled_unavailable(provider, outlook_account):
+    assert not provider.webhook_notifications_enabled(outlook_account)
 
 
 @responses.activate

--- a/tests/events/microsoft/test_events_provider.py
+++ b/tests/events/microsoft/test_events_provider.py
@@ -220,6 +220,8 @@ def subscribe_responses():
         ],
     )
 
+    responses.delete(BASE_URL + "/subscriptions/f798ca9d-d630-4306-b065-af52199f5613",)
+
 
 @pytest.fixture
 def subscribe_response_gone():
@@ -510,6 +512,8 @@ def test_watch_calendar_gone(provider, outlook_account):
         provider.watch_calendar(outlook_account, calendar)
 
 
+@responses.activate
+@pytest.mark.usefixtures("subscribe_responses")
 def test_webhook_notifications_enabled(provider, outlook_account):
     assert provider.webhook_notifications_enabled(outlook_account)
 


### PR DESCRIPTION
This is currently rollbaring for one account in production.

Sync-engine has two modes for syncing calendar:
* polling changes since last time it synced something, this has more delay of course 
* listening to webhooks, almost instant
	
Depending on what you return from ` webhook_notifications_enabled` it will do one of those two things.

For Microsoft I expected subscriptions to always work, but it turns out that it does not always work in practice. We can still fetch events and calendars but not create subscriptions in this case.

As explained in the docstring:

We found that in practice subscriptions don't work for some accounts. There are some theories on the internet why it does not work i.e.: Office365 administrator applying a restrictive policy or some weird setup when the calendars might still be on on-premise servers but everything else in Azure. Microsoft does not give a definite answer, so we can only speculate.

For more context see:
* https://learn.microsoft.com/en-us/answers/questions/417261/error-on-adding-subscription-on-events-using-ms-gr.html
* https://stackoverflow.com/questions/65030751/ms-graph-adding-subscription-returns-extensionerror-and-serviceunavailable


The good news is that we can fallback to polling mode and still sync those calendars/events. Just slower and with more overhead.