### PR TITLE
Upgrade cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,7 +18,7 @@ charset-normalizer==2.0.7
 ciso8601==2.2.0
 click==7.1.2
 colorlog==6.5.0
-cryptography==39.0.1
+cryptography==41.0.1
 decorator==5.1.1
 dnspython==2.1.0
 executing==1.2.0


### PR DESCRIPTION
pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in cryptography 0.5-40.0.2 are vulnerable to a security issue. More details about the vulnerability itself can be found in https://www.openssl.org/news/secadv/20230530.txt.

Note that we don't use anything from cryptography in this project. It's a dependency of flanker, and we don't use the part of flanker that depends on cryptography.

Changelog

```
.. _v41-0-1:

41.0.1 - 2023-06-01
~~~~~~~~~~~~~~~~~~~

* Temporarily allow invalid ECDSA signature algorithm parameters in X.509
  certificates, which are generated by older versions of Java.
* Allow null bytes in pass phrases when serializing private keys.

.. _v41-0-0:

41.0.0 - 2023-05-30
~~~~~~~~~~~~~~~~~~~

* **BACKWARDS INCOMPATIBLE:** Support for OpenSSL less than 1.1.1d has been
  removed.  Users on older version of OpenSSL will need to upgrade.
* **BACKWARDS INCOMPATIBLE:** Support for Python 3.6 has been removed.
* **BACKWARDS INCOMPATIBLE:** Dropped support for LibreSSL < 3.6.
* Updated the minimum supported Rust version (MSRV) to 1.56.0, from 1.48.0.
* Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.1.1.
* Added support for the :class:`~cryptography.x509.OCSPAcceptableResponses`
  OCSP extension.
* Added support for the :class:`~cryptography.x509.MSCertificateTemplate`
  proprietary Microsoft certificate extension.
* Implemented support for equality checks on all asymmetric public key types.
* Added support for ``aes256-gcm@openssh.com`` encrypted keys in
  :func:`~cryptography.hazmat.primitives.serialization.load_ssh_private_key`.
* Added support for obtaining X.509 certificate signature algorithm parameters
  (including PSS) via
  :meth:`~cryptography.x509.Certificate.signature_algorithm_parameters`.
* Support signing :class:`~cryptography.hazmat.primitives.asymmetric.padding.PSS`
  X.509 certificates via the new keyword-only argument ``rsa_padding`` on
  :meth:`~cryptography.x509.CertificateBuilder.sign`.
* Added support for
  :class:`~cryptography.hazmat.primitives.ciphers.aead.ChaCha20Poly1305`
  on BoringSSL.

.. _v40-0-2:

40.0.2 - 2023-04-14
~~~~~~~~~~~~~~~~~~~

* Fixed compilation when using LibreSSL 3.7.2.
* Added some functions to support an upcoming ``pyOpenSSL`` release.

.. _v40-0-1:

40.0.1 - 2023-03-24
~~~~~~~~~~~~~~~~~~~

* Fixed a bug where certain operations would fail if an object happened to be
  in the top-half of the memory-space. This only impacted 32-bit systems.

.. _v40-0-0:

40.0.0 - 2023-03-24
~~~~~~~~~~~~~~~~~~~


* **BACKWARDS INCOMPATIBLE:** As announced in the 39.0.0 changelog, the way
  ``cryptography`` links OpenSSL has changed. This only impacts users who
  build ``cryptography`` from source (i.e., not from a ``wheel``), and
  specify their own version of OpenSSL. For those users, the ``CFLAGS``,
  ``LDFLAGS``, ``INCLUDE``, ``LIB``, and ``CRYPTOGRAPHY_SUPPRESS_LINK_FLAGS``
  environment variables are no longer valid. Instead, users need to configure
  their builds `as documented here`_.
* Support for Python 3.6 is deprecated and will be removed in the next
  release.
* Deprecated the current minimum supported Rust version (MSRV) of 1.48.0.
  In the next release we will raise MSRV to 1.56.0. Users with the latest
  ``pip`` will typically get a wheel and not need Rust installed, but check
  :doc:`/installation` for documentation on installing a newer ``rustc`` if
  required.
* Deprecated support for OpenSSL less than 1.1.1d. The next release of
  ``cryptography`` will drop support for older versions.
* Deprecated support for DSA keys in
  :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_key`
  and
  :func:`~cryptography.hazmat.primitives.serialization.load_ssh_private_key`.
* Deprecated support for OpenSSH serialization in
  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey`
  and
  :class:`~cryptography.hazmat.primitives.asymmetric.dsa.DSAPrivateKey`.
* The minimum supported version of PyPy3 is now 7.3.10.
* Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.1.0.
* Added support for parsing SSH certificates in addition to public keys with
  :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_identity`.
  :func:`~cryptography.hazmat.primitives.serialization.load_ssh_public_key`
  continues to support only public keys.
* Added support for generating SSH certificates with
  :class:`~cryptography.hazmat.primitives.serialization.SSHCertificateBuilder`.
* Added :meth:`~cryptography.x509.Certificate.verify_directly_issued_by` to
  :class:`~cryptography.x509.Certificate`.
* Added a check to :class:`~cryptography.x509.NameConstraints` to ensure that
  :class:`~cryptography.x509.DNSName` constraints do not contain any ``*``
  wildcards.
* Removed many unused CFFI OpenSSL bindings. This will not impact you unless
  you are using ``cryptography`` to directly invoke OpenSSL's C API. Note that
  these have never been considered a stable, supported, public API by
  ``cryptography``, this note is included as a courtesy.
* The X.509 builder classes now raise ``UnsupportedAlgorithm`` instead of
  ``ValueError`` if an unsupported hash algorithm is passed.
* Added public union type aliases for type hinting:

  * Asymmetric types:
    :const:`~cryptography.hazmat.primitives.asymmetric.types.PublicKeyTypes`,
    :const:`~cryptography.hazmat.primitives.asymmetric.types.PrivateKeyTypes`,
    :const:`~cryptography.hazmat.primitives.asymmetric.types.CertificatePublicKeyTypes`,
    :const:`~cryptography.hazmat.primitives.asymmetric.types.CertificateIssuerPublicKeyTypes`,
    :const:`~cryptography.hazmat.primitives.asymmetric.types.CertificateIssuerPrivateKeyTypes`.
  * SSH keys:
    :const:`~cryptography.hazmat.primitives.serialization.SSHPublicKeyTypes`,
    :const:`~cryptography.hazmat.primitives.serialization.SSHPrivateKeyTypes`,
    :const:`~cryptography.hazmat.primitives.serialization.SSHCertPublicKeyTypes`,
    :const:`~cryptography.hazmat.primitives.serialization.SSHCertPrivateKeyTypes`.
  * PKCS12:
    :const:`~cryptography.hazmat.primitives.serialization.pkcs12.PKCS12PrivateKeyTypes`
  * PKCS7:
    :const:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7HashTypes`,
    :const:`~cryptography.hazmat.primitives.serialization.pkcs7.PKCS7PrivateKeyTypes`.
  * Two-factor:
    :const:`~cryptography.hazmat.primitives.twofactor.hotp.HOTPHashTypes`

* Deprecated previously undocumented but not private type aliases in the
  ``cryptography.hazmat.primitives.asymmetric.types`` module in favor of new
  ones above.


.. _v39-0-2:


39.0.2 - 2023-03-02
~~~~~~~~~~~~~~~~~~~

* Fixed a bug where the content type header was not properly encoded for
  PKCS7 signatures when using the ``Text`` option and ``SMIME`` encoding.
```

Forward dependencies

```
cryptography==39.0.1
└── cffi [required: >=1.12, installed: 1.15.1]
    └── pycparser [required: Any, installed: 2.21]
```

Reverse dependencies

```
cryptography==39.0.1
└── flanker==0.9.11 [requires: cryptography>=0.5]
```