### PR TITLE
Fix conference_data not being populated on event updates

### DIFF
--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -320,6 +320,7 @@ class Event(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMi
         self.message = event.message
         self.status = event.status
         self.visibility = event.visibility
+        self.conference_data = event.conference_data
 
         if event.sequence_number is not None:
             self.sequence_number = event.sequence_number

--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -291,7 +291,7 @@ class Event(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMi
 
         return list(self_hash.values())
 
-    def update(self, event):
+    def update(self, event: "Event") -> None:
         if event.namespace is not None and event.namespace.id is not None:
             self.namespace_id = event.namespace.id
 

--- a/tests/events/test_create_and_update.py
+++ b/tests/events/test_create_and_update.py
@@ -28,3 +28,10 @@ def test_init_explodes(cls):
 )
 def test_create_class(kwargs, cls):
     assert isinstance(Event.create(**kwargs), cls)
+
+
+def test_update():
+    event = Event.create()
+    event.update(Event.create(conference_data={"foo": "bar"}))
+
+    assert event.conference_data == {"foo": "bar"}


### PR DESCRIPTION
Back when implementing https://github.com/closeio/sync-engine/pull/491 I forgot about the fact that sync engine always creates transient objects even when doing updates.

i.e. when it updates event objects it does something like that `persistent_event.update(transient_event)`. Every time you add a new column you are supposed to update `.update()`. That means that changes to `conference_data` were never synced after initial event creation.