### PR TITLE
Don't break on missing categories

### DIFF
--- a/inbox/models/thread.py
+++ b/inbox/models/thread.py
@@ -117,9 +117,11 @@ class Thread(MailSyncBase, HasPublicID, HasRevisions, UpdatedAtMixin, DeletedAtM
         sorted_messages = sorted(
             self.messages, key=lambda m: m.received_date, reverse=True
         )
-        for m in sorted_messages:
-            if "sent" in [c.name for c in m.categories] or (m.is_draft and m.is_sent):
-                sent_recent_date = m.received_date
+        for message in sorted_messages:
+            if "sent" in [
+                category.name for category in message.categories if category
+            ] or (message.is_draft and message.is_sent):
+                sent_recent_date = message.received_date
                 return sent_recent_date
 
     @property


### PR DESCRIPTION
This is a stop gap solution for https://github.com/closeio/sync-engine/issues/302.

There's a pretty laud rollbar both on CRM and sync-engine side.

`category` can be None because somebody at Nylas decided to drop a foreign key mentioned in [the issue](https://github.com/closeio/sync-engine/issues/302). We should still investigate if we can add those constraints back because the decision to drop such constraints does not look like a correct one to me. In the meantime let's ship this because for people that hit this problem we simply get stuck on this and stop syncing their inboxes.