### PR TITLE
Implement detection for German Archive folder

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -698,6 +698,7 @@ class CrispinClient:
             "junk": "spam",
             "spam": "spam",
             "archive": "archive",
+            "archiv": "archive",
             "sent": "sent",
             "sent items": "sent",
             "trash": "trash",


### PR DESCRIPTION
The backstory:

One of our customers complained that "Done" button in email thread does not move their email to Archive folder. That button is supposed to mark the email as read and move it to Archive folder. It was only marking it as read.

The investigation:

I quickly found out that we are not able to identify Archive (Archiv in German) folder in German Outlook as it uses folder names in German. I was able to reproduce the same problem with outlook.de domain email myself. We assign roles to folders based on IMAP flags (think tags) and names. In case of Archive there are no standard IMAP flags so we do it by name but we don't take into account German name. This fixes it.

As always this is a gradual improvement as we cannot possibly know all the cases here. A lot of clients translate names only in UI and use English names in IMAP, but at least German Outlook uses names in German internally.