### PR TITLE
Upgrade requests and friends

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,10 +11,10 @@ boto==2.49.0
 boto3==1.19.4
 botocore==1.22.9
 cchardet==2.1.7
-certifi==2022.12.7
+certifi==2023.5.7
 cffi==1.15.1
 chardet==3.0.4
-charset-normalizer==2.0.7
+charset-normalizer==3.1.0
 ciso8601==2.2.0
 click==7.1.2
 colorlog==6.5.0
@@ -35,7 +35,7 @@ guppy3==3.1.2
 hiredis==1.1.0
 html2text==2020.1.16
 icalendar==4.0.9
-idna==3.3
+idna==3.4
 imapclient==2.2.0
 importlib-metadata==4.8.1
 importlib-resources==5.4.0
@@ -70,7 +70,7 @@ pytz==2021.3
 PyYAML==5.4.1
 redis==2.10.6
 regex==2021.11.10
-requests==2.26.0
+requests==2.31.0
 requests-file==1.5.1
 rollbar==0.16.2
 s3transfer==0.5.0
@@ -83,7 +83,7 @@ tldextract==3.1.2
 structlog==21.4.0
 traitlets==5.9.0
 typing_extensions==4.0.1
-urllib3==1.26.10
+urllib3==1.26.16
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.7


### PR DESCRIPTION
Sorts out CVE mentioned at the top in the changelog. The only incompatible changes are related to dropping support for old Python versions.

Changelog
```
2.31.0 (2023-05-22)
-------------------

**Security**
- Versions of Requests between v2.3.0 and v2.30.0 are vulnerable to potential
  forwarding of `Proxy-Authorization` headers to destination servers when
  following HTTPS redirects.

  When proxies are defined with user info (https://user:pass@proxy:8080), Requests
  will construct a `Proxy-Authorization` header that is attached to the request to
  authenticate with the proxy.

  In cases where Requests receives a redirect response, it previously reattached
  the `Proxy-Authorization` header incorrectly, resulting in the value being
  sent through the tunneled connection to the destination server. Users who rely on
  defining their proxy credentials in the URL are *strongly* encouraged to upgrade
  to Requests 2.31.0+ to prevent unintentional leakage and rotate their proxy
  credentials once the change has been fully deployed.

  Users who do not use a proxy or do not supply their proxy credentials through
  the user information portion of their proxy URL are not subject to this
  vulnerability.

  Full details can be read in our [Github Security Advisory](https://github.com/psf/requests/security/advisories/GHSA-j8r2-6x86-q33q)
  and [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681).


2.30.0 (2023-05-03)
-------------------

**Dependencies**
- ⚠️ Added support for urllib3 2.0. ⚠️

  This may contain minor breaking changes so we advise careful testing and
  reviewing https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
  prior to upgrading.

  Users who wish to stay on urllib3 1.x can pin to `urllib3<2`.

2.29.0 (2023-04-26)
-------------------

**Improvements**

- Requests now defers chunked requests to the urllib3 implementation to improve
  standardization. (#6226)
- Requests relaxes header component requirements to support bytes/str subclasses. (#6356)

2.28.2 (2023-01-12)
-------------------

**Dependencies**

- Requests now supports charset\_normalizer 3.x. (#6261)

**Bugfixes**

- Updated MissingSchema exception to suggest https scheme rather than http. (#6188)

2.28.1 (2022-06-29)
-------------------

**Improvements**

- Speed optimization in `iter_content` with transition to `yield from`. (#6170)

**Dependencies**

- Added support for chardet 5.0.0 (#6179)
- Added support for charset-normalizer 2.1.0 (#6169)

2.28.0 (2022-06-09)
-------------------

**Deprecations**

- ⚠️ Requests has officially dropped support for Python 2.7. ⚠️ (#6091)
- Requests has officially dropped support for Python 3.6 (including pypy3.6). (#6091)

**Improvements**

- Wrap JSON parsing issues in Request's JSONDecodeError for payloads without
  an encoding to make `json()` API consistent. (#6097)
- Parse header components consistently, raising an InvalidHeader error in
  all invalid cases. (#6154)
- Added provisional 3.11 support with current beta build. (#6155)
- Requests got a makeover and we decided to paint it black. (#6095)

**Bugfixes**

- Fixed bug where setting `CURL_CA_BUNDLE` to an empty string would disable
  cert verification. All Requests 2.x versions before 2.28.0 are affected. (#6074)
- Fixed urllib3 exception leak, wrapping `urllib3.exceptions.SSLError` with
  `requests.exceptions.SSLError` for `content` and `iter_content`. (#6057)
- Fixed issue where invalid Windows registry entries caused proxy resolution
  to raise an exception rather than ignoring the entry. (#6149)
- Fixed issue where entire payload could be included in the error message for
  JSONDecodeError. (#6036)

2.27.1 (2022-01-05)
-------------------

**Bugfixes**

- Fixed parsing issue that resulted in the `auth` component being
  dropped from proxy URLs. (#6028)

2.27.0 (2022-01-03)
-------------------

**Improvements**

- Officially added support for Python 3.10. (#5928)

- Added a `requests.exceptions.JSONDecodeError` to unify JSON exceptions between
  Python 2 and 3. This gets raised in the `response.json()` method, and is
  backwards compatible as it inherits from previously thrown exceptions.
  Can be caught from `requests.exceptions.RequestException` as well. (#5856)

- Improved error text for misnamed `InvalidSchema` and `MissingSchema`
  exceptions. This is a temporary fix until exceptions can be renamed
  (Schema->Scheme). (#6017)

- Improved proxy parsing for proxy URLs missing a scheme. This will address
  recent changes to `urlparse` in Python 3.9+. (#5917)

**Bugfixes**

- Fixed defect in `extract_zipped_paths` which could result in an infinite loop
  for some paths. (#5851)

- Fixed handling for `AttributeError` when calculating length of files obtained
  by `Tarfile.extractfile()`. (#5239)

- Fixed urllib3 exception leak, wrapping `urllib3.exceptions.InvalidHeader` with
  `requests.exceptions.InvalidHeader`. (#5914)

- Fixed bug where two Host headers were sent for chunked requests. (#5391)

- Fixed regression in Requests 2.26.0 where `Proxy-Authorization` was
  incorrectly stripped from all requests sent with `Session.send`. (#5924)

- Fixed performance regression in 2.26.0 for hosts with a large number of
  proxies available in the environment. (#5924)

- Fixed idna exception leak, wrapping `UnicodeError` with
  `requests.exceptions.InvalidURL` for URLs with a leading dot (.) in the
  domain. (#5414)

**Deprecations**

- Requests support for Python 2.7 and 3.6 will be ending in 2022. While we
  don't have exact dates, Requests 2.27.x is likely to be the last release
  series providing support.
```

Forward dependencies

```
requests==2.26.0
├── certifi [required: >=2017.4.17, installed: 2022.12.7]
├── charset-normalizer [required: ~=2.0.0, installed: 2.0.7]
├── idna [required: >=2.5,<4, installed: 3.3]
└── urllib3 [required: >=1.21.1,<1.27, installed: 1.26.10]
```

Reverse dependencies

```
requests==2.26.0
├── authalligator-client==0.1 [requires: requests]
├── requests-file==1.5.1 [requires: requests>=1.0.0]
│   └── tldextract==3.1.2 [requires: requests-file>=1.4]
├── responses==0.22.0 [requires: requests>=2.22.0,<3.0]
├── rollbar==0.16.2 [requires: requests>=0.12.1]
└── tldextract==3.1.2 [requires: requests>=2.1.0]
```