### PR TITLE
Correctly handle None event body for Microsoft calendars

### DIFF
--- a/inbox/events/microsoft/graph_types.py
+++ b/inbox/events/microsoft/graph_types.py
@@ -207,7 +207,7 @@ class MsGraphEvent(TypedDict):
     attendees: List[MsGraphAttendee]
     onlineMeeting: Optional[MsGraphOnelineMeetingInfo]
     locations: List[MsGraphLocation]
-    body: MsGraphItemBody
+    body: Optional[MsGraphItemBody]
     originalStartTimeZone: str
     originalEndTimeZone: str
 

--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -562,6 +562,9 @@ def get_event_description(event: MsGraphEvent) -> Optional[str]:
     Returns:
         Plain text string with all the HTML removed
     """
+    if not event["body"]:
+        return None
+
     content_type = event["body"]["contentType"]
 
     assert content_type in ["text", "html"]

--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -1137,6 +1137,7 @@ def test_get_event_participant(attendee, participant):
             "Test description",
         ),
         ({"body": {"contentType": "text", "content": "Text\n"}}, "Text"),
+        ({"body": None}, None),
     ],
 )
 def test_get_event_description(event, description):


### PR DESCRIPTION
Normally a body is a dictionary that looks like this `{"contentType": "html", "content": "..."}`.
It should not be nullable (at least according to Microsoft) but our experience with Rollbars shows otherwise. Not the first time Microsoft contradicts themselves.