### PR TITLE
Bump cryptography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.1.0
 ciso8601==2.2.0
 click==8.1.7
 colorlog==6.5.0
-cryptography==41.0.5
+cryptography==41.0.7
 decorator==5.1.1
 dnspython==2.1.0
 executing==1.2.0


### PR DESCRIPTION
Another day, another CVE

Changelog

```
41.0.7 - 2023-11-27

    Fixed compilation when using LibreSSL 3.8.2.

41.0.6 - 2023-11-27

    Fixed a null-pointer-dereference and segfault that could occur when loading certificates from a PKCS#7 bundle. Credit to pkuzco for reporting the issue. CVE-2023-49083

```