### PR TITLE
Bump flask version

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -16,7 +16,7 @@ cffi==1.15.1
 chardet==3.0.4
 charset-normalizer==3.1.0
 ciso8601==2.2.0
-click==7.1.2
+click==8.1.7
 colorlog==6.5.0
 cryptography==41.0.3
 decorator==5.1.1
@@ -25,7 +25,7 @@ executing==1.2.0
 filelock==3.4.0
 git+https://github.com/closeio/flanker-new.git@fa272d95345d45e8bb1f9bc32bc2c074bf52a484#egg=flanker
 tld==0.12.6
-Flask==2.0.3
+Flask==2.2.5
 Flask-RESTful==0.3.9
 gdata==2.0.18
 gevent==23.7.0


### PR DESCRIPTION
Summary:

Updating Flask to address CVE: https://nvd.nist.gov/vuln/detail/CVE-2023-30861

Test Plan:
Tested via automated tests, will need advice for relevant manual testing.

