### PR TITLE
Microsoft: Gracefully handle invalid event organizer

### DIFF
--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -653,12 +653,15 @@ def parse_event(
     organizer = event["organizer"]
     if organizer:
         organizer_email_address = organizer.get("emailAddress", {})
-        owner = email.utils.formataddr(
-            (
-                organizer_email_address.get("name", ""),
-                organizer_email_address.get("address", ""),
+        try:
+            owner = email.utils.formataddr(
+                (
+                    organizer_email_address.get("name", ""),
+                    organizer_email_address.get("address", ""),
+                )
             )
-        )
+        except UnicodeEncodeError:
+            owner = ""
     else:
         owner = ""
     attendees = event.get("attendees", [])

--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -1380,6 +1380,16 @@ def test_parse_event_singular():
     assert event.read_only is False
 
 
+def test_parse_event_with_invalid_organizer():
+    event_with_invalid_organizer = single_instance_event.copy()
+    event_with_invalid_organizer["organizer"] = {
+        "name": "Garrett’s Bespoke Barber Shop",
+        "address": "Garrett’s Bespoke Barber Shop",
+    }
+    event = parse_event(event_with_invalid_organizer, read_only=False)
+    assert event.owner == ""
+
+
 outlook_calendar = {
     "id": "AAMkADdiYzg5OGRlLTY1MjktNDc2Ni05YmVkLWMxMzFlNTQ0MzU3YQBGAAAAAACi9RQWB-SNTZBuALM6KIOsBwBtf4g8yY_zTZgZh6x0X-50AAAAAAEGAABtf4g8yY_zTZgZh6x0X-50AAAAADafAAA=",
     "name": "Calendar",


### PR DESCRIPTION
We currently have a loud Rollbar happening in a produciton for a single account,organizer address is supposed to be an email address, but as always there's non-confirming data.