### PR TITLE
move initial poll call out of loop

### DIFF
--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -124,7 +124,7 @@ class SyncService:
 
     def run(self):
         # When the service first starts we should check the state of the world.
-        self.poll()
+        retry_with_logging(self.poll)
         while self.keep_running:
             retry_with_logging(self._run_impl, self.log)
 

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -123,6 +123,8 @@ class SyncService:
             gevent.spawn_later(exit_after, self.stop)
 
     def run(self):
+        # When the service first starts we should check the state of the world.
+        self.poll()
         while self.keep_running:
             retry_with_logging(self._run_impl, self.log)
 
@@ -131,8 +133,6 @@ class SyncService:
         Waits for notifications about Account migrations and checks for start/stop commands.
 
         """
-        # When the service first starts we should check the state of the world.
-        self.poll()
         event = None
         while self.keep_running and event is None:
             event = self.queue_group.receive_event(timeout=self.poll_interval)


### PR DESCRIPTION
Currently we're [polling the database](https://github.com/closeio/sync-engine/blob/master/inbox/mailsync/service.py#L135) on *every* loop iteration so listening to the Redis queue for events only means we'll start syncing the new account(s) sooner than in 20s which is what the poll interval is set to.

I think the call that I moved was intended to be _outside_ the worker loop so we'd only poll the state of the world on startup and then rely on EventQueue to start syncing new accounts.

WDYT @squeaky-pl  ? I'm not sure if this is worth merging since I don't see this polling to be a significant load on the DB.