### PR TITLE
Allow parse_message_list to gracefully handle many elements

### DIFF
--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -19,9 +19,9 @@ from inbox.crispin import (
     GMetadata,
     RawFolder,
     RawMessage,
+    fixed_parse_message_list,
     localized_folder_names,
-    optimized_parse_message_list,
-    unoptimized_parse_message_list,
+    original_parse_message_list,
 )
 
 
@@ -812,16 +812,26 @@ def test_german_outlook(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    "callee", [optimized_parse_message_list, unoptimized_parse_message_list]
+    "callee", [fixed_parse_message_list, original_parse_message_list]
 )
 def test_parse_message_list(callee):
     assert callee([b"1 123 124 1024"]) == [1, 123, 124, 1024]
 
 
 @pytest.mark.parametrize(
-    "callee", [optimized_parse_message_list, unoptimized_parse_message_list]
+    "callee", [fixed_parse_message_list, original_parse_message_list]
 )
 def test_parse_message_list_large_list(callee):
     large_list = [" ".join(str(uid) for uid in range(1, 6_000_000)).encode()]
 
     assert callee(large_list) == list(range(1, 6_000_000))
+
+
+def test_fixed_parse_message_list_multiple_elements():
+    assert set(fixed_parse_message_list([b"1 2", b"1 123 124 1024"])) == {
+        1,
+        2,
+        123,
+        124,
+        1024,
+    }


### PR DESCRIPTION
Fixes: https://github.com/closeio/sync-engine/issues/485