### PR TITLE
Add throttle to /calendar_list_update/<account_public_id>

### DIFF
--- a/tests/webhooks/test_gpush_calendar_notifications.py
+++ b/tests/webhooks/test_gpush_calendar_notifications.py
@@ -173,6 +173,7 @@ def test_receive_sync_message(db, webhooks_client, watched_account, watched_cale
 
 
 def test_calendar_update(db, webhooks_client, watched_account):
+    limitlion.throttle = mock.Mock(return_value=(True, 1, 1))
     calendar_path = CALENDAR_LIST_PATH.format(watched_account.public_id)
 
     before = datetime.utcnow() - timedelta(seconds=1)


### PR DESCRIPTION
Adds a throttle to `/calendar_list_update/<account_public_id>`.

Google allows you to subscribe to the same resource many times. The Google subscription logic in nyls-sync is kind of dumb. It will create a new subscription each time the calendar sync greenlet starts. If for whatever reason it's restarted too many times in short period of time we would indirectly DDOS ourselves by Google, as it will deliver as many notifications for a single change as many times we subscribed.

This how such incident looks like:

![image](https://github.com/closeio/sync-engine/assets/754356/06aea578-e39a-478a-94c4-76189a5c628c)

And then it will trickle down to mysql problems

![image](https://github.com/closeio/sync-engine/assets/754356/282f01fb-3f62-4ad5-b4a0-5ab52eeb0367)



This puts an RPS band-aid we already had in the other endpoint `/calendar_update/<calendar_public_id>`.

This will hopefully keep it from alerting us during Xmas break 🎅.
Long-term we should really ensure that we check in nylas-sync that we don't subscribe to the same resource many times. This would require storing Google `channel id` and `resource id` in the database as Google does not have an API that would allow you to list previously created subscriptions. Not an easy fix as you need to run migrations across all the dbs, but I'll get to it after Xmas.

