### PR TITLE
Bump cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.1.0
 ciso8601==2.2.0
 click==8.1.7
 colorlog==6.5.0
-cryptography==41.0.4
+cryptography==41.0.5
 decorator==5.1.1
 dnspython==2.1.0
 executing==1.2.0


### PR DESCRIPTION
Updates bundled OpenSSL version due to CVEs

Changelog

```
41.0.5 - 2023-10-24

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.1.4.
    Added a function to support an upcoming pyOpenSSL release.

```