### PR TITLE
Bump cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.1.0
 ciso8601==2.2.0
 click==7.1.2
 colorlog==6.5.0
-cryptography==41.0.2
+cryptography==41.0.3
 decorator==5.1.1
 dnspython==2.1.0
 executing==1.2.0


### PR DESCRIPTION
Changelog:

```
41.0.3 - 2023-08-01

    Fixed performance regression loading DH public keys.

    Fixed a memory leak when using ChaCha20Poly1305.

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.1.2.

```