### PR TITLE
Bump gevent to `23.9.1` to resolve `CVE-2023-41419`

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -28,7 +28,7 @@ tld==0.12.6
 Flask==2.2.5
 Flask-RESTful==0.3.9
 gdata==2.0.18
-gevent==23.7.0
+gevent==23.9.1
 greenlet==2.0.2
 gunicorn==20.1.0
 guppy3==3.1.2


### PR DESCRIPTION
Looks like all the changes are backward-compatible or bugfixes.

### [Changelog](https://www.gevent.org/changelog.html)

<img width="894" alt="Screen Shot 2023-09-26 at 07 45 25" src="https://github.com/closeio/closeio/assets/113755748/c4c5eb34-af77-4b01-afe8-52398edb539f">