### PR TITLE
Upgrade Flask to 2.0.3

### DIFF
--- a/inbox/webhooks/microsoft_notifications.py
+++ b/inbox/webhooks/microsoft_notifications.py
@@ -3,6 +3,7 @@ from typing import List, cast
 
 from flask import Blueprint, make_response, request
 from sqlalchemy.orm.exc import NoResultFound
+from werkzeug.exceptions import BadRequest
 
 from inbox.config import config
 from inbox.events.microsoft.graph_types import (
@@ -59,7 +60,10 @@ def validate_webhook_payload_factory(type: MsGraphType):
             have two separate endpoints, one for calendar changes and one for
             event changes.
             """
-            if request.json is None:
+
+            try:
+                request.json
+            except BadRequest:
                 return ("Malformed JSON payload", 400)
 
             change_notifications: List[MsGraphChangeNotification] = cast(

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -25,7 +25,7 @@ executing==1.2.0
 filelock==3.4.0
 git+https://github.com/closeio/flanker-new.git@fa272d95345d45e8bb1f9bc32bc2c074bf52a484#egg=flanker
 tld==0.12.6
-Flask==1.1.4
+Flask==2.0.3
 Flask-RESTful==0.3.9
 gdata==2.0.18
 gevent==22.10.2
@@ -40,14 +40,14 @@ imapclient==2.2.0
 importlib-metadata==4.8.1
 importlib-resources==5.4.0
 ipython==8.10.0
-itsdangerous==1.1.0
-Jinja2==2.11.3
+itsdangerous==2.1.2
+Jinja2==3.1.2
 jmespath==0.9.3
 limitlion==0.10.0
 lxml==4.9.1
 --no-binary lxml
 Mako==1.2.2
-MarkupSafe==1.1.1
+MarkupSafe==2.1.2
 matplotlib-inline==0.1.6
 mysqlclient==1.3.14
 parso==0.8.3
@@ -87,7 +87,7 @@ urllib3==1.26.10
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.7
-Werkzeug==1.0.1
+Werkzeug==2.2.3
 zipp==3.6.0
 zope.event==4.5.0
 zope.interface==5.4.0

--- a/tests/webhooks/test_microsoft_notifications.py
+++ b/tests/webhooks/test_microsoft_notifications.py
@@ -34,6 +34,26 @@ def test_validate_webhook_payload_malformed(test_client):
     assert response.status_code == 400
 
 
+def test_validate_webhook_payload_missing_content_type(test_client):
+    response = test_client.post(
+        "/w/microsoft/calendar_list_update/fake_id", data='{"value": []}'
+    )
+
+    assert response.data.decode() == "Malformed JSON payload"
+    assert response.status_code == 400
+
+
+def test_validate_webhook_payload_with_content_type(test_client):
+    response = test_client.post(
+        "/w/microsoft/calendar_list_update/fake_id",
+        data='{"value": []}',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.data.decode() == "Couldn't find account 'fake_id'"
+    assert response.status_code == 404
+
+
 bad_client_state_payload = {
     "value": [
         {


### PR DESCRIPTION
Note that Flask is already at 2.2.x, I'm upgrading minimally to have a version of Werkzeug that does not have [CVE](https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-3319936)

Also we don't use Jinja, itsdangerous or MarkupSafe in sync-engine.

I tested email sync, sync back and calendar sync extensively manually both locally and on one production cluster.

The only thing that broke is how Flask handles `request.json` without `Content-Type: application/json`

Flask changelog

```
Version 2.0.3
-------------

Released 2022-02-14

-   The test client's ``as_tuple`` parameter is deprecated and will be
    removed in Werkzeug 2.1. It is now also deprecated in Flask, to be
    removed in Flask 2.1, while remaining compatible with both in
    2.0.x. Use ``response.request.environ`` instead. :pr:`4341`
-   Fix type annotation for ``errorhandler`` decorator. :issue:`4295`
-   Revert a change to the CLI that caused it to hide ``ImportError``
    tracebacks when importing the application. :issue:`4307`
-   ``app.json_encoder`` and ``json_decoder`` are only passed to
    ``dumps`` and ``loads`` if they have custom behavior. This improves
    performance, mainly on PyPy. :issue:`4349`
-   Clearer error message when ``after_this_request`` is used outside a
    request context. :issue:`4333`


Version 2.0.2
-------------

Released 2021-10-04

-   Fix type annotation for ``teardown_*`` methods. :issue:`4093`
-   Fix type annotation for ``before_request`` and ``before_app_request``
    decorators. :issue:`4104`
-   Fixed the issue where typing requires template global
    decorators to accept functions with no arguments. :issue:`4098`
-   Support View and MethodView instances with async handlers. :issue:`4112`
-   Enhance typing of ``app.errorhandler`` decorator. :issue:`4095`
-   Fix registering a blueprint twice with differing names. :issue:`4124`
-   Fix the type of ``static_folder`` to accept ``pathlib.Path``.
    :issue:`4150`
-   ``jsonify`` handles ``decimal.Decimal`` by encoding to ``str``.
    :issue:`4157`
-   Correctly handle raising deferred errors in CLI lazy loading.
    :issue:`4096`
-   The CLI loader handles ``**kwargs`` in a ``create_app`` function.
    :issue:`4170`
-   Fix the order of ``before_request`` and other callbacks that trigger
    before the view returns. They are called from the app down to the
    closest nested blueprint. :issue:`4229`


Version 2.0.1
-------------

Released 2021-05-21

-   Re-add the ``filename`` parameter in ``send_from_directory``. The
    ``filename`` parameter has been renamed to ``path``, the old name
    is deprecated. :pr:`4019`
-   Mark top-level names as exported so type checking understands
    imports in user projects. :issue:`4024`
-   Fix type annotation for ``g`` and inform mypy that it is a namespace
    object that has arbitrary attributes. :issue:`4020`
-   Fix some types that weren't available in Python 3.6.0. :issue:`4040`
-   Improve typing for ``send_file``, ``send_from_directory``, and
    ``get_send_file_max_age``. :issue:`4044`, :pr:`4026`
-   Show an error when a blueprint name contains a dot. The ``.`` has
    special meaning, it is used to separate (nested) blueprint names and
    the endpoint name. :issue:`4041`
-   Combine URL prefixes when nesting blueprints that were created with
    a ``url_prefix`` value. :issue:`4037`
-   Revert a change to the order that URL matching was done. The
    URL is again matched after the session is loaded, so the session is
    available in custom URL converters. :issue:`4053`
-   Re-add deprecated ``Config.from_json``, which was accidentally
    removed early. :issue:`4078`
-   Improve typing for some functions using ``Callable`` in their type
    signatures, focusing on decorator factories. :issue:`4060`
-   Nested blueprints are registered with their dotted name. This allows
    different blueprints with the same name to be nested at different
    locations. :issue:`4069`
-   ``register_blueprint`` takes a ``name`` option to change the
    (pre-dotted) name the blueprint is registered with. This allows the
    same blueprint to be registered multiple times with unique names for
    ``url_for``. Registering the same blueprint with the same name
    multiple times is deprecated. :issue:`1091`
-   Improve typing for ``stream_with_context``. :issue:`4052`


Version 2.0.0
-------------

Released 2021-05-11

-   Drop support for Python 2 and 3.5.
-   Bump minimum versions of other Pallets projects: Werkzeug >= 2,
    Jinja2 >= 3, MarkupSafe >= 2, ItsDangerous >= 2, Click >= 8. Be sure
    to check the change logs for each project. For better compatibility
    with other applications (e.g. Celery) that still require Click 7,
    there is no hard dependency on Click 8 yet, but using Click 7 will
    trigger a DeprecationWarning and Flask 2.1 will depend on Click 8.
-   JSON support no longer uses simplejson. To use another JSON module,
    override ``app.json_encoder`` and ``json_decoder``. :issue:`3555`
-   The ``encoding`` option to JSON functions is deprecated. :pr:`3562`
-   Passing ``script_info`` to app factory functions is deprecated. This
    was not portable outside the ``flask`` command. Use
    ``click.get_current_context().obj`` if it's needed. :issue:`3552`
-   The CLI shows better error messages when the app failed to load
    when looking up commands. :issue:`2741`
-   Add ``SessionInterface.get_cookie_name`` to allow setting the
    session cookie name dynamically. :pr:`3369`
-   Add ``Config.from_file`` to load config using arbitrary file
    loaders, such as ``toml.load`` or ``json.load``.
    ``Config.from_json`` is deprecated in favor of this. :pr:`3398`
-   The ``flask run`` command will only defer errors on reload. Errors
    present during the initial call will cause the server to exit with
    the traceback immediately. :issue:`3431`
-   ``send_file`` raises a ``ValueError`` when passed an ``io`` object
    in text mode. Previously, it would respond with 200 OK and an empty
    file. :issue:`3358`
-   When using ad-hoc certificates, check for the cryptography library
    instead of PyOpenSSL. :pr:`3492`
-   When specifying a factory function with ``FLASK_APP``, keyword
    argument can be passed. :issue:`3553`
-   When loading a ``.env`` or ``.flaskenv`` file, the current working
    directory is no longer changed to the location of the file.
    :pr:`3560`
-   When returning a ``(response, headers)`` tuple from a view, the
    headers replace rather than extend existing headers on the response.
    For example, this allows setting the ``Content-Type`` for
    ``jsonify()``. Use ``response.headers.extend()`` if extending is
    desired. :issue:`3628`
-   The ``Scaffold`` class provides a common API for the ``Flask`` and
    ``Blueprint`` classes. ``Blueprint`` information is stored in
    attributes just like ``Flask``, rather than opaque lambda functions.
    This is intended to improve consistency and maintainability.
    :issue:`3215`
-   Include ``samesite`` and ``secure`` options when removing the
    session cookie. :pr:`3726`
-   Support passing a ``pathlib.Path`` to ``static_folder``. :pr:`3579`
-   ``send_file`` and ``send_from_directory`` are wrappers around the
    implementations in ``werkzeug.utils``. :pr:`3828`
-   Some ``send_file`` parameters have been renamed, the old names are
    deprecated. ``attachment_filename`` is renamed to ``download_name``.
    ``cache_timeout`` is renamed to ``max_age``. ``add_etags`` is
    renamed to ``etag``. :pr:`3828, 3883`
-   ``send_file`` passes ``download_name`` even if
    ``as_attachment=False`` by using ``Content-Disposition: inline``.
    :pr:`3828`
-   ``send_file`` sets ``conditional=True`` and ``max_age=None`` by
    default. ``Cache-Control`` is set to ``no-cache`` if ``max_age`` is
    not set, otherwise ``public``. This tells browsers to validate
    conditional requests instead of using a timed cache. :pr:`3828`
-   ``helpers.safe_join`` is deprecated. Use
    ``werkzeug.utils.safe_join`` instead. :pr:`3828`
-   The request context does route matching before opening the session.
    This could allow a session interface to change behavior based on
    ``request.endpoint``. :issue:`3776`
-   Use Jinja's implementation of the ``|tojson`` filter. :issue:`3881`
-   Add route decorators for common HTTP methods. For example,
    ``@app.post("/login")`` is a shortcut for
    ``@app.route("/login", methods=["POST"])``. :pr:`3907`
-   Support async views, error handlers, before and after request, and
    teardown functions. :pr:`3412`
-   Support nesting blueprints. :issue:`593, 1548`, :pr:`3923`
-   Set the default encoding to "UTF-8" when loading ``.env`` and
    ``.flaskenv`` files to allow to use non-ASCII characters. :issue:`3931`
-   ``flask shell`` sets up tab and history completion like the default
    ``python`` shell if ``readline`` is installed. :issue:`3941`
-   ``helpers.total_seconds()`` is deprecated. Use
    ``timedelta.total_seconds()`` instead. :pr:`3962`
-   Add type hinting. :pr:`3973`.
```

werkzeug changelog

```
Version 2.2.3
-------------

Released 2023-02-14

-   Ensure that URL rules using path converters will redirect with strict slashes when
    the trailing slash is missing. :issue:`2533`
-   Type signature for ``get_json`` specifies that return type is not optional when
    ``silent=False``. :issue:`2508`
-   ``parse_content_range_header`` returns ``None`` for a value like ``bytes */-1``
    where the length is invalid, instead of raising an ``AssertionError``. :issue:`2531`
-   Address remaining ``ResourceWarning`` related to the socket used by ``run_simple``.
    Remove ``prepare_socket``, which now happens when creating the server. :issue:`2421`
-   Update pre-existing headers for ``multipart/form-data`` requests with the test
    client. :issue:`2549`
-   Fix handling of header extended parameters such that they are no longer quoted.
    :issue:`2529`
-   ``LimitedStream.read`` works correctly when wrapping a stream that may not return
    the requested size in one ``read`` call. :issue:`2558`
-   A cookie header that starts with ``=`` is treated as an empty key and discarded,
    rather than stripping the leading ``==``.
-   Specify a maximum number of multipart parts, default 1000, after which a
    ``RequestEntityTooLarge`` exception is raised on parsing. This mitigates a DoS
    attack where a larger number of form/file parts would result in disproportionate
    resource use.



Version 2.2.2
-------------

Released 2022-08-08

-   Fix router to restore the 2.1 ``strict_slashes == False`` behaviour
    whereby leaf-requests match branch rules and vice
    versa. :pr:`2489`
-   Fix router to identify invalid rules rather than hang parsing them,
    and to correctly parse ``/`` within converter arguments. :pr:`2489`
-   Update subpackage imports in :mod:`werkzeug.routing` to use the
    ``import as`` syntax for explicitly re-exporting public attributes.
    :pr:`2493`
-   Parsing of some invalid header characters is more robust. :pr:`2494`
-   When starting the development server, a warning not to use it in a
    production deployment is always shown. :issue:`2480`
-   ``LocalProxy.__wrapped__`` is always set to the wrapped object when
    the proxy is unbound, fixing an issue in doctest that would cause it
    to fail. :issue:`2485`
-   Address one ``ResourceWarning`` related to the socket used by
    ``run_simple``. :issue:`2421`



Version 2.2.1
-------------

Released 2022-07-27

-   Fix router so that ``/path/`` will match a rule ``/path`` if strict
    slashes mode is disabled for the rule. :issue:`2467`
-   Fix router so that partial part matches are not allowed
    i.e. ``/2df`` does not match ``/<int>``. :pr:`2470`
-   Fix router static part weighting, so that simpler routes are matched
    before more complex ones. :issue:`2471`
-   Restore ``ValidationError`` to be importable from
    ``werkzeug.routing``. :issue:`2465`


Version 2.2.0
-------------

Released 2022-07-23

-   Deprecated ``get_script_name``, ``get_query_string``,
    ``peek_path_info``, ``pop_path_info``, and
    ``extract_path_info``. :pr:`2461`
-   Remove previously deprecated code. :pr:`2461`
-   Add MarkupSafe as a dependency and use it to escape values when
    rendering HTML. :issue:`2419`
-   Added the ``werkzeug.debug.preserve_context`` mechanism for
    restoring context-local data for a request when running code in the
    debug console. :pr:`2439`
-   Fix compatibility with Python 3.11 by ensuring that ``end_lineno``
    and ``end_col_offset`` are present on AST nodes. :issue:`2425`
-   Add a new faster URL matching router based on a state machine. If a custom converter
    needs to match a ``/`` it must set the class variable ``part_isolating = False``.
    :pr:`2433`
-   Fix branch leaf path masking branch paths when strict-slashes is
    disabled. :issue:`1074`
-   Names within options headers are always converted to lowercase. This
    matches :rfc:`6266` that the case is not relevant. :issue:`2442`
-   ``AnyConverter`` validates the value passed for it when building
    URLs. :issue:`2388`
-   The debugger shows enhanced error locations in tracebacks in Python
    3.11. :issue:`2407`
-   Added Sans-IO ``is_resource_modified`` and ``parse_cookie`` functions
    based on WSGI versions. :issue:`2408`
-   Added Sans-IO ``get_content_length`` function. :pr:`2415`
-   Don't assume a mimetype for test responses. :issue:`2450`
-   Type checking ``FileStorage`` accepts ``os.PathLike``. :pr:`2418`


Version 2.1.2
-------------

Released 2022-04-28

-   The development server does not set ``Transfer-Encoding: chunked``
    for 1xx, 204, 304, and HEAD responses. :issue:`2375`
-   Response HTML for exceptions and redirects starts with
    ``<!doctype html>`` and ``<html lang=en>``. :issue:`2390`
-   Fix ability to set some ``cache_control`` attributes to ``False``.
    :issue:`2379`
-   Disable ``keep-alive`` connections in the development server, which
    are not supported sufficiently by Python's ``http.server``.
    :issue:`2397`


Version 2.1.1
-------------

Released 2022-04-01

-   ``ResponseCacheControl.s_maxage`` converts its value to an int, like
    ``max_age``. :issue:`2364`


Version 2.1.0
-------------

Released 2022-03-28

-   Drop support for Python 3.6. :pr:`2277`
-   Using gevent or eventlet requires greenlet>=1.0 or PyPy>=7.3.7.
    ``werkzeug.locals`` and ``contextvars`` will not work correctly with
    older versions. :pr:`2278`
-   Remove previously deprecated code. :pr:`2276`

    -   Remove the non-standard ``shutdown`` function from the WSGI
        environ when running the development server. See the docs for
        alternatives.
    -   Request and response mixins have all been merged into the
        ``Request`` and ``Response`` classes.
    -   The user agent parser and the ``useragents`` module is removed.
        The ``user_agent`` module provides an interface that can be
        subclassed to add a parser, such as ua-parser. By default it
        only stores the whole string.
    -   The test client returns ``TestResponse`` instances and can no
        longer be treated as a tuple. All data is available as
        properties on the response.
    -   Remove ``locals.get_ident`` and related thread-local code from
        ``locals``, it no longer makes sense when moving to a
        contextvars-based implementation.
    -   Remove the ``python -m werkzeug.serving`` CLI.
    -   The ``has_key`` method on some mapping datastructures; use
        ``key in data`` instead.
    -   ``Request.disable_data_descriptor`` is removed, pass
        ``shallow=True`` instead.
    -   Remove the ``no_etag`` parameter from ``Response.freeze()``.
    -   Remove the ``HTTPException.wrap`` class method.
    -   Remove the ``cookie_date`` function. Use ``http_date`` instead.
    -   Remove the ``pbkdf2_hex``, ``pbkdf2_bin``, and ``safe_str_cmp``
        functions. Use equivalents in ``hashlib`` and ``hmac`` modules
        instead.
    -   Remove the ``Href`` class.
    -   Remove the ``HTMLBuilder`` class.
    -   Remove the ``invalidate_cached_property`` function. Use
        ``del obj.attr`` instead.
    -   Remove ``bind_arguments`` and ``validate_arguments``. Use
        :meth:`Signature.bind` and :func:`inspect.signature` instead.
    -   Remove ``detect_utf_encoding``, it's built-in to ``json.loads``.
    -   Remove ``format_string``, use :class:`string.Template` instead.
    -   Remove ``escape`` and ``unescape``. Use MarkupSafe instead.

-   The ``multiple`` parameter of ``parse_options_header`` is
    deprecated. :pr:`2357`
-   Rely on :pep:`538` and :pep:`540` to handle decoding file names
    with the correct filesystem encoding. The ``filesystem`` module is
    removed. :issue:`1760`
-   Default values passed to ``Headers`` are validated the same way
    values added later are. :issue:`1608`
-   Setting ``CacheControl`` int properties, such as ``max_age``, will
    convert the value to an int. :issue:`2230`
-   Always use ``socket.fromfd`` when restarting the dev server.
    :pr:`2287`
-   When passing a dict of URL values to ``Map.build``, list values do
    not filter out ``None`` or collapse to a single value. Passing a
    ``MultiDict`` does collapse single items. This undoes a previous
    change that made it difficult to pass a list, or ``None`` values in
    a list, to custom URL converters. :issue:`2249`
-   ``run_simple`` shows instructions for dealing with "address already
    in use" errors, including extra instructions for macOS. :pr:`2321`
-   Extend list of characters considered always safe in URLs based on
    :rfc:`3986`. :issue:`2319`
-   Optimize the stat reloader to avoid watching unnecessary files in
    more cases. The watchdog reloader is still recommended for
    performance and accuracy. :issue:`2141`
-   The development server uses ``Transfer-Encoding: chunked`` for
    streaming responses when it is configured for HTTP/1.1.
    :issue:`2090, 1327`, :pr:`2091`
-   The development server uses HTTP/1.1, which enables keep-alive
    connections and chunked streaming responses, when ``threaded`` or
    ``processes`` is enabled. :pr:`2323`
-   ``cached_property`` works for classes with ``__slots__`` if a
    corresponding ``_cache_{name}`` slot is added. :pr:`2332`
-   Refactor the debugger traceback formatter to use Python's built-in
    ``traceback`` module as much as possible. :issue:`1753`
-   The ``TestResponse.text`` property is a shortcut for
    ``r.get_data(as_text=True)``, for convenient testing against text
    instead of bytes. :pr:`2337`
-   ``safe_join`` ensures that the path remains relative if the trusted
    directory is the empty string. :pr:`2349`
-   Percent-encoded newlines (``%0a``), which are decoded by WSGI
    servers, are considered when routing instead of terminating the
    match early. :pr:`2350`
-   The test client doesn't set duplicate headers for ``CONTENT_LENGTH``
    and ``CONTENT_TYPE``. :pr:`2348`
-   ``append_slash_redirect`` handles ``PATH_INFO`` with internal
    slashes. :issue:`1972`, :pr:`2338`
-   The default status code for ``append_slash_redirect`` is 308 instead
    of 301. This preserves the request body, and matches a previous
    change to ``strict_slashes`` in routing. :issue:`2351`
-   Fix ``ValueError: I/O operation on closed file.`` with the test
    client when following more than one redirect. :issue:`2353`
-   ``Response.autocorrect_location_header`` is disabled by default.
    The ``Location`` header URL will remain relative, and exclude the
    scheme and domain, by default. :issue:`2352`
-   ``Request.get_json()`` will raise a 400 ``BadRequest`` error if the
    ``Content-Type`` header is not ``application/json``. This makes a
    very common source of confusion more visible. :issue:`2339`


Version 2.0.3
-------------

Released 2022-02-07

-   ``ProxyFix`` supports IPv6 addresses. :issue:`2262`
-   Type annotation for ``Response.make_conditional``,
    ``HTTPException.get_response``, and ``Map.bind_to_environ`` accepts
    ``Request`` in addition to ``WSGIEnvironment`` for the first
    parameter. :pr:`2290`
-   Fix type annotation for ``Request.user_agent_class``. :issue:`2273`
-   Accessing ``LocalProxy.__class__`` and ``__doc__`` on an unbound
    proxy returns the fallback value instead of a method object.
    :issue:`2188`
-   Redirects with the test client set ``RAW_URI`` and ``REQUEST_URI``
    correctly. :issue:`2151`


Version 2.0.2
-------------

Released 2021-10-05

-   Handle multiple tokens in ``Connection`` header when routing
    WebSocket requests. :issue:`2131`
-   Set the debugger pin cookie secure flag when on https. :pr:`2150`
-   Fix type annotation for ``MultiDict.update`` to accept iterable
    values :pr:`2142`
-   Prevent double encoding of redirect URL when ``merge_slash=True``
    for ``Rule.match``. :issue:`2157`
-   ``CombinedMultiDict.to_dict`` with ``flat=False`` considers all
    component dicts when building value lists. :issue:`2189`
-   ``send_file`` only sets a detected ``Content-Encoding`` if
    ``as_attachment`` is disabled to avoid browsers saving
    decompressed ``.tar.gz`` files. :issue:`2149`
-   Fix type annotations for ``TypeConversionDict.get`` to not return an
    ``Optional`` value if both ``default`` and ``type`` are not
    ``None``. :issue:`2169`
-   Fix type annotation for routing rule factories to accept
    ``Iterable[RuleFactory]`` instead of ``Iterable[Rule]`` for the
    ``rules`` parameter. :issue:`2183`
-   Add missing type annotation for ``FileStorage.__getattr__``
    :issue:`2155`
-   The debugger pin cookie is set with ``SameSite`` set to ``Strict``
    instead of ``None`` to be compatible with modern browser security.
    :issue:`2156`
-   Type annotations use ``IO[bytes]`` and ``IO[str]`` instead of
    ``BinaryIO`` and ``TextIO`` for wider type compatibility.
    :issue:`2130`
-   Ad-hoc TLS certs are generated with SAN matching CN. :issue:`2158`
-   Fix memory usage for locals when using Python 3.6 or pre 0.4.17
    greenlet versions. :pr:`2212`
-   Fix type annotation in ``CallbackDict``, because it is not
    utilizing a bound TypeVar. :issue:`2235`
-   Fix setting CSP header options on the response. :pr:`2237`
-   Fix an issue with with the interactive debugger where lines would
    not expand on click for very long tracebacks. :pr:`2239`
-   The interactive debugger handles displaying an exception that does
    not have a traceback, such as from ``ProcessPoolExecutor``.
    :issue:`2217`


Version 2.0.1
-------------

Released 2021-05-17

-   Fix type annotation for ``send_file`` ``max_age`` callable. Don't
    pass ``pathlib.Path`` to ``max_age``. :issue:`2119`
-   Mark top-level names as exported so type checking understands
    imports in user projects. :issue:`2122`
-   Fix some types that weren't available in Python 3.6.0. :issue:`2123`
-   ``cached_property`` is generic over its return type, properties
    decorated with it report the correct type. :issue:`2113`
-   Fix multipart parsing bug when boundary contains special regex
    characters. :issue:`2125`
-   Type checking understands that calling ``headers.get`` with a string
    default will always return a string. :issue:`2128`
-   If ``HTTPException.description`` is not a string,
    ``get_description`` will convert it to a string. :issue:`2115`


Version 2.0.0
-------------

Released 2021-05-11

-   Drop support for Python 2 and 3.5. :pr:`1693`
-   Deprecate :func:`utils.format_string`, use :class:`string.Template`
    instead. :issue:`1756`
-   Deprecate :func:`utils.bind_arguments` and
    :func:`utils.validate_arguments`, use :meth:`Signature.bind` and
    :func:`inspect.signature` instead. :issue:`1757`
-   Deprecate :class:`utils.HTMLBuilder`. :issue:`1761`
-   Deprecate :func:`utils.escape` and :func:`utils.unescape`, use
    MarkupSafe instead. :issue:`1758`
-   Deprecate the undocumented ``python -m werkzeug.serving`` CLI.
    :issue:`1834`
-   Deprecate the ``environ["werkzeug.server.shutdown"]`` function
    that is available when running the development server. :issue:`1752`
-   Deprecate the ``useragents`` module and the built-in user agent
    parser. Use a dedicated parser library instead by subclassing
    ``user_agent.UserAgent`` and setting ``Request.user_agent_class``.
    :issue:`2078`
-   Remove the unused, internal ``posixemulation`` module. :issue:`1759`
-   All ``datetime`` values are timezone-aware with
    ``tzinfo=timezone.utc``. This applies to anything using
    ``http.parse_date``: ``Request.date``, ``.if_modified_since``,
    ``.if_unmodified_since``; ``Response.date``, ``.expires``,
    ``.last_modified``, ``.retry_after``; ``parse_if_range_header``, and
    ``IfRange.date``. When comparing values, the other values must also
    be aware, or these values must be made naive. When passing
    parameters or setting attributes, naive values are still assumed to
    be in UTC. :pr:`2040`
-   Merge all request and response wrapper mixin code into single
    ``Request`` and ``Response`` classes. Using the mixin classes is no
    longer necessary and will show a deprecation warning. Checking
    ``isinstance`` or ``issubclass`` against ``BaseRequest`` and
    ``BaseResponse`` will show a deprecation warning and check against
    ``Request`` or ``Response`` instead. :issue:`1963`
-   JSON support no longer uses simplejson if it's installed. To use
    another JSON module, override ``Request.json_module`` and
    ``Response.json_module``. :pr:`1766`
-   ``Response.get_json()`` no longer caches the result, and the
    ``cache`` parameter is removed. :issue:`1698`
-   ``Response.freeze()`` generates an ``ETag`` header if one is not
    set. The ``no_etag`` parameter (which usually wasn't visible
    anyway) is no longer used. :issue:`1963`
-   Add a ``url_scheme`` argument to :meth:`~routing.MapAdapter.build`
    to override the bound scheme. :pr:`1721`
-   Passing an empty list as a query string parameter to ``build()``
    won't append an unnecessary ``?``. Also drop any number of ``None``
    items in a list. :issue:`1992`
-   When passing a ``Headers`` object to a test client method or
    ``EnvironBuilder``, multiple values for a key are joined into one
    comma separated value. This matches the HTTP spec on multi-value
    headers. :issue:`1655`
-   Setting ``Response.status`` and ``status_code`` uses identical
    parsing and error checking. :issue:`1658`, :pr:`1728`
-   ``MethodNotAllowed`` and ``RequestedRangeNotSatisfiable`` take a
    ``response`` kwarg, consistent with other HTTP errors. :pr:`1748`
-   The response generated by :exc:`~exceptions.Unauthorized` produces
    one ``WWW-Authenticate`` header per value in ``www_authenticate``,
    rather than joining them into a single value, to improve
    interoperability with browsers and other clients. :pr:`1755`
-   If ``parse_authorization_header`` can't decode the header value, it
    returns ``None`` instead of raising a ``UnicodeDecodeError``.
    :issue:`1816`
-   The debugger no longer uses jQuery. :issue:`1807`
-   The test client includes the query string in ``REQUEST_URI`` and
    ``RAW_URI``. :issue:`1781`
-   Switch the parameter order of ``default_stream_factory`` to match
    the order used when calling it. :pr:`1085`
-   Add ``send_file`` function to generate a response that serves a
    file. Adapted from Flask's implementation. :issue:`265`, :pr:`1850`
-   Add ``send_from_directory`` function to safely serve an untrusted
    path within a trusted directory. Adapted from Flask's
    implementation. :issue:`1880`
-   ``send_file`` takes ``download_name``, which is passed even if
    ``as_attachment=False`` by using ``Content-Disposition: inline``.
    ``download_name`` replaces Flask's ``attachment_filename``.
    :issue:`1869`
-   ``send_file`` sets ``conditional=True`` and ``max_age=None`` by
    default. ``Cache-Control`` is set to ``no-cache`` if ``max_age`` is
    not set, otherwise ``public``. This tells browsers to validate
    conditional requests instead of using a timed cache.
    ``max_age=None`` replaces Flask's ``cache_timeout=43200``.
    :issue:`1882`
-   ``send_file`` can be called with ``etag="string"`` to set a custom
    ETag instead of generating one. ``etag`` replaces Flask's
    ``add_etags``. :issue:`1868`
-   ``send_file`` sets the ``Content-Encoding`` header if an encoding is
    returned when guessing ``mimetype`` from ``download_name``.
    :pr:`3896`
-   Update the defaults used by ``generate_password_hash``. Increase
    PBKDF2 iterations to 260000 from 150000. Increase salt length to 16
    from 8. Use ``secrets`` module to generate salt. :pr:`1935`
-   The reloader doesn't crash if ``sys.stdin`` is somehow ``None``.
    :pr:`1915`
-   Add arguments to ``delete_cookie`` to match ``set_cookie`` and the
    attributes modern browsers expect. :pr:`1889`
-   ``utils.cookie_date`` is deprecated, use ``utils.http_date``
    instead. The value for ``Set-Cookie expires`` is no longer "-"
    delimited. :pr:`2040`
-   Use ``request.headers`` instead of ``request.environ`` to look up
    header attributes. :pr:`1808`
-   The test ``Client`` request methods (``client.get``, etc.) always
    return an instance of ``TestResponse``. In addition to the normal
    behavior of ``Response``, this class provides ``request`` with the
    request that produced the response, and ``history`` to track
    intermediate responses when ``follow_redirects`` is used.
    :issue:`763, 1894`
-   The test ``Client`` request methods takes an ``auth`` parameter to
    add an ``Authorization`` header. It can be an ``Authorization``
    object or a ``(username, password)`` tuple for ``Basic`` auth.
    :pr:`1809`
-   Calling ``response.close()`` on a response from the test ``Client``
    will close the request input stream. This matches file behavior
    and can prevent a ``ResourceWarning`` in some cases. :issue:`1785`
-   ``EnvironBuilder.from_environ`` decodes values encoded for WSGI, to
    avoid double encoding the new values. :pr:`1959`
-   The default stat reloader will watch Python files under
    non-system/virtualenv ``sys.path`` entries, which should contain
    most user code. It will also watch all Python files under
    directories given in ``extra_files``. :pr:`1945`
-   The reloader ignores ``__pycache__`` directories again. :pr:`1945`
-   ``run_simple`` takes ``exclude_patterns`` a list of ``fnmatch``
    patterns that will not be scanned by the reloader. :issue:`1333`
-   Cookie names are no longer unquoted. This was against :rfc:`6265`
    and potentially allowed setting ``__Secure`` prefixed cookies.
    :pr:`1965`
-   Fix some word matches for user agent platform when the word can be a
    substring. :issue:`1923`
-   The development server logs ignored SSL errors. :pr:`1967`
-   Temporary files for form data are opened in ``rb+`` instead of
    ``wb+`` mode for better compatibility with some libraries.
    :issue:`1961`
-   Use SHA-1 instead of MD5 for generating ETags and the debugger pin,
    and in some tests. MD5 is not available in some environments, such
    as FIPS 140. This may invalidate some caches since the ETag will be
    different. :issue:`1897`
-   Add ``Cross-Origin-Opener-Policy`` and
    ``Cross-Origin-Embedder-Policy`` response header properties.
    :pr:`2008`
-   ``run_simple`` tries to show a valid IP address when binding to all
    addresses, instead of ``0.0.0.0`` or ``::``. It also warns about not
    running the development server in production in this case.
    :issue:`1964`
-   Colors in the development server log are displayed if Colorama is
    installed on Windows. For all platforms, style support no longer
    requires Click. :issue:`1832`
-   A range request for an empty file (or other data with length 0) will
    return a 200 response with the empty file instead of a 416 error.
    :issue:`1937`
-   New sans-IO base classes for ``Request`` and ``Response`` have been
    extracted to contain all the behavior that is not WSGI or IO
    dependent. These are not a public API, they are part of an ongoing
    refactor to let ASGI frameworks use Werkzeug. :pr:`2005`
-   Parsing ``multipart/form-data`` has been refactored to use sans-io
    patterns. This should also make parsing forms with large binary file
    uploads significantly faster. :issue:`1788, 875`
-   ``LocalProxy`` matches the current Python data model special
    methods, including all r-ops, in-place ops, and async. ``__class__``
    is proxied, so the proxy will look like the object in more cases,
    including ``isinstance``. Use ``issubclass(type(obj), LocalProxy)``
    to check if an object is actually a proxy. :issue:`1754`
-   ``Local`` uses ``ContextVar`` on Python 3.7+ instead of
    ``threading.local``. :pr:`1778`
-   ``request.values`` does not include ``form`` for GET requests (even
    though GET bodies are undefined). This prevents bad caching proxies
    from caching form data instead of query strings. :pr:`2037`
-   The development server adds the underlying socket to ``environ`` as
    ``werkzeug.socket``. This is non-standard and specific to the dev
    server, other servers may expose this under their own key. It is
    useful for handling a WebSocket upgrade request. :issue:`2052`
-   URL matching assumes ``websocket=True`` mode for WebSocket upgrade
    requests. :issue:`2052`
-   Updated ``UserAgentParser`` to handle more cases. :issue:`1971`
-   ``werzeug.DechunkedInput.readinto`` will not read beyond the size of
    the buffer. :issue:`2021`
-   Fix connection reset when exceeding max content size. :pr:`2051`
-   ``pbkdf2_hex``, ``pbkdf2_bin``, and ``safe_str_cmp`` are deprecated.
    ``hashlib`` and ``hmac`` provide equivalents. :pr:`2083`
-   ``invalidate_cached_property`` is deprecated. Use ``del obj.name``
    instead. :pr:`2084`
-   ``Href`` is deprecated. Use ``werkzeug.routing`` instead.
    :pr:`2085`
-   ``Request.disable_data_descriptor`` is deprecated. Create the
    request with ``shallow=True`` instead. :pr:`2085`
-   ``HTTPException.wrap`` is deprecated. Create a subclass manually
    instead. :pr:`2085`
```