### PR TITLE
Truncate datetimes that cannot be saved in MySQL

### DIFF
--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -58,6 +58,10 @@ def test_get_microsoft_timezone(windows_tz_id, olson_tz_id):
             },
             datetime.datetime(1, 1, 1, tzinfo=pytz.UTC),
         ),
+        (
+            {"dateTime": "9999-12-31T23:59:59.9999999", "timeZone": "UTC"},
+            datetime.datetime(9999, 12, 31, 23, 59, 59, tzinfo=pytz.UTC),
+        ),
     ],
 )
 def test_parse_msggraph_datetime_tz_as_utc(datetime_tz, dt):


### PR DESCRIPTION
Note that we won't sync this to CRM because I've only seen this on events that have this in body

```
'start': {'dateTime': '9999-12-31T23:59:59.9999999', 'timeZone': 'UTC'},
 'end': {'dateTime': '9999-12-31T23:59:59.9999999', 'timeZone': 'UTC'},
```

and we don't sync events with `start == end` to CRM.