### PR TITLE
Update certifi

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,7 +11,7 @@ boto==2.49.0
 boto3==1.19.4
 botocore==1.22.9
 cchardet==2.1.7
-certifi==2023.5.7
+certifi==2023.7.22
 cffi==1.15.1
 chardet==3.0.4
 charset-normalizer==3.1.0


### PR DESCRIPTION
Certifi 2023.07.22 removes root certificates from "e-Tugra" from the root store. These are in the process of being removed from Mozilla's trust store.

e-Tugra's root certificates are being removed pursuant to an investigation prompted by reporting of security issues in their systems. Conclusions of Mozilla's investigation can be found [here](https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/C-HrP1SEq1A).