### PR TITLE
Upgrade attrs

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -22,7 +22,6 @@ tomli==2.0.1
 typed-ast==1.4.1
 typing_extensions==4.4.0
 mypy_extensions==0.4.3
-types-attrs==19.1.0
 types-boto==2.49.17
 types-python-dateutil==2.8.2
 types-pytz==2021.3.0

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.4
 astor==0.8.1
-attrs==20.2.0
+attrs==23.1.0
 black==19.10b0
 click==7.1.2
 isort==5.4.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -3,7 +3,7 @@ aniso8601==2.0.0
 arrow==0.17.0
 asn1crypto==0.24.0
 asttokens==2.2.1
-attrs==21.2.0
+attrs==23.1.0
 git+https://github.com/closeio/authalligator-client.git@e7cc8e0bc5b1f2285ab5997e2590a8eb056fc627#egg=authalligator_client
 backcall==0.2.0
 jedi==0.18.2


### PR DESCRIPTION
Prerequisite to some work I want to do to improve Zoom support.

Attrs is in general backward compatible so I don't think there's anything to worry about here. The only backward incompatible changes is dropping support for older Python versions.

Changelog

```
## [23.1.0](https://github.com/python-attrs/attrs/tree/23.1.0) - 2023-04-16

### Backwards-incompatible Changes

- Python 3.6 has been dropped and packaging switched to static package data using [Hatch](https://hatch.pypa.io/latest/).
  [#993](https://github.com/python-attrs/attrs/issues/993)


### Deprecations

- The support for *zope-interface* via the `attrs.validators.provides` validator is now deprecated and will be removed in, or after, April 2024.

  The presence of a C-based package in our developement dependencies has caused headaches and we're not under the impression it's used a lot.

  Let us know if you're using it and we might publish it as a separate package.
  [#1120](https://github.com/python-attrs/attrs/issues/1120)


### Changes

- `attrs.filters.exclude()` and `attrs.filters.include()` now support the passing of attribute names as strings.
  [#1068](https://github.com/python-attrs/attrs/issues/1068)
- `attrs.has()` and `attrs.fields()` now handle generic classes correctly.
  [#1079](https://github.com/python-attrs/attrs/issues/1079)
- Fix frozen exception classes when raised within e.g. `contextlib.contextmanager`, which mutates their `__traceback__` attributes.
  [#1081](https://github.com/python-attrs/attrs/issues/1081)
- `@frozen` now works with type checkers that implement [PEP-681](https://peps.python.org/pep-0681/) (ex. [pyright](https://github.com/microsoft/pyright/)).
  [#1084](https://github.com/python-attrs/attrs/issues/1084)
- Restored ability to unpickle instances pickled before 22.2.0.
  [#1085](https://github.com/python-attrs/attrs/issues/1085)
- `attrs.asdict()`'s and `attrs.astuple()`'s type stubs now accept the `attrs.AttrsInstance` protocol.
  [#1090](https://github.com/python-attrs/attrs/issues/1090)
- Fix slots class cellvar updating closure in CPython 3.8+ even when `__code__` introspection is unavailable.
  [#1092](https://github.com/python-attrs/attrs/issues/1092)
- `attrs.resolve_types()` can now pass `include_extras` to `typing.get_type_hints()` on Python 3.9+, and does so by default.
  [#1099](https://github.com/python-attrs/attrs/issues/1099)
- Added instructions for pull request workflow to `CONTRIBUTING.md`.
  [#1105](https://github.com/python-attrs/attrs/issues/1105)
- Added *type* parameter to `attrs.field()` function for use with `attrs.make_class()`.

  Please note that type checkers ignore type metadata passed into `make_class()`, but it can be useful if you're wrapping _attrs_.
  [#1107](https://github.com/python-attrs/attrs/issues/1107)
- It is now possible for `attrs.evolve()` (and `attr.evolve()`) to change fields named `inst` if the instance is passed as a positional argument.

  Passing the instance using the `inst` keyword argument is now deprecated and will be removed in, or after, April 2024.
  [#1117](https://github.com/python-attrs/attrs/issues/1117)
- `attrs.validators.optional()` now also accepts a tuple of validators (in addition to lists of validators).
  [#1122](https://github.com/python-attrs/attrs/issues/1122)


## [22.2.0](https://github.com/python-attrs/attrs/tree/22.2.0) - 2022-12-21

### Backwards-incompatible Changes

- Python 3.5 is not supported anymore.
  [#988](https://github.com/python-attrs/attrs/issues/988)


### Deprecations

- Python 3.6 is now deprecated and support will be removed in the next release.
  [#1017](https://github.com/python-attrs/attrs/issues/1017)


### Changes

- `attrs.field()` now supports an *alias* option for explicit `__init__` argument names.

  Get `__init__` signatures matching any taste, peculiar or plain!
  The [PEP 681 compatible](https://peps.python.org/pep-0681/#field-specifier-parameters) *alias* option can be use to override private attribute name mangling, or add other arbitrary field argument name overrides.
  [#950](https://github.com/python-attrs/attrs/issues/950)
- `attrs.NOTHING` is now an enum value, making it possible to use with e.g. [`typing.Literal`](https://docs.python.org/3/library/typing.html#typing.Literal).
  [#983](https://github.com/python-attrs/attrs/issues/983)
- Added missing re-import of `attr.AttrsInstance` to the `attrs` namespace.
  [#987](https://github.com/python-attrs/attrs/issues/987)
- Fix slight performance regression in classes with custom `__setattr__` and speedup even more.
  [#991](https://github.com/python-attrs/attrs/issues/991)
- Class-creation performance improvements by switching performance-sensitive templating operations to f-strings.

  You can expect an improvement of about 5% -- even for very simple classes.
  [#995](https://github.com/python-attrs/attrs/issues/995)
- `attrs.has()` is now a [`TypeGuard`](https://docs.python.org/3/library/typing.html#typing.TypeGuard) for `AttrsInstance`.
  That means that type checkers know a class is an instance of an `attrs` class if you check it using `attrs.has()` (or `attr.has()`) first.
  [#997](https://github.com/python-attrs/attrs/issues/997)
- Made `attrs.AttrsInstance` stub available at runtime and fixed type errors related to the usage of `attrs.AttrsInstance` in *Pyright*.
  [#999](https://github.com/python-attrs/attrs/issues/999)
- On Python 3.10 and later, call [`abc.update_abstractmethods()`](https://docs.python.org/3/library/abc.html#abc.update_abstractmethods) on dict classes after creation.
  This improves the detection of abstractness.
  [#1001](https://github.com/python-attrs/attrs/issues/1001)
- *attrs*'s pickling methods now use dicts instead of tuples.
  That is safer and more robust across different versions of a class.
  [#1009](https://github.com/python-attrs/attrs/issues/1009)
- Added `attrs.validators.not_(wrapped_validator)` to logically invert *wrapped_validator* by accepting only values where *wrapped_validator* rejects the value with a `ValueError` or `TypeError` (by default, exception types configurable).
  [#1010](https://github.com/python-attrs/attrs/issues/1010)
- The type stubs for `attrs.cmp_using()` now have default values.
  [#1027](https://github.com/python-attrs/attrs/issues/1027)
- To conform with [PEP 681](https://peps.python.org/pep-0681/), `attr.s()` and `attrs.define()` now accept *unsafe_hash* in addition to *hash*.
  [#1065](https://github.com/python-attrs/attrs/issues/1065)


## [22.1.0](https://github.com/python-attrs/attrs/tree/22.1.0) - 2022-07-28

### Backwards-incompatible Changes

- Python 2.7 is not supported anymore.

  Dealing with Python 2.7 tooling has become too difficult for a volunteer-run project.

  We have supported Python 2 more than 2 years after it was officially discontinued and feel that we have paid our dues.
  All version up to 21.4.0 from December 2021 remain fully functional, of course.
  [#936](https://github.com/python-attrs/attrs/issues/936)

- The deprecated `cmp` attribute of `attrs.Attribute` has been removed.
  This does not affect the *cmp* argument to `attr.s` that can be used as a shortcut to set *eq* and *order* at the same time.
  [#939](https://github.com/python-attrs/attrs/issues/939)


### Changes

- Instantiation of frozen slotted classes is now faster.
  [#898](https://github.com/python-attrs/attrs/issues/898)
- If an `eq` key is defined, it is also used before hashing the attribute.
  [#909](https://github.com/python-attrs/attrs/issues/909)
- Added `attrs.validators.min_len()`.
  [#916](https://github.com/python-attrs/attrs/issues/916)
- `attrs.validators.deep_iterable()`'s *member_validator* argument now also accepts a list of validators and wraps them in an `attrs.validators.and_()`.
  [#925](https://github.com/python-attrs/attrs/issues/925)
- Added missing type stub re-imports for `attrs.converters` and `attrs.filters`.
  [#931](https://github.com/python-attrs/attrs/issues/931)
- Added missing stub for `attr(s).cmp_using()`.
  [#949](https://github.com/python-attrs/attrs/issues/949)
- `attrs.validators._in()`'s `ValueError` is not missing the attribute, expected options, and the value it got anymore.
  [#951](https://github.com/python-attrs/attrs/issues/951)
- Python 3.11 is now officially supported.
  [#969](https://github.com/python-attrs/attrs/issues/969)


## [21.4.0](https://github.com/python-attrs/attrs/tree/21.4.0) - 2021-12-29

### Changes

- Fixed the test suite on PyPy3.8 where `cloudpickle` does not work.
  [#892](https://github.com/python-attrs/attrs/issues/892)
- Fixed `coverage report` for projects that use `attrs` and don't set a `--source`.
  [#895](https://github.com/python-attrs/attrs/issues/895),
  [#896](https://github.com/python-attrs/attrs/issues/896)


## [21.3.0](https://github.com/python-attrs/attrs/tree/21.3.0) - 2021-12-28

### Backward-incompatible Changes

- When using `@define`, converters are now run by default when setting an attribute on an instance -- additionally to validators.
  I.e. the new default is `on_setattr=[attrs.setters.convert, attrs.setters.validate]`.

  This is unfortunately a breaking change, but it was an oversight, impossible to raise a `DeprecationWarning` about, and it's better to fix it now while the APIs are very fresh with few users.
  [#835](https://github.com/python-attrs/attrs/issues/835),
  [#886](https://github.com/python-attrs/attrs/issues/886)

- `import attrs` has finally landed!
  As of this release, you can finally import `attrs` using its proper name.

  Not all names from the `attr` namespace have been transferred; most notably `attr.s` and `attr.ib` are missing.
  See `attrs.define` and `attrs.field` if you haven't seen our next-generation APIs yet.
  A more elaborate explanation can be found [On The Core API Names](https://www.attrs.org/en/latest/names.html)

  This feature is at least for one release **provisional**.
  We don't *plan* on changing anything, but such a big change is unlikely to go perfectly on the first strike.

  The API docs have been mostly updated, but it will be an ongoing effort to change everything to the new APIs.
  Please note that we have **not** moved -- or even removed -- anything from `attr`!

  Please do report any bugs or documentation inconsistencies!
  [#887](https://github.com/python-attrs/attrs/issues/887)


### Changes

- `attr.asdict(retain_collection_types=False)` (default) dumps collection-esque keys as tuples.
  [#646](https://github.com/python-attrs/attrs/issues/646),
  [#888](https://github.com/python-attrs/attrs/issues/888)
- `__match_args__` are now generated to support Python 3.10's
  [Structural Pattern Matching](https://docs.python.org/3.10/whatsnew/3.10.html#pep-634-structural-pattern-matching).
  This can be controlled by the `match_args` argument to the class decorators on Python 3.10 and later.
  On older versions, it is never added and the argument is ignored.
  [#815](https://github.com/python-attrs/attrs/issues/815)
- If the class-level *on_setattr* is set to `attrs.setters.validate` (default in `@define` and `@mutable`) but no field defines a validator, pretend that it's not set.
  [#817](https://github.com/python-attrs/attrs/issues/817)
- The generated `__repr__` is significantly faster on Pythons with f-strings.
  [#819](https://github.com/python-attrs/attrs/issues/819)
- Attributes transformed via `field_transformer` are wrapped with `AttrsClass` again.
  [#824](https://github.com/python-attrs/attrs/issues/824)
- Generated source code is now cached more efficiently for identical classes.
  [#828](https://github.com/python-attrs/attrs/issues/828)
- Added `attrs.converters.to_bool()`.
  [#830](https://github.com/python-attrs/attrs/issues/830)
- `attrs.resolve_types()` now resolves types of subclasses after the parents are resolved.
  [#842](https://github.com/python-attrs/attrs/issues/842)
  [#843](https://github.com/python-attrs/attrs/issues/843)
- Added new validators: `lt(val)` (\< val), `le(va)` (≤ val), `ge(val)` (≥ val), `gt(val)` (> val), and `maxlen(n)`.
  [#845](https://github.com/python-attrs/attrs/issues/845)
- `attrs` classes are now fully compatible with [cloudpickle](https://github.com/cloudpipe/cloudpickle) (no need to disable `repr` anymore).
  [#857](https://github.com/python-attrs/attrs/issues/857)
- Added new context manager `attrs.validators.disabled()` and functions `attrs.validators.(set|get)_disabled()`.
  They deprecate `attrs.(set|get)_run_validators()`.
  All functions are interoperable and modify the same internal state.
  They are not – and never were – thread-safe, though.
  [#859](https://github.com/python-attrs/attrs/issues/859)
- `attrs.validators.matches_re()` now accepts pre-compiled regular expressions in addition to pattern strings.
  [#877](https://github.com/python-attrs/attrs/issues/877)
```

Reverse dependencies:

```
attrs==21.2.0
├── authalligator-client==0.1 [requires: attrs]
├── flanker==0.9.11 [requires: attrs]
├── hypothesis==6.30.0 [requires: attrs>=19.2.0]
└── pytest==7.2.0 [requires: attrs>=19.2.0]
    ├── pytest-cov==4.0.0 [requires: pytest>=4.6]
    └── pytest-timeout==2.1.0 [requires: pytest>=5.0.0]
```