### PR TITLE
Bump cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.1.0
 ciso8601==2.2.0
 click==7.1.2
 colorlog==6.5.0
-cryptography==41.0.1
+cryptography==41.0.2
 decorator==5.1.1
 dnspython==2.1.0
 executing==1.2.0


### PR DESCRIPTION
This PR resolves a security alert for this dependency.

The cryptography package before 41.0.2 for Python mishandles SSH certificates that have critical options.