### PR TITLE
Bump ipython to 8.10.0

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,10 +2,11 @@ alembic==1.7.5
 aniso8601==2.0.0
 arrow==0.17.0
 asn1crypto==0.24.0
+asttokens==2.2.1
 attrs==21.2.0
 git+https://github.com/closeio/authalligator-client.git@a3b176b333c33614988e698b432910cfe5bacdd7#egg=authalligator_client
 backcall==0.2.0
-jedi==0.18.1
+jedi==0.18.2
 boto==2.49.0
 boto3==1.19.4
 botocore==1.22.9
@@ -18,8 +19,9 @@ ciso8601==2.2.0
 click==7.1.2
 colorlog==6.5.0
 cryptography==38.0.4
-decorator==5.1.0
+decorator==5.1.1
 dnspython==2.1.0
+executing==1.2.0
 filelock==3.4.0
 git+https://github.com/closeio/flanker-new.git@fa272d95345d45e8bb1f9bc32bc2c074bf52a484#egg=flanker
 tld==0.12.6
@@ -37,8 +39,7 @@ idna==3.3
 imapclient==2.2.0
 importlib-metadata==4.8.1
 importlib-resources==5.4.0
-ipython==7.31.1
-ipython_genutils==0.2.0
+ipython==8.10.0
 itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==0.9.3
@@ -47,17 +48,18 @@ lxml==4.9.1
 --no-binary lxml
 Mako==1.2.2
 MarkupSafe==1.1.1
-matplotlib-inline==0.1.3 
+matplotlib-inline==0.1.6
 mysqlclient==1.3.14
-parso==0.8.2
+parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
 ply==3.11
 psutil==5.8.0
 ptyprocess==0.7.0
-prompt-toolkit==3.0.22
+prompt-toolkit==3.0.36
+pure-eval==0.2.2
 pycparser==2.21
-pygments==2.10.0
+pygments==2.14.0
 pyinstrument==3.2.0
 pyinstrument-cext==0.2.2
 pymongo==2.9.5  # For json_util in bson
@@ -76,13 +78,14 @@ setproctitle==1.2.2
 six==1.16.0
 sqlalchemy==1.4.26
 statsd==3.3.0
+stack-data==0.6.2
 tldextract==3.1.2
 structlog==21.4.0
-traitlets==4.3.3
+traitlets==5.9.0
 typing_extensions==4.0.1
 urllib3==1.26.10
 vobject==0.9.6.1
-wcwidth==0.2.5
+wcwidth==0.2.6
 WebOb==1.8.7
 Werkzeug==1.0.1
 zipp==3.6.0


### PR DESCRIPTION
Changelog: https://ipython.readthedocs.io/en/stable/whatsnew/version8.html

Fixes a CVE but apparently it's only exploitable on Windows.

Bumped all the packages down the tree at the same time.

```
ipython==8.10.0
  - backcall [required: Any, installed: 0.2.0]
  - decorator [required: Any, installed: 5.1.0]
  - jedi [required: >=0.16, installed: 0.18.1]
    - parso [required: >=0.8.0,<0.9.0, installed: 0.8.2]
  - matplotlib-inline [required: Any, installed: 0.1.3]
    - traitlets [required: Any, installed: 5.9.0]
  - pexpect [required: >4.3, installed: 4.8.0]
    - ptyprocess [required: >=0.5, installed: 0.7.0]
  - pickleshare [required: Any, installed: 0.7.5]
  - prompt-toolkit [required: >=3.0.30,<3.1.0, installed: 3.0.36]
    - wcwidth [required: Any, installed: 0.2.5]
  - pygments [required: >=2.4.0, installed: 2.10.0]
  - stack-data [required: Any, installed: 0.6.2]
    - asttokens [required: >=2.1.0, installed: 2.2.1]
      - six [required: Any, installed: 1.16.0]
    - executing [required: >=1.2.0, installed: 1.2.0]
    - pure-eval [required: Any, installed: 0.2.2]
  - traitlets [required: >=5, installed: 5.9.0]
 ```

I already confirmed that that the console works correctly after those updates.