### PR TITLE
Update werkzeug to 3.0.1

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -87,7 +87,7 @@ urllib3==1.26.18
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.7
-Werkzeug==2.2.3
+Werkzeug==3.0.1
 zipp==3.6.0
 zope.event==4.5.0
 zope.interface==5.4.0


### PR DESCRIPTION
Fixes https://github.com/closeio/sync-engine/security/dependabot/31

<details>
<summary>Change Log</summary>

Version 3.0.1
-------------

Released 2023-10-24

-   Fix slow multipart parsing for large parts potentially enabling DoS
    attacks. :cwe:`CWE-407`

Version 3.0.0
-------------

Released 2023-09-30

-   Remove previously deprecated code. :pr:`2768`
-   Deprecate the ``__version__`` attribute. Use feature detection, or
    ``importlib.metadata.version("werkzeug")``, instead. :issue:`2770`
-   ``generate_password_hash`` uses scrypt by default. :issue:`2769`
-   Add the ``"werkzeug.profiler"`` item to the  WSGI ``environ`` dictionary
    passed to `ProfilerMiddleware`'s `filename_format` function. It contains
    the ``elapsed`` and ``time`` values for the profiled request. :issue:`2775`
-   Explicitly marked the PathConverter as non path isolating. :pr:`2784`


Version 2.3.8
-------------

Unreleased


Version 2.3.7
-------------

Released 2023-08-14

-   Use ``flit_core`` instead of ``setuptools`` as build backend.
-   Fix parsing of multipart bodies. :issue:`2734` Adjust index of last newline
    in data start. :issue:`2761`
-   Parsing ints from header values strips spacing first. :issue:`2734`
-   Fix empty file streaming when testing. :issue:`2740`
-   Clearer error message when URL rule does not start with slash. :pr:`2750`
-   ``Accept`` ``q`` value can be a float without a decimal part. :issue:`2751`


Version 2.3.6
-------------

Released 2023-06-08

-   ``FileStorage.content_length`` does not fail if the form data did not provide a
    value. :issue:`2726`


Version 2.3.5
-------------

Released 2023-06-07

-   Python 3.12 compatibility. :issue:`2704`
-   Fix handling of invalid base64 values in ``Authorization.from_header``. :issue:`2717`
-   The debugger escapes the exception message in the page title. :pr:`2719`
-   When binding ``routing.Map``, a long IDNA ``server_name`` with a port does not fail
    encoding. :issue:`2700`
-   ``iri_to_uri`` shows a deprecation warning instead of an error when passing bytes.
    :issue:`2708`
-   When parsing numbers in HTTP request headers such as ``Content-Length``, only ASCII
    digits are accepted rather than any format that Python's ``int`` and ``float``
    accept. :issue:`2716`


Version 2.3.4
-------------

Released 2023-05-08

-   ``Authorization.from_header`` and ``WWWAuthenticate.from_header`` detects tokens
    that end with base64 padding (``=``). :issue:`2685`
-   Remove usage of ``warnings.catch_warnings``. :issue:`2690`
-   Remove ``max_form_parts`` restriction from standard form data parsing and only use
    if for multipart content. :pr:`2694`
-   ``Response`` will avoid converting the ``Location`` header in some cases to preserve
    invalid URL schemes like ``itms-services``. :issue:`2691`


Version 2.3.3
-------------

Released 2023-05-01

-   Fix parsing of large multipart bodies. Remove invalid leading newline, and restore
    parsing speed. :issue:`2658, 2675`
-   The cookie ``Path`` attribute is set to ``/`` by default again, to prevent clients
    from falling back to RFC 6265's ``default-path`` behavior. :issue:`2672, 2679`


Version 2.3.2
-------------

Released 2023-04-28

-   Parse the cookie ``Expires`` attribute correctly in the test client. :issue:`2669`
-   ``max_content_length`` can only be enforced on streaming requests if the server
    sets ``wsgi.input_terminated``. :issue:`2668`


Version 2.3.1
-------------

Released 2023-04-27

-   Percent-encode plus (+) when building URLs and in test requests. :issue:`2657`
-   Cookie values don't quote characters defined in RFC 6265. :issue:`2659`
-   Include ``pyi`` files for ``datastructures`` type annotations. :issue:`2660`
-   ``Authorization`` and ``WWWAuthenticate`` objects can be compared for equality.
    :issue:`2665`


Version 2.3.0
-------------

Released 2023-04-25

-   Drop support for Python 3.7. :pr:`2648`
-   Remove previously deprecated code. :pr:`2592`
-   Passing bytes where strings are expected is deprecated, as well as the ``charset``
    and ``errors`` parameters in many places. Anywhere that was annotated, documented,
    or tested to accept bytes shows a warning. Removing this artifact of the transition
    from Python 2 to 3 removes a significant amount of overhead in instance checks and
    encoding cycles. In general, always work with UTF-8, the modern HTML, URL, and HTTP
    standards all strongly recommend this. :issue:`2602`
-   Deprecate the ``werkzeug.urls`` module, except for the ``uri_to_iri`` and
    ``iri_to_uri`` functions. Use the ``urllib.parse`` library instead. :issue:`2600`
-   Update which characters are considered safe when using percent encoding in URLs,
    based on the WhatWG URL Standard. :issue:`2601`
-   Update which characters are considered safe when using percent encoding for Unicode
    filenames in downloads. :issue:`2598`
-   Deprecate the ``safe_conversion`` parameter of ``iri_to_uri``. The ``Location``
    header is converted to IRI using the same process as everywhere else. :issue:`2609`
-   Deprecate ``werkzeug.wsgi.make_line_iter`` and ``make_chunk_iter``. :pr:`2613`
-   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
    :pr:`2574`
-   ``Request.get_json()`` will raise a ``415 Unsupported Media Type`` error if the
    ``Content-Type`` header is not ``application/json``, instead of a generic 400.
    :issue:`2550`
-   A URL converter's ``part_isolating`` defaults to ``False`` if its ``regex`` contains
    a ``/``. :issue:`2582`
-   A custom converter's regex can have capturing groups without breaking the router.
    :pr:`2596`
-   The reloader can pick up arguments to ``python`` like ``-X dev``, and does not
    require heuristics to determine how to reload the command. Only available
    on Python >= 3.10. :issue:`2589`
-   The Watchdog reloader ignores file opened events. Bump the minimum version of
    Watchdog to 2.3.0. :issue:`2603`
-   When using a Unix socket for the development server, the path can start with a dot.
    :issue:`2595`
-   Increase default work factor for PBKDF2 to 600,000 iterations. :issue:`2611`
-   ``parse_options_header`` is 2-3 times faster. It conforms to :rfc:`9110`, some
    invalid parts that were previously accepted are now ignored. :issue:`1628`
-   The ``is_filename`` parameter to ``unquote_header_value`` is deprecated. :pr:`2614`
-   Deprecate the ``extra_chars`` parameter and passing bytes to ``quote_header_value``,
    the ``allow_token`` parameter to ``dump_header``, and the ``cls`` parameter and
    passing bytes to ``parse_dict_header``. :pr:`2618`
-   Improve ``parse_accept_header`` implementation. Parse according to :rfc:`9110`.
    Discard items with invalid ``q`` values. :issue:`1623`
-   ``quote_header_value`` quotes the empty string. :pr:`2618`
-   ``dump_options_header`` skips ``None`` values rather than using a bare key.
    :pr:`2618`
-   ``dump_header`` and ``dump_options_header`` will not quote a value if the key ends
    with an asterisk ``*``.
-   ``parse_dict_header`` will decode values with charsets. :pr:`2618`
-   Refactor the ``Authorization`` and ``WWWAuthenticate`` header data structures.
    :issue:`1769`, :pr:`2619`

    -   Both classes have ``type``, ``parameters``, and ``token`` attributes. The
        ``token`` attribute supports auth schemes that use a single opaque token rather
        than ``key=value`` parameters, such as ``Bearer``.
    -   Neither class is a ``dict`` anymore, although they still implement getting,
        setting, and deleting ``auth[key]`` and ``auth.key`` syntax, as well as
        ``auth.get(key)`` and ``key in auth``.
    -   Both classes have a ``from_header`` class method. ``parse_authorization_header``
        and ``parse_www_authenticate_header`` are deprecated.
    -   The methods ``WWWAuthenticate.set_basic`` and ``set_digest`` are deprecated.
        Instead, an instance should be created and assigned to
        ``response.www_authenticate``.
    -   A list of instances can be assigned to ``response.www_authenticate`` to set
        multiple header values. However, accessing the property only returns the first
        instance.

-   Refactor ``parse_cookie`` and ``dump_cookie``. :pr:`2637`

    -   ``parse_cookie`` is up to 40% faster, ``dump_cookie`` is up to 60% faster.
    -   Passing bytes to ``parse_cookie`` and ``dump_cookie`` is deprecated. The
        ``dump_cookie`` ``charset`` parameter is deprecated.
    -   ``dump_cookie`` allows ``domain`` values that do not include a dot ``.``, and
        strips off a leading dot.
    -   ``dump_cookie`` does not set ``path="/"`` unnecessarily by default.

-   Refactor the test client cookie implementation. :issue:`1060, 1680`

    -   The ``cookie_jar`` attribute is deprecated. ``http.cookiejar`` is no longer used
        for storage.
    -   Domain and path matching is used when sending cookies in requests. The
        ``domain`` and ``path`` parameters default to ``localhost`` and ``/``.
    -   Added a ``get_cookie`` method to inspect cookies.
    -   Cookies have ``decoded_key`` and ``decoded_value`` attributes to match what the
        app sees rather than the encoded values a client would see.
    -   The first positional ``server_name`` parameter to ``set_cookie`` and
        ``delete_cookie`` is deprecated. Use the ``domain`` parameter instead.
    -   Other parameters to ``delete_cookie`` besides ``domain``, ``path``, and
        ``value`` are deprecated.

-   If ``request.max_content_length`` is set, it is checked immediately when accessing
    the stream, and while reading from the stream in general, rather than only during
    form parsing. :issue:`1513`
-   The development server, which must not be used in production, will exhaust the
    request stream up to 10GB or 1000 reads. This allows clients to see a 413 error if
    ``max_content_length`` is exceeded, instead of a "connection reset" failure.
    :pr:`2620`
-   The development server discards header keys that contain underscores ``_``, as they
    are ambiguous with dashes ``-`` in WSGI. :pr:`2622`
-   ``secure_filename`` looks for more Windows reserved file names. :pr:`2623`
-   Update type annotation for ``best_match`` to make ``default`` parameter clearer.
    :issue:`2625`
-   Multipart parser handles empty fields correctly. :issue:`2632`
-   The ``Map`` ``charset`` parameter and ``Request.url_charset`` property are
    deprecated. Percent encoding in URLs must always represent UTF-8 bytes. Invalid
    bytes are left percent encoded rather than replaced. :issue:`2602`
-   The ``Request.charset``, ``Request.encoding_errors``, ``Response.charset``, and
    ``Client.charset`` attributes are deprecated. Request and response data must always
    use UTF-8. :issue:`2602`
-   Header values that have charset information only allow ASCII, UTF-8, and ISO-8859-1.
    :pr:`2614, 2641`
-   Update type annotation for ``ProfilerMiddleware`` ``stream`` parameter.
    :issue:`2642`
-   Use postponed evaluation of annotations. :pr:`2644`
-   The development server escapes ASCII control characters in decoded URLs before
    logging the request to the terminal. :pr:`2652`
-   The ``FormDataParser`` ``parse_functions`` attribute and ``get_parse_func`` method,
    and the invalid ``application/x-url-encoded`` content type, are deprecated.
    :pr:`2653`
-   ``generate_password_hash`` supports scrypt. Plain hash methods are deprecated, only
    scrypt and pbkdf2 are supported. :issue:`2654`
</details