### PR TITLE
Use send_file to create file download response

### DIFF
--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -1,4 +1,3 @@
-import base64
 import contextlib
 import itertools
 import json
@@ -9,6 +8,7 @@ import uuid
 from collections import namedtuple
 from datetime import datetime
 from hashlib import sha256
+from io import BytesIO
 
 import gevent
 from flask import (
@@ -16,8 +16,8 @@ from flask import (
     Response,
     g,
     jsonify as flask_jsonify,
-    make_response,
     request,
+    send_file,
     stream_with_context,
 )
 from flask_restful import reqparse
@@ -1528,7 +1528,12 @@ def file_download_api(public_id):
         account = g.namespace.account
         statsd_string = f"api.direct_fetching.{account.provider}.{account.id}"
 
-        response = make_response(f.data)
+        response = send_file(
+            BytesIO(f.data),
+            mimetype="application/octet-stream",
+            as_attachment=True,
+            download_name=name,
+        )
         statsd_client.incr(f"{statsd_string}.successes")
 
     except TemporaryEmailFetchException:
@@ -1566,15 +1571,6 @@ def file_download_api(public_id):
         )
 
         return err(404, "Couldn't find data on email server.")
-
-    response.headers["Content-Type"] = "application/octet-stream"  # ct
-    # Try encoding as utf-8 first; if it fails, use RFC2047/MIME encoding.
-    # See https://tools.ietf.org/html/rfc7230#section-3.2.4.
-    try:
-        name = name.encode("utf-8")
-    except UnicodeEncodeError:
-        name = b"=?utf-8?b?" + base64.b64encode(name.encode("latin-1")) + b"?="
-    response.headers["Content-Disposition"] = "attachment; filename=" + name.decode()
 
     request.environ["log_context"]["headers"] = response.headers
     return response

--- a/tests/imap/data.py
+++ b/tests/imap/data.py
@@ -9,6 +9,8 @@ import flanker
 from flanker import mime
 from hypothesis import strategies as s
 
+MAX_INT_VALUE = (1 << 32) - 1
+
 
 def _build_address_header(addresslist):
     return ", ".join(
@@ -68,7 +70,7 @@ mime_message = s.builds(
     basic_text,
 )
 
-randint = s.integers(min_value=0, max_value=1 << 63)
+randint = s.integers(min_value=0, max_value=MAX_INT_VALUE)
 
 uid_data = s.builds(
     build_uid_data,
@@ -82,5 +84,5 @@ uid_data = s.builds(
 
 
 uids = s.dictionaries(
-    s.integers(min_value=22, max_value=1 << 63), uid_data, min_size=5, max_size=10
+    s.integers(min_value=22, max_value=MAX_INT_VALUE), uid_data, min_size=5, max_size=10
 )


### PR DESCRIPTION
[Docs](https://flask.palletsprojects.com/en/3.0.x/api/#flask.send_file).

We should not be encoding those headers manually, instead let Flask do its thing.
Given this code was written more than 10 years ago it does not surprise me the way it was done originally back then.