### PR TITLE
convert_flags

### DIFF
--- a/inbox/models/backends/imap.py
+++ b/inbox/models/backends/imap.py
@@ -136,19 +136,19 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
         """
         changed = False
         new_flags = {flag.decode() for flag in new_flags}
-        col_for_flag = {
+        columns_for_flag = {
             "\\Draft": "is_draft",
             "\\Seen": "is_seen",
             "\\Recent": "is_recent",
             "\\Answered": "is_answered",
             "\\Flagged": "is_flagged",
         }
-        for flag, col in col_for_flag.items():
-            prior_flag_value = getattr(self, col)
-            new_flag_value = flag in new_flags
-            if prior_flag_value != new_flag_value:
+        for flag, column in columns_for_flag.items():
+            prior_column_value = getattr(self, column)
+            new_column_value = flag in new_flags
+            if prior_column_value != new_column_value:
                 changed = True
-                setattr(self, col, new_flag_value)
+                setattr(self, column, new_column_value)
             new_flags.discard(flag)
 
         extra_flags = sorted(new_flags)


### PR DESCRIPTION
imaplib parses IMAP responses based on regular expression patterns. If something looks like integer e.g. `"123"` it will be returned as integer `123` to client code and if something looks like string e.g. `"asd"` it will be returned as bytes `b"asd"`.

In general IMAP servers should not mix things that look like strings with things that look like like ints but some IMAP servers (we have at least two different accounts with rollbars) do it. I am pretty sure that int flags are not even valid but couldn't find anything anything in the spec to support this claim. (Flags normally start with \ or $ character which would guarantee the to be bytes).  Nonetheless we don't care about int flags as they are definitely non-standard and we don't know how to interpret them.

The end result here is that if we get an int flag `123` the downstream code will see `b"123"` which will prevent exceptions and make code more type-safe.