### PR TITLE
Upgrade greenlet

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -29,7 +29,7 @@ Flask==2.0.3
 Flask-RESTful==0.3.9
 gdata==2.0.18
 gevent==22.10.2
-greenlet==2.0.1
+greenlet==2.0.2
 gunicorn==20.1.0
 guppy3==3.1.2
 hiredis==1.1.0


### PR DESCRIPTION
Always good idea to keep this on the latest micro version as sync-engine is all built around gevent and greenlet. Gevent did not have any release.

Changelog:

```
2.0.2 (2023-01-28)
==================

- Fix calling ``greenlet.settrace()`` with the same tracer object that
  was currently active. See `issue 332
  <https://github.com/python-greenlet/greenlet/issues/332>`_.
- Various compilation and standards conformance fixes. See #335, #336,
  #300, #302, #334.
  ```