### PR TITLE
Microsoft: handle sporadic underlying connection was closed, cache webhook_notifications_enabled

### DIFF
--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -73,6 +73,7 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
         self.client = MicrosoftGraphClient(
             lambda: self._get_access_token(scopes=MICROSOFT_CALENDAR_SCOPES)
         )
+        self._webhook_notifications_enabled: Optional[bool] = None
 
     def sync_calendars(self) -> CalendarSyncResponse:
         """
@@ -216,6 +217,10 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
         * https://learn.microsoft.com/en-us/answers/questions/417261/error-on-adding-subscription-on-events-using-ms-gr.html
         * https://stackoverflow.com/questions/65030751/ms-graph-adding-subscription-returns-extensionerror-and-serviceunavailable
         """
+
+        if self._webhook_notifications_enabled is not None:
+            return self._webhook_notifications_enabled
+
         try:
             dummy_subscription = self.client.subscribe_to_calendar_changes(
                 webhook_url=CALENDAR_LIST_WEBHOOK_URL.format(account.public_id),
@@ -227,6 +232,7 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
                 message == "ExtensionError"
                 and "is currently on backend 'Unknown'" in description
             ):
+                self._webhook_notifications_enabled = False
                 return False
 
             raise
@@ -234,6 +240,7 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
         subscription_id = cast(MsGraphSubscription, dummy_subscription)["id"]
         self.client.unsubscribe(subscription_id)
 
+        self._webhook_notifications_enabled = True
         return True
 
     def watch_calendar_list(self, account: Account) -> Optional[datetime.datetime]:

--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -206,8 +206,8 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
         Return True if webhook notifications are enabled for a given account.
 
         This works by creating a dummy subscription and then immediately deleting
-        it. We found that in practice subscriptions don't work for
-        some accounts. There are some theories on the internet
+        it, subsequent calls use cached value. We found that in practice subscriptions
+        don't work for some accounts. There are some theories on the internet
         why it does not work i.e.: Office365 administrator applying a restrictive
         policy or some weird setup when the calendars might still be on on-premise
         servers but everything else in Azure. Microsoft does not give a definite answer,
@@ -218,6 +218,8 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
         * https://stackoverflow.com/questions/65030751/ms-graph-adding-subscription-returns-extensionerror-and-serviceunavailable
         """
 
+        # First check if we already have cached value since this function is called
+        # repeatedly and there is no need to do extra HTTP request every time.
         if self._webhook_notifications_enabled is not None:
             return self._webhook_notifications_enabled
 


### PR DESCRIPTION
This takes care of two things:

- When I changed `webhook_notifications_enabled` to create a dummy subscription and then delete it I did not realize this is called periodically in a loop. We need to do it only once to know if we are on unlucky account, then we can just cache it.

- We sporadically get `The underlying connection was closed: A connection that was expected to be kept alive was closed by the server.`. We get this when subscribing to notifications over webhooks Microsoft makes an initial contact with webhook url. This is safe to retry.