### PR TITLE
Limit error_message length

### DIFF
--- a/inbox/logging.py
+++ b/inbox/logging.py
@@ -339,11 +339,9 @@ def create_error_log_context(
     if exc_type is None and exc_value is None and exc_tb is None:
         return out
 
-    assert exc_type is not None
-
     # Break down the info as much as Python gives us, for easier aggregation of
     # similar error types.
-    if hasattr(exc_type, "__name__"):
+    if exc_type and hasattr(exc_type, "__name__"):
         out["error_name"] = exc_type.__name__
 
     if hasattr(exc_value, "code"):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,35 @@
+import sys
+from unittest.mock import ANY
+
+import pytest
+
+from inbox.logging import MAX_ERROR_MESSAGE_LENGTH, create_error_log_context
+
+
+@pytest.mark.parametrize(
+    ("error_class", "error_message", "expected_error_log_context"),
+    [
+        (Exception, "test", {"error_name": "Exception", "error_message": "test"}),
+        (
+            ValueError,
+            "test2" * 4096,
+            {
+                "error_name": "ValueError",
+                "error_message": ("test2" * 4096)[:MAX_ERROR_MESSAGE_LENGTH] + "...",
+            },
+        ),
+    ],
+)
+def test_create_error_log_context(
+    error_class, error_message, expected_error_log_context
+):
+    try:
+        raise error_class(error_message)
+    except error_class:
+        exc_info = sys.exc_info()
+
+    error_log_context = create_error_log_context(exc_info)
+
+    assert error_log_context == {**expected_error_log_context, "error_traceback": ANY}
+    assert error_log_context["error_traceback"].startswith("Traceback")
+    assert "test_create_error_log_context" in error_log_context["error_traceback"]


### PR DESCRIPTION
`create_error_log_context` is used to enrich logs with exception information. Sometimes we get a pretty long messages containing several MBs of data. This happens often with IMAP errors when servers returns some type of garbage we cannot parse as imaplib will include entire response in the exception args. This in turn needlessly stresses our logging infra.