### PR TITLE
Switch CircleCI runner to 22.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
         default: true
         description: Set to false to disable pushing image
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:current
     resource_class: <<parameters.resource_class>>
     working_directory: ~/sync-engine
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
        - MINIO_DOMAIN=minio
 
   app:
+    image: sync-engine_app
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This is in preparation for Ubuntu 22.04. Note that this only changes the CircleCI runner image, and not Dockerfile for now.