### PR TITLE
Fix 410 response status check on calendar sync

### DIFF
--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -134,7 +134,8 @@ class GoogleEventsProvider(AbstractEventsProvider):
         try:
             return self._get_resource_list(url, updatedMin=sync_from_time_str)
         except requests.exceptions.HTTPError as exc:
-            if exc.response and exc.response.status_code == 410:
+            assert exc.response is not None
+            if exc.response.status_code == 410:
                 # The calendar API may return 410 if you pass a value for
                 # updatedMin that's too far in the past. In that case, refetch
                 # all events.


### PR DESCRIPTION
Another `Response.__bool__` footgun that delegates to `.ok` similar to https://github.com/closeio/sync-engine/pull/630

Fixes https://app.rollbar.com/a/ElasticInc/fix/item/sync-engine/1343

Related to https://github.com/closeio/sync-engine/commit/f2263e7478db22c3874a04cecb82670f1873d87a (cc @gcheshkov)