### PR TITLE
Make the fact that something is being killed an error

### DIFF
--- a/inbox/instrumentation.py
+++ b/inbox/instrumentation.py
@@ -269,7 +269,7 @@ class KillerGreenletTracer(GreenletTracer):
         # We can't just call activet_greenlet.kill() here because gevent will
         # throw an exception on this thread saying that we would block forever
         # (which is true).
-        self.log.warning(
+        self.log.error(
             "interrupting blocked greenlet",
             context=getattr(active_greenlet, "context", None),
             blocking_greenlet_id=id(active_greenlet),


### PR DESCRIPTION
This may mean that the entire pod gets stalled eventually and should have more visibility in Rollbar