### PR TITLE
Validate address headers earlier to prevent OOM

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import json
 import os
 import typing
 from collections import defaultdict
@@ -46,7 +47,12 @@ from inbox.models.mixins import (
     UpdatedAtMixin,
 )
 from inbox.security.blobstorage import decode_blob, encode_blob
-from inbox.sqlalchemy_ext.util import JSON, MAX_MYSQL_INTEGER, json_field_too_long
+from inbox.sqlalchemy_ext.util import (
+    JSON,
+    MAX_MYSQL_INTEGER,
+    MAX_TEXT_BYTES,
+    json_field_too_long,
+)
 from inbox.util.addr import parse_mimepart_address_header
 from inbox.util.blockstore import save_to_blockstore
 from inbox.util.encoding import unicode_safe_truncate
@@ -94,6 +100,22 @@ def normalize_data(data: str) -> str:
 class MessageTooBigException(Exception):
     def __init__(self, body_length):
         super().__init__(f"message length ({body_length}) is over the parsing limit")
+
+
+class HeaderTooBigException(Exception):
+    def __init__(self, header):
+        super().__init__(f"header {header!r} length is over the parsing limit")
+
+
+def parse_and_validate_mimepart_address_header(
+    mimepart: MimePart, header: str
+) -> List[List[str]]:
+    parsed = parse_mimepart_address_header(mimepart, header)
+
+    if len(json.dumps(parsed).encode()) > MAX_TEXT_BYTES:
+        raise HeaderTooBigException(header)
+
+    return parsed
 
 
 class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMixin):
@@ -326,7 +348,7 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
             msg._parse_metadata(
                 parsed, body_string, received_date, account.id, folder_name, mid
             )
-        except (mime.DecodingError, MessageTooBigException) as e:
+        except (mime.DecodingError, MessageTooBigException, HeaderTooBigException) as e:
             parsed = None
             msg.parsed_body = ""
             log.warning(
@@ -427,12 +449,12 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
             )
 
         self.subject: Optional[str] = parsed.subject
-        self.from_addr = parse_mimepart_address_header(parsed, "From")
-        self.sender_addr = parse_mimepart_address_header(parsed, "Sender")
-        self.reply_to = parse_mimepart_address_header(parsed, "Reply-To")
-        self.to_addr = parse_mimepart_address_header(parsed, "To")
-        self.cc_addr = parse_mimepart_address_header(parsed, "Cc")
-        self.bcc_addr = parse_mimepart_address_header(parsed, "Bcc")
+        self.from_addr = parse_and_validate_mimepart_address_header(parsed, "From")
+        self.sender_addr = parse_and_validate_mimepart_address_header(parsed, "Sender")
+        self.reply_to = parse_and_validate_mimepart_address_header(parsed, "Reply-To")
+        self.to_addr = parse_and_validate_mimepart_address_header(parsed, "To")
+        self.cc_addr = parse_and_validate_mimepart_address_header(parsed, "Cc")
+        self.bcc_addr = parse_and_validate_mimepart_address_header(parsed, "Bcc")
 
         self.in_reply_to: Optional[str] = parsed.headers.get("In-Reply-To")
 


### PR DESCRIPTION
This prevents following situation we are currently facing with a particular inbox.

The inbox has garbled email messages in it. Some of them are garbled inside address headers leading the parser to try interpreting garbage as a very long email names/address. It eventually leads to out of memory and crash entire sync worker :-) This introduces a hard limit on header length which is what MySQL's maximum on TEXT field (65 KB) which is the type we use to store email addresses. Such messages are garbage anyway so we just mark them as invalid and move on.