### PR TITLE
Make selecting categories for generic accounts deteministic.

### DIFF
--- a/inbox/models/account.py
+++ b/inbox/models/account.py
@@ -1,6 +1,7 @@
 import os
 import traceback
 from datetime import datetime
+from typing import Literal
 
 from sqlalchemy import (
     BigInteger,
@@ -44,6 +45,9 @@ log = get_logger()
 # GmailAccount
 
 
+CategoryType = Literal["folder", "label"]
+
+
 class Account(
     MailSyncBase,
     HasPublicID,
@@ -75,7 +79,7 @@ class Account(
         return self.provider
 
     @property
-    def category_type(self):
+    def category_type(self) -> CategoryType:
         """
         Whether the account is organized by folders or labels
         ('folder'/ 'label'), depending on the provider.

--- a/inbox/models/backends/generic.py
+++ b/inbox/models/backends/generic.py
@@ -3,6 +3,7 @@ from typing import Union
 from sqlalchemy import Boolean, Column, ForeignKey, String
 from sqlalchemy.orm import relationship
 
+from inbox.models.account import CategoryType
 from inbox.models.backends.imap import ImapAccount
 from inbox.models.secret import Secret
 
@@ -103,7 +104,7 @@ class GenericAccount(ImapAccount):
         self.smtp_secret.type = "password"
 
     @property
-    def category_type(self):
+    def category_type(self) -> CategoryType:
         if self.provider == "gmail":
             return "label"
         else:

--- a/inbox/models/backends/gmail.py
+++ b/inbox/models/backends/gmail.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, ForeignKey, String
 
 from inbox.config import config
 from inbox.logging import get_logger
+from inbox.models.account import CategoryType
 from inbox.models.backends.calendar_sync_account import CalendarSyncAccountMixin
 from inbox.models.backends.imap import ImapAccount
 from inbox.models.backends.oauth import OAuthAccount
@@ -47,7 +48,7 @@ class GmailAccount(CalendarSyncAccountMixin, OAuthAccount, ImapAccount):
         return PROVIDER
 
     @property
-    def category_type(self):
+    def category_type(self) -> CategoryType:
         return "label"
 
     @property

--- a/inbox/models/backends/imap.py
+++ b/inbox/models/backends/imap.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import List
+from typing import List, Set
 
 from sqlalchemy import (
     BigInteger,
@@ -22,6 +22,7 @@ from sqlalchemy.sql.expression import false
 from inbox.logging import get_logger
 from inbox.models.account import Account
 from inbox.models.base import MailSyncBase
+from inbox.models.category import Category
 from inbox.models.folder import Folder
 from inbox.models.label import Label
 from inbox.models.message import Message
@@ -209,8 +210,8 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
         return self.imapaccount.namespace
 
     @property
-    def categories(self):
-        categories = {lbl.category for lbl in self.labels}
+    def categories(self) -> Set[Category]:
+        categories = {label.category for label in self.labels}
         categories.add(self.folder.category)
         return categories
 

--- a/inbox/models/backends/outlook.py
+++ b/inbox/models/backends/outlook.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, ForeignKey, String
 
 from inbox.config import config
+from inbox.models.account import CategoryType
 from inbox.models.backends.calendar_sync_account import CalendarSyncAccountMixin
 from inbox.models.backends.imap import ImapAccount
 from inbox.models.backends.oauth import OAuthAccount
@@ -60,7 +61,7 @@ class OutlookAccount(CalendarSyncAccountMixin, ImapAccount, OAuthAccount):
         return PROVIDER
 
     @property
-    def category_type(self):
+    def category_type(self) -> CategoryType:
         return "folder"
 
     @property


### PR DESCRIPTION
This fixes the problem that for some accounts archived messages will randomly come back to inbox.

Long story short an IMAP message on generic (non-google) account can be only in a single folder. But for some of the on-prem IMAP servers (at least Dovecot according to my investigation) we are not able to reliably detect the fact that the message was moved from one folder to another (for example from inbox to archive) and it ends up in our database as if it was in those two folders at the same time (inbox, archive). This is never true in practice. I spent a lot of time trying to figure out why we cannot detect those moves, and we should keep investigating that but there's an intermittent solution that makes it easier on our customers.

The previous code would just select one of the folders, and it would depend on the order they came from the database as they were not sorted in any way. So from the CRM point of view when queried using API it could keep alternating between inbox and archive pseudo-randomly, which causes an annoying problem of old messages reappearing in CRM inbox. In practice the message is in the folder it was added to last, so by sorting it by updated_at we get consistent and correct behavior despite not fixing the core problem.

I sprinkled some types at the same time around, the real changes are in [this commit](https://github.com/closeio/sync-engine/pull/467/commits/fc96730e2a09ef48816e32220b3c4b46aeed3785), if it makes it easier to review.