### PR TITLE
Bump setuptools to 67.4.0 and pymongo to 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN python3 -m pip install pip==22.3.1 virtualenv==20.17.1 && \
   python3 -m virtualenv /opt/venv && \
-  /opt/venv/bin/python3 -m pip install setuptools==57.5.0 && \
+  /opt/venv/bin/python3 -m pip install setuptools==67.4.0 && \
   /opt/venv/bin/python3 -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt && \
   /opt/venv/bin/python3 -m pip install -e . && \
   /opt/venv/bin/python3 -m pip check

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -62,7 +62,7 @@ pycparser==2.21
 pygments==2.14.0
 pyinstrument==3.2.0
 pyinstrument-cext==0.2.2
-pymongo==2.9.5  # For json_util in bson
+pymongo==3.0  # For json_util in bson
 Pympler==0.9
 PyNaCl==1.4.0
 python-dateutil==2.8.2


### PR DESCRIPTION
Resolves [CVE-2022-40897](https://github.com/advisories/GHSA-r9hx-vwmv-q579)

We need to bump PyMongo along with setuptools, because bumping setuptools removes 2to3 that PyMongo's installation depends on.

Changelog: https://pymongo.readthedocs.io/en/stable/changelog.html
Since we only use `bson.json_util`, the part that should interest us is this:
https://user-images.githubusercontent.com/113755748/231822387-e2bf782c-4c64-4550-abd0-9a972c58a26a.png

It looks like these changes do not affect us, but I'm not sure about the `Int64` bit.

Also, not 100% sure I understand why we're using the PyMongo bson module.
Is it so that we can store arbitrary data structures (including datetimes) in the database using a string representation of BSON?

