### PR TITLE
Handle MSGraph timezone-aware datetimes

### DIFF
--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -81,6 +81,14 @@ def parse_msgraph_datetime_tz_as_utc(datetime_tz: MsGraphDateTimeTimeZone):
     # so we need to use ciso8601 because Python stdlib only supports up to 6.
     dt = ciso8601.parse_datetime(datetime_tz["dateTime"])
 
+    # Microsoft sometimes returns payloads such as this one:
+    # {"dateTime": "0001-01-01T00:00:00.0000000Z", "timeZone": "tzone://Microsoft/Utc"}
+    # We're removing the timezone from the parsed datetime, otherwise
+    # `tzinfo.localize` would fail. This datetime is obviously not correct
+    # anyway.
+    if dt.tzinfo and dt == datetime.datetime(1, 1, 1, tzinfo=pytz.UTC):
+        dt = dt.replace(tzinfo=None)
+
     return tzinfo.localize(dt).astimezone(pytz.UTC)
 
 

--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -51,6 +51,13 @@ def test_get_microsoft_timezone(windows_tz_id, olson_tz_id):
             },
             datetime.datetime(2022, 9, 22, 16, 30, tzinfo=pytz.UTC),
         ),
+        (
+            {
+                "dateTime": "0001-01-01T00:00:00.0000000Z",
+                "timeZone": "tzone://Microsoft/Utc",
+            },
+            datetime.datetime(1, 1, 1, tzinfo=pytz.UTC),
+        ),
     ],
 )
 def test_parse_msggraph_datetime_tz_as_utc(datetime_tz, dt):


### PR DESCRIPTION
Fixes #

Summary:
MSGraph can return values such as `{"dateTime": "0001-01-01T00:00:00.0000000Z", "timeZone": "tzone://Microsoft/Utc"}` for some calendar events' `start` or `end` fields. This causes `tzinfo.localize(dt)` in `parse_msgraph_datetime_tz_as_utc` to fail, as `tzinfo` is already set.

Test Plan:

Reviewers:
Please add the reviewer as an assignee to this PR on the right
