### PR TITLE
Reduce mail parsing memory footprint, don't do useless processing

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -599,15 +599,15 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
     def calculate_body(
         self, html_parts: List[bytes], plain_parts: List[bytes], store_body: bool = True
     ) -> None:
-        html_body = b"".join(html_parts).decode("utf-8").strip()
-        plain_body = b"\n".join(plain_parts).decode("utf-8").strip()
-        if html_body:
+        if any(html_parts):
+            html_body = b"".join(html_parts).decode("utf-8").strip()
             self.snippet = self.calculate_html_snippet(html_body)
             if store_body:
                 self.body = html_body
             else:
                 self.body = None
-        elif plain_body:
+        elif any(plain_parts):
+            plain_body = b"\n".join(plain_parts).decode("utf-8").strip()
             self.snippet = self.calculate_plaintext_snippet(plain_body)
             if store_body:
                 self.body = plaintext2html(plain_body, False)

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -87,8 +87,8 @@ def _trim_filename(
     return s
 
 
-def normalize_data(data: str) -> bytes:
-    return data.encode("utf-8", "strict").replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+def normalize_data(data: str) -> str:
+    return data.replace("\r\n", "\n").replace("\r", "\n")
 
 
 class MessageTooBigException(Exception):
@@ -351,8 +351,8 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
             msg._mark_error()
 
         if parsed is not None:
-            plain_parts: List[bytes] = []
-            html_parts: List[bytes] = []
+            plain_parts: List[str] = []
+            html_parts: List[str] = []
             for mimepart in parsed.walk(with_self=parsed.content_type.is_singlepart()):
                 try:
                     if mimepart.content_type.is_multipart():
@@ -478,8 +478,8 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
         mid: int,
         mimepart: MimePart,
         namespace_id: int,
-        html_parts: List[bytes],
-        plain_parts: List[bytes],
+        html_parts: List[str],
+        plain_parts: List[str],
     ) -> None:
         disposition, _ = mimepart.content_disposition
         content_id: Optional[str] = mimepart.headers.get("Content-Id")
@@ -619,17 +619,17 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
             self.snippet = ""
 
     def calculate_body(
-        self, html_parts: List[bytes], plain_parts: List[bytes], store_body: bool = True
+        self, html_parts: List[str], plain_parts: List[str], store_body: bool = True
     ) -> None:
         if any(html_parts):
-            html_body = b"".join(html_parts).decode("utf-8").strip()
+            html_body = "".join(html_parts).strip()
             self.snippet = self.calculate_html_snippet(html_body)
             if store_body:
                 self.body = html_body
             else:
                 self.body = None
         elif any(plain_parts):
-            plain_body = b"\n".join(plain_parts).decode("utf-8").strip()
+            plain_body = "\n".join(plain_parts).strip()
             self.snippet = self.calculate_plaintext_snippet(plain_body)
             if store_body:
                 self.body = plaintext2html(plain_body, False)

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -517,14 +517,16 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
         if is_text:
             if data is None:
                 return
-            normalized_data: bytes = data.encode("utf-8", "strict")
-            normalized_data = normalized_data.replace(b"\r\n", b"\n").replace(
-                b"\r", b"\n"
-            )
-            if content_type == "text/html":
-                html_parts.append(normalized_data)
-            elif content_type == "text/plain":
-                plain_parts.append(normalized_data)
+
+            if content_type in ["text/html", "text/plain"]:
+                normalized_data: bytes = data.encode("utf-8", "strict")
+                normalized_data = normalized_data.replace(b"\r\n", b"\n").replace(
+                    b"\r", b"\n"
+                )
+                if content_type == "text/html":
+                    html_parts.append(normalized_data)
+                elif content_type == "text/plain":
+                    plain_parts.append(normalized_data)
             else:
                 log.info(
                     "Saving other text MIME part as attachment",

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -525,7 +525,11 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
                 )
                 if content_type == "text/html":
                     html_parts.append(normalized_data)
-                elif content_type == "text/plain":
+                elif content_type == "text/plain" and not html_parts:
+                    # either html_parts or plain_parts are used to calculate
+                    # message body and snippet in calculate_body but not
+                    # both at the same time. As soon as we have at least one
+                    # html part we can stop collecting plain ones.
                     plain_parts.append(normalized_data)
             else:
                 log.info(


### PR DESCRIPTION
TLDR: we had an email message in our production cluster that was causing OOMs while being synced. I downloaded the message, measured memory pressure while parsing it and realized that email prasing logic uses excessive amount of RAM and does pointless operations. 

1. We do pointless `str` -> `bytes` -> `str` conversions while storing html and text parts, we just need `str`s.
2. While calculating message snippet and body we always prefer html parts over plain parts. Most emails these days contain alternative html and plain parts, the plain parts are only carried for the reason of backwards compatibility. Nonetheless we were carrying over plain parts through processing and doing calculations on it even if we were throwing away the results.
3. We were prematurely decoding a mimepart by accessing `mimepart.body` early even if we didn't care about what's inside this particular mimepart.

The message that I saw in production is a pathological case because it's a really long email that contains more than 1000 mimeparts, but it demonstrates very well the kind of savings we can make here.

The video shows memory pressure after processing each mimepart. On master the memory pressure (measurements taken with psutil rss usage) to process this message peaks at 866MBs:

https://user-images.githubusercontent.com/754356/229727005-9a22a436-b97c-4946-a93e-0297636cbd49.mp4

After changes on this branch it's reduced to 190MBs and goes significantly faster.


https://user-images.githubusercontent.com/754356/229727551-c07d8eea-c51b-45f3-a4cf-91ec1a4fbc70.mp4

For obvious privacy reasons I could not ship this email/test, but this logic is already covered by other tests.
