### PR TITLE
Bump cryptography to 39.0.1

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -17,7 +17,7 @@ charset-normalizer==2.0.7
 ciso8601==2.2.0
 click==7.1.2
 colorlog==6.5.0
-cryptography==38.0.4
+cryptography==39.0.1
 decorator==5.1.0
 dnspython==2.1.0
 filelock==3.4.0


### PR DESCRIPTION
Bumps cryptography because of CVE

We don't use crptography directly

Reverse dependencies

```
cryptography==36.0.0
  - flanker==0.9.11 [requires: cryptography>=0.5]
```

Flanker itself [only uses cryptogtaphy to do DKIM](https://github.com/mailgun/flanker/blob/2bb021ee48dd3aebe7bf2aac098df61d55fc299b/flanker/dkim.py) which concerns email sending and we don't send emails from sync-engine.

Changelog

```
.. _v39-0-1:

39.0.1 - 2023-02-07
~~~~~~~~~~~~~~~~~~~

* **SECURITY ISSUE** - Fixed a bug where ``Cipher.update_into`` accepted Python
  buffer protocol objects, but allowed immutable buffers. **CVE-2023-23931**
* Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.0.8.

.. _v39-0-0:

39.0.0 - 2023-01-01
~~~~~~~~~~~~~~~~~~~

* **BACKWARDS INCOMPATIBLE:** Support for OpenSSL 1.1.0 has been removed.
  Users on older version of OpenSSL will need to upgrade.
* **BACKWARDS INCOMPATIBLE:** Dropped support for LibreSSL < 3.5. The new
  minimum LibreSSL version is 3.5.0. Going forward our policy is to support
  versions of LibreSSL that are available in versions of OpenBSD that are
  still receiving security support.
* **BACKWARDS INCOMPATIBLE:** Removed the ``encode_point`` and
  ``from_encoded_point`` methods on
  :class:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicNumbers`,
  which had been deprecated for several years.
  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.public_bytes`
  and
  :meth:`~cryptography.hazmat.primitives.asymmetric.ec.EllipticCurvePublicKey.from_encoded_point`
  should be used instead.
* **BACKWARDS INCOMPATIBLE:** Support for using MD5 or SHA1 in
  :class:`~cryptography.x509.CertificateBuilder`, other X.509 builders, and
  PKCS7 has been removed.
* **BACKWARDS INCOMPATIBLE:** Dropped support for macOS 10.10 and 10.11, macOS
  users must upgrade to 10.12 or newer.
* **ANNOUNCEMENT:** The next version of ``cryptography`` (40.0) will change
  the way we link OpenSSL. This will only impact users who build
  ``cryptography`` from source (i.e., not from a ``wheel``), and specify their
  own version of OpenSSL. For those users, the ``CFLAGS``, ``LDFLAGS``,
  ``INCLUDE``, ``LIB``, and ``CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS`` environment
  variables will no longer be respected. Instead, users will need to
  configure their builds `as documented here`_.
* Added support for
  :ref:`disabling the legacy provider in OpenSSL 3.0.x<legacy-provider>`.
* Added support for disabling RSA key validation checks when loading RSA
  keys via
  :func:`~cryptography.hazmat.primitives.serialization.load_pem_private_key`,
  :func:`~cryptography.hazmat.primitives.serialization.load_der_private_key`,
  and
  :meth:`~cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateNumbers.private_key`.
  This speeds up key loading but is :term:`unsafe` if you are loading potentially
  attacker supplied keys.
* Significantly improved performance for
  :class:`~cryptography.hazmat.primitives.ciphers.aead.ChaCha20Poly1305`
  when repeatedly calling ``encrypt`` or ``decrypt`` with the same key.
* Added support for creating OCSP requests with precomputed hashes using
  :meth:`~cryptography.x509.ocsp.OCSPRequestBuilder.add_certificate_by_hash`.
* Added support for loading multiple PEM-encoded X.509 certificates from
  a single input via :func:`~cryptography.x509.load_pem_x509_certificates`.
  ```