### PR TITLE
Bugfix: Response is not None

### DIFF
--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -407,7 +407,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
                 # Handle error and return None
                 self._handle_watch_errors(r)
             except requests.exceptions.HTTPError as e:
-                assert e.response
+                assert e.response is not None
                 if e.response.status_code == 404:
                     raise CalendarGoneException(calendar.uid) from e
 


### PR DESCRIPTION
Turns out that Response implements [`__bool__`](https://github.com/psf/requests/blob/main/src/requests/models.py#L730) and returns False for HTTP errors.
What we really wanted is check for None here and since it has `__bool__` we need to do it explicitely.
