### PR TITLE
Don't ORDER BY when SELECT COUNT(*)

### DIFF
--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -129,7 +129,6 @@ with contextlib.suppress(ImportError):
     # test failure.
     from inbox.util.eas.codes import STORE_STATUS_CODES
 
-
 from inbox.logging import get_logger
 
 log = get_logger()
@@ -735,11 +734,11 @@ def folders_labels_query_api():
     results = results.filter(
         Category.namespace_id == g.namespace.id, Category.deleted_at == EPOCH
     )
-    results = results.order_by(asc(Category.id))
 
     if args["view"] == "count":
         return g.encoder.jsonify({"count": results.scalar()})
 
+    results = results.order_by(asc(Category.id))
     results = results.limit(args["limit"]).offset(args["offset"]).all()
     if args["view"] == "ids":
         return g.encoder.jsonify([r for r, in results])
@@ -978,9 +977,7 @@ def contact_api():
 
     if args["filter"]:
         results = results.filter(Contact.email_address == args["filter"])
-    results = results.with_hint(Contact, "USE INDEX (idx_namespace_created)").order_by(
-        asc(Contact.created_at)
-    )
+    results = results.with_hint(Contact, "USE INDEX (idx_namespace_created)")
 
     if args["view"] == "count":
         return g.encoder.jsonify({"count": results.scalar()})
@@ -991,6 +988,7 @@ def contact_api():
             joinedload(Contact.phone_numbers),
         )
 
+    results = results.order_by(asc(Contact.created_at))
     results = results.limit(args["limit"]).offset(args["offset"]).all()
     if args["view"] == "ids":
         return g.encoder.jsonify([r for r, in results])
@@ -1598,13 +1596,12 @@ def calendar_api():
     else:
         query = g.db_session.query(Calendar)
 
-    results = query.filter(Calendar.namespace_id == g.namespace.id).order_by(
-        asc(Calendar.id)
-    )
+    results = query.filter(Calendar.namespace_id == g.namespace.id)
 
     if args["view"] == "count":
         return g.encoder.jsonify({"count": results.scalar()})
 
+    results = results.order_by(asc(Calendar.id))
     results = results.limit(args["limit"]).offset(args["offset"]).all()
     if args["view"] == "ids":
         return g.encoder.jsonify([r for r, in results])


### PR DESCRIPTION
Sync-engine offers APIs that can return counts of the rows and row data.

When running `SELECT COUNT(*) FROM table WHERE ...` it normally does not make sense to add `ORDER BY` clauses since there is only one result. 

---

MySQL is lax on this and it will happily let you do it, even though it does not make sense:

```SQL
select COUNT(*) from 
(
   SELECT 1 AS val
   UNION ALL
   SELECT 2 AS val
   UNION ALL 
   SELECT 3 AS val
) something ORDER BY val DESC;
```

| COUNT(*) |
| -------- |
| 3        |

---


but PostgreSQL will *rightly* complain, because you need `GROUP BY` to have more than one result and something to sort on:

```SQL
select COUNT(*) from 
(
   SELECT 1 AS val
   UNION ALL
   SELECT 2 AS val
   UNION ALL 
   SELECT 3 AS val
) something ORDER BY val DESC;
```

`Query Error: error: column "something.val" must appear in the GROUP BY clause or be used in an aggregate function`

---

The APIs currently add `ORDER BY` clauses even it you are running `SELECT COUNT(*)` queries which does nothing on MySQL but triggers errors on PostgreSQL. I changed the code to only add `ORDER BY` when we don't run `SELECT COUNT(*)` which makes it more portable and runs correctly both on MySQL and PostgreSQL.


