### PR TITLE
Bump cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,13 +11,13 @@ boto3==1.19.4
 botocore==1.22.9
 cchardet==2.1.7
 certifi==2022.12.7
-cffi==1.14.6
+cffi==1.15.1
 chardet==3.0.4
 charset-normalizer==2.0.7
 ciso8601==2.2.0
 click==7.1.2
 colorlog==6.5.0
-cryptography==36.0.0
+cryptography==38.0.4
 decorator==5.1.0
 dnspython==2.1.0
 filelock==3.4.0


### PR DESCRIPTION
> 38.0.3 - 2022-11-01
>
> Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.7, which resolves CVE-2022-3602 and CVE-2022-3786.

Flanker uses cryptography to optionally [sign email messages](https://github.com/closeio/flanker-new/blob/63d1cdf927777f49f97e8d7f01e105a3b0d25cd2/docs/User%20Manual.md#dkim). We don't send emails from sync-engine so this should have no impact.

Bumped cffi at the same time as it's always backward compatible package.

Changelog

```rst
38.0.4 - 2022-11-27

    Fixed compilation when using LibreSSL 3.6.0.
    Fixed error when using py2app to build an application with a cryptography dependency.

38.0.3 - 2022-11-01

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.7, which resolves CVE-2022-3602 and CVE-2022-3786.

38.0.2 - 2022-10-11 (YANKED)

Attention!

This release was subsequently yanked from PyPI due to a regression in OpenSSL.

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.6.

38.0.1 - 2022-09-07

    Fixed parsing TLVs in ASN.1 with length greater than 65535 bytes (typically seen in large CRLs).

38.0.0 - 2022-09-06

    Final deprecation of OpenSSL 1.1.0. The next release of cryptography will drop support.
    We no longer ship manylinux2010 wheels. Users should upgrade to the latest pip to ensure this doesn't cause issues downloading wheels on their platform. We now ship manylinux_2_28 wheels for users on new enough platforms.
    Updated the minimum supported Rust version (MSRV) to 1.48.0, from 1.41.0. Users with the latest pip will typically get a wheel and not need Rust installed, but check [:doc:`/installation`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id29) for documentation on installing a newer rustc if required.
    [:meth:`~cryptography.fernet.Fernet.decrypt`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id31) and related methods now accept both str and bytes tokens.
    Parsing CertificateSigningRequest restores the behavior of enforcing that the Extension critical field must be correctly encoded DER. See https://github.com/pyca/cryptography/issues/6368 for complete details.
    Added two new OpenSSL functions to the bindings to support an upcoming pyOpenSSL release.
    When parsing [:class:`~cryptography.x509.CertificateRevocationList`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id33) and [:class:`~cryptography.x509.CertificateSigningRequest`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id35) values, it is now enforced that the version value in the input must be valid according to the rules of [RFC 2986](http://tools.ietf.org/html/rfc2986.html) and [RFC 5280](http://tools.ietf.org/html/rfc5280.html).
    Using MD5 or SHA1 in [:class:`~cryptography.x509.CertificateBuilder`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id37) and other X.509 builders is deprecated and support will be removed in the next version.
    Added additional APIs to [:class:`~cryptography.x509.certificate_transparency.SignedCertificateTimestamp`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id39), including [:attr:`~cryptography.x509.certificate_transparency.SignedCertificateTimestamp.signature_hash_algorithm`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id41), [:attr:`~cryptography.x509.certificate_transparency.SignedCertificateTimestamp.signature_algorithm`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id43), [:attr:`~cryptography.x509.certificate_transparency.SignedCertificateTimestamp.signature`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id45), and [:attr:`~cryptography.x509.certificate_transparency.SignedCertificateTimestamp.extension_bytes`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id47).
    Added [:attr:`~cryptography.x509.Certificate.tbs_precertificate_bytes`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id49), allowing users to access the to-be-signed pre-certificate data needed for signed certificate timestamp verification.
    [:class:`~cryptography.hazmat.primitives.kdf.kbkdf.KBKDFHMAC`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id51) and [:class:`~cryptography.hazmat.primitives.kdf.kbkdf.KBKDFCMAC`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id53) now support [:attr:`~cryptography.hazmat.primitives.kdf.kbkdf.CounterLocation.MiddleFixed`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id55) counter location.
    Fixed [RFC 4514](http://tools.ietf.org/html/rfc4514.html) name parsing to reverse the order of the RDNs according to the section 2.1 of the RFC, affecting method [:meth:`~cryptography.x509.Name.from_rfc4514_string`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id57).
    It is now possible to customize some aspects of encryption when serializing private keys, using [:meth:`~cryptography.hazmat.primitives.serialization.PrivateFormat.encryption_builder`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id59).
    Removed several legacy symbols from our OpenSSL bindings. Users of pyOpenSSL versions older than 22.0 will need to upgrade.
    Added [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES128`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id61) and [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES256`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id63) classes. These classes do not replace [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.AES`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id65) (which allows all AES key lengths), but are intended for applications where developers want to be explicit about key length.

37.0.4 - 2022-07-05

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.5.

37.0.3 - 2022-06-21 (YANKED)

Attention!

This release was subsequently yanked from PyPI due to a regression in OpenSSL.

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.4.

37.0.2 - 2022-05-03

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.3.
    Added a constant needed for an upcoming pyOpenSSL release.

37.0.1 - 2022-04-27

    Fixed an issue where parsing an encrypted private key with the public loader functions would hang waiting for console input on OpenSSL 3.0.x rather than raising an error.
    Restored some legacy symbols for older pyOpenSSL users. These will be removed again in the future, so pyOpenSSL users should still upgrade to the latest version of that package when they upgrade cryptography.

37.0.0 - 2022-04-26

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.2.
    BACKWARDS INCOMPATIBLE: Dropped support for LibreSSL 2.9.x and 3.0.x. The new minimum LibreSSL version is 3.1+.
    BACKWARDS INCOMPATIBLE: Removed signer and verifier methods from the public key and private key classes. These methods were originally deprecated in version 2.0, but had an extended deprecation timeline due to usage. Any remaining users should transition to sign and verify.
    Deprecated OpenSSL 1.1.0 support. OpenSSL 1.1.0 is no longer supported by the OpenSSL project. The next release of cryptography will be the last to support compiling with OpenSSL 1.1.0.
    Deprecated Python 3.6 support. Python 3.6 is no longer supported by the Python core team. Support for Python 3.6 will be removed in a future cryptography release.
    Deprecated the current minimum supported Rust version (MSRV) of 1.41.0. In the next release we will raise MSRV to 1.48.0. Users with the latest pip will typically get a wheel and not need Rust installed, but check [:doc:`/installation`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id72) for documentation on installing a newer rustc if required.
    Deprecated [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.CAST5`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id74), [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.SEED`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id76), [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.IDEA`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id78), and [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.Blowfish`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id80) because they are legacy algorithms with extremely low usage. These will be removed in a future version of cryptography.
    Added limited support for distinguished names containing a bit string.
    We now ship universal2 wheels on macOS, which contain both arm64 and x86_64 architectures. Users on macOS should upgrade to the latest pip to ensure they can use this wheel, although we will continue to ship x86_64 specific wheels for now to ease the transition.
    This will be the final release for which we ship manylinux2010 wheels. Going forward the minimum supported manylinux ABI for our wheels will be manylinux2014. The vast majority of users will continue to receive manylinux wheels provided they have an up to date pip. For PyPy wheels this release already requires manylinux2014 for compatibility with binaries distributed by upstream.
    Added support for multiple [:class:`~cryptography.x509.ocsp.OCSPSingleResponse`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id82) in a [:class:`~cryptography.x509.ocsp.OCSPResponse`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id84).
    Restored support for signing certificates and other structures in [:doc:`/x509/index`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id86) with SHA3 hash algorithms.
    [:class:`~cryptography.hazmat.primitives.ciphers.algorithms.TripleDES`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id88) is disabled in FIPS mode.
    Added support for serialization of PKCS#12 CA friendly names/aliases in [:func:`~cryptography.hazmat.primitives.serialization.pkcs12.serialize_key_and_certificates`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id90)
    Added support for 12-15 byte (96 to 120 bit) nonces to [:class:`~cryptography.hazmat.primitives.ciphers.aead.AESOCB3`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id92). This class previously supported only 12 byte (96 bit).
    Added support for [:class:`~cryptography.hazmat.primitives.ciphers.aead.AESSIV`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id94) when using OpenSSL 3.0.0+.
    Added support for serializing PKCS7 structures from a list of certificates with [:class:`~cryptography.hazmat.primitives.serialization.pkcs7.serialize_certificates`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id96).
    Added support for parsing [RFC 4514](http://tools.ietf.org/html/rfc4514.html) strings with [:meth:`~cryptography.x509.Name.from_rfc4514_string`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id98).
    Added [:attr:`~cryptography.hazmat.primitives.asymmetric.padding.PSS.AUTO`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id100) to [:class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id102). This can be used to verify a signature where the salt length is not already known.
    Added [:attr:`~cryptography.hazmat.primitives.asymmetric.padding.PSS.DIGEST_LENGTH`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id104) to [:class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id106). This constant will set the salt length to the same length as the PSS hash algorithm.
    Added support for loading RSA-PSS key types with [:func:`~cryptography.hazmat.primitives.serialization.load_pem_private_key`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id108) and [:func:`~cryptography.hazmat.primitives.serialization.load_der_private_key`](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#id110). This functionality is limited to OpenSSL 1.1.1e+ and loads the key as a normal RSA private key, discarding the PSS constraint information.

36.0.2 - 2022-03-15

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 1.1.1n.

36.0.1 - 2021-12-14

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 1.1.1m.
```

Reverse dependencies:
```
cryptography==36.0.0
  - flanker==0.9.11 [requires: cryptography>=0.5]
```

Forward dependencies:
```
cryptography==36.0.0
  - cffi [required: >=1.12, installed: 1.14.6]
    - pycparser [required: Any, installed: 2.21]
```