### PR TITLE
Fix 404 response status check on calendar sync

### DIFF
--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -358,7 +358,7 @@ class WebhookEventSync(EventSync):
                 try:
                     self._sync_calendar(calendar, db_session)
                 except HTTPError as exc:
-                    assert exc.response
+                    assert exc.response is not None
                     if exc.response.status_code == 404:
                         self.log.warning(
                             "Tried to sync a deleted calendar."


### PR DESCRIPTION
[Response](https://requests.readthedocs.io/en/latest/_modules/requests/models/#Response) class has a `__bool__` that delegates to `.ok` - so it's not suitable for nullability check. This PR use an actual nullability check.

Issue Introduced in https://github.com/closeio/sync-engine/commit/940fe5a44ecc21fac0fbc4d298850ffb5431b24d#diff-8eac2193636c772e0f91e1271b85a19ace467179c8d9743e078dc071f13158cdR361

Fixes https://app.rollbar.com/a/ElasticInc/fix/item/sync-engine/1340