### PR TITLE
Expose Google conferenceData

### DIFF
--- a/inbox/api/kellogs.py
+++ b/inbox/api/kellogs.py
@@ -330,6 +330,7 @@ def _encode(obj, namespace_public_id=None, expand=False, is_n1=False):
             "visibility": obj.visibility,
             "uid": obj.uid,
             "calendar_event_link": obj.calendar_event_link,
+            "conference_data": obj.conference_data,
         }
         if isinstance(obj, RecurringEvent):
             resp["recurrence"] = {

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -24,7 +24,13 @@ from inbox.events.util import (
 )
 from inbox.models import Account, Calendar
 from inbox.models.backends.oauth import token_manager
-from inbox.models.event import EVENT_STATUSES, ConferenceData, EntryPoint, Event
+from inbox.models.event import (
+    EVENT_STATUSES,
+    ConferenceData,
+    ConferenceSolution,
+    EntryPoint,
+    Event,
+)
 
 CALENDARS_URL = "https://www.googleapis.com/calendar/v3/users/me/calendarList"
 STATUS_MAP = {
@@ -496,12 +502,17 @@ def sanitize_conference_data(
         return None
 
     raw_entry_points = conference_data.get("entryPoints", [])
+    raw_conference_solution = conference_data.get("conferenceSolution", {})
+
     return ConferenceData(
         entry_points=[
             EntryPoint(uri=entry_point["uri"])
             for entry_point in raw_entry_points
             if entry_point.get("uri")
-        ]
+        ],
+        conference_solution=ConferenceSolution(
+            name=raw_conference_solution.get("name", ""),
+        ),
     )
 
 

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -8,7 +8,8 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 import arrow
-import attr as attrs
+import attrs
+import attrs.validators
 import gevent
 import requests
 

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -500,12 +500,12 @@ STRING_VALIDATORS = [
 
 @attrs.frozen(kw_only=True)
 class EntryPoint:
-    uri: str = attrs.field(validator=STRING_VALIDATORS)
+    uri: str = attrs.field(validator=STRING_VALIDATORS)  # type: ignore
 
 
 @attrs.frozen(kw_only=True)
 class ConferenceSolution:
-    name: str = attrs.field(validator=STRING_VALIDATORS)
+    name: str = attrs.field(validator=STRING_VALIDATORS)  # type: ignore
 
 
 @attrs.frozen(kw_only=True)

--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -3,10 +3,9 @@ import contextlib
 import json
 from datetime import datetime
 from email.utils import parseaddr
-from typing import List, Union
+from typing import Union
 
 import arrow
-import attr as attrs
 from dateutil.parser import parse as date_parse
 from sqlalchemy import (
     Boolean,
@@ -104,28 +103,6 @@ class FlexibleDateTime(TypeDecorator):
             y = arrow.get(y)
 
         return x == y
-
-
-@attrs.frozen(kw_only=True)
-class EntryPoint:
-    uri: str = attrs.field(validator=attrs.validators.instance_of(str))
-
-
-@attrs.frozen(kw_only=True)
-class ConferenceSolution:
-    name: str = attrs.field(validator=attrs.validators.instance_of(str))
-
-
-@attrs.frozen(kw_only=True)
-class ConferenceData:
-    entry_points: List[EntryPoint] = attrs.field(
-        validator=attrs.validators.deep_iterable(
-            attrs.validators.instance_of(EntryPoint)
-        )
-    )
-    conference_solution: ConferenceSolution = attrs.field(
-        validator=attrs.validators.instance_of(ConferenceSolution)
-    )
 
 
 class Event(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMixin):

--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -112,11 +112,19 @@ class EntryPoint:
 
 
 @attrs.frozen(kw_only=True)
+class ConferenceSolution:
+    name: str = attrs.field(validator=attrs.validators.instance_of(str))
+
+
+@attrs.frozen(kw_only=True)
 class ConferenceData:
     entry_points: List[EntryPoint] = attrs.field(
         validator=attrs.validators.deep_iterable(
             attrs.validators.instance_of(EntryPoint)
         )
+    )
+    conference_solution: ConferenceSolution = attrs.field(
+        validator=attrs.validators.instance_of(ConferenceSolution)
     )
 
 

--- a/migrations/versions/260_add_event_conference_data.py
+++ b/migrations/versions/260_add_event_conference_data.py
@@ -1,0 +1,24 @@
+"""add event.conference_data
+
+Revision ID: fe0488decbd1
+Revises: f9dab5e44c0f
+Create Date: 2023-07-03 14:50:25.020134
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "fe0488decbd1"
+down_revision = "f9dab5e44c0f"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    op.add_column(
+        "event", sa.Column("conference_data", sa.Text(length=4194304), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("event", "conference_data")

--- a/tests/events/test_google_events.py
+++ b/tests/events/test_google_events.py
@@ -7,6 +7,7 @@ import gevent
 import pytest
 import requests
 
+from inbox.api.kellogs import _encode
 from inbox.basicauth import AccessNotEnabledError
 from inbox.events.google import GoogleEventsProvider, parse_event_response
 from inbox.models import Calendar, Event
@@ -315,6 +316,135 @@ def test_event_parsing():
     updates = provider.sync_events("uid", 1)
     assert len(updates) == 1
     assert updates[0].read_only is True
+
+
+@pytest.mark.parametrize(
+    "raw_conference_data,conference_data",
+    [
+        ({}, None),
+        (
+            {
+                "conferenceData": {
+                    "entryPoints": [
+                        {
+                            "entryPointType": "video",
+                            "meetingCode": "999999",
+                            "uri": "https://us02web.zoom.us/j/999999",
+                            "label": "us02web.zoom.us/j/999999",
+                        },
+                        {
+                            "entryPointType": "phone",
+                            "regionCode": "US",
+                            "uri": "tel:+1999999,,999999#",
+                            "label": "+1 999999",
+                        },
+                        {
+                            "entryPointType": "more",
+                            "uri": "https://www.google.com/url?q=https://applications.zoom.us/addon/invitation/detail",
+                        },
+                    ],
+                    "signature": "ADR/999999",
+                    "conferenceSolution": {
+                        "iconUri": "https://lh3.googleusercontent.com/",
+                        "name": "Zoom Meeting",
+                        "key": {"type": "addOn"},
+                    },
+                    "parameters": {
+                        "addOnParameters": {
+                            "parameters": {
+                                "meetingType": "2",
+                                "meetingUuid": "999999",
+                                "scriptId": "999999",
+                                "realMeetingId": "999999",
+                                "meetingCreatedBy": "ben.bitdiddle2222@gmail.com",
+                            }
+                        }
+                    },
+                    "conferenceId": "999999",
+                }
+            },
+            {
+                "entry_points": [
+                    {"uri": "https://us02web.zoom.us/j/999999"},
+                    {"uri": "tel:+1999999,,999999#"},
+                    {
+                        "uri": "https://www.google.com/url?q=https://applications.zoom.us/addon/invitation/detail"
+                    },
+                ]
+            },
+        ),
+        (
+            {
+                "conferenceData": {
+                    "entryPoints": [
+                        {
+                            "uri": "https://meet.google.com/999999",
+                            "label": "meet.google.com/999999",
+                            "entryPointType": "video",
+                        },
+                        {
+                            "pin": "999999",
+                            "uri": "https://tel.meet/999999",
+                            "entryPointType": "more",
+                        },
+                        {
+                            "pin": "999999",
+                            "uri": "tel:+1-999999",
+                            "label": "+1 999999",
+                            "regionCode": "US",
+                            "entryPointType": "phone",
+                        },
+                    ],
+                    "conferenceId": "999999",
+                    "conferenceSolution": {
+                        "key": {"type": "hangoutsMeet"},
+                        "name": "Google Meet",
+                        "iconUri": "https://fonts.gstatic.com/s/i/productlogos/",
+                    },
+                }
+            },
+            {
+                "entry_points": [
+                    {"uri": "https://meet.google.com/999999"},
+                    {"uri": "https://tel.meet/999999"},
+                    {"uri": "tel:+1-999999"},
+                ]
+            },
+        ),
+    ],
+)
+def test_event_with_conference_data(raw_conference_data, conference_data):
+    raw_event = {
+        "created": "2014-01-09T03:33:02.000Z",
+        "creator": {
+            "displayName": "Ben Bitdiddle",
+            "email": "ben.bitdiddle2222@gmail.com",
+            "self": True,
+        },
+        "etag": '"2778476764000000"',
+        "htmlLink": "https://www.google.com/calendar/event?eid=BAR",
+        "iCalUID": "20140615_60o30dr564o30c1g60o30dr4ck@google.com",
+        "id": "20140615_60o30dr564o30c1g60o30dr4ck",
+        "kind": "calendar#event",
+        "organizer": {
+            "displayName": "Ben Bitdiddle",
+            "email": "ben.bitdiddle2222@gmail.com",
+            "self": True,
+        },
+        "sequence": 0,
+        "start": {"date": "2014-03-15"},
+        "end": {"date": "2014-03-15"},
+        "status": "confirmed",
+        "summary": "Ides of March",
+        "transparency": "transparent",
+        "updated": "2014-01-09T03:33:02.000Z",
+        "visibility": "public",
+        **raw_conference_data,
+    }
+
+    event = parse_event_response(raw_event, True)
+    assert event.conference_data == conference_data
+    assert _encode(event, "999999")["conference_data"] == conference_data
 
 
 def test_handle_offset_all_day_events():

--- a/tests/events/test_google_events.py
+++ b/tests/events/test_google_events.py
@@ -370,7 +370,8 @@ def test_event_parsing():
                     {
                         "uri": "https://www.google.com/url?q=https://applications.zoom.us/addon/invitation/detail"
                     },
-                ]
+                ],
+                "conference_solution": {"name": "Zoom Meeting"},
             },
         ),
         (
@@ -408,7 +409,8 @@ def test_event_parsing():
                     {"uri": "https://meet.google.com/999999"},
                     {"uri": "https://tel.meet/999999"},
                     {"uri": "tel:+1-999999"},
-                ]
+                ],
+                "conference_solution": {"name": "Google Meet"},
             },
         ),
     ],


### PR DESCRIPTION
To correctly support Zoom and possible other add-ons that you can install into your Google workspace we need to expose Google's `conferenceData` that contains Zoom related data. Zoom add-on does not add anything to event description or location.

To follow previous sync-engine conventions I use `snake_case` instead of `camelCase`. I also only exposed a subset we need i.e. URIs and conference solution name as we don't immediately need all this data and I don't want to needlessly store it in a table that is quite large already. I normally would not want to expose JSON columns but we already do this in sync-engine and if we ever need to support more add-ons and more data it's gonna be easier (every migration needs to be ran across many databases).

Note that I [explicitly validate the JSON values](https://github.com/closeio/sync-engine/pull/491/files#diff-dee09c7df3a55d14417d06301a49bf48015cf0bde72482498c15d77e3fb45d92R492-R541) because I don't want to end up with arbitrary structure saved in the database by mistake. I chose the limits by looking at historical data. sync-engine uses Text columns for storing JSON data.

Deploy plan:
* [x] Run migration across all the database
* [ ] Deploy