### PR TITLE
Upgrade lxml

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -44,8 +44,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 jmespath==0.9.3
 limitlion==0.10.0
-lxml==4.9.1
---no-binary lxml
+lxml==5.1.0
 Mako==1.2.2
 MarkupSafe==2.1.2
 matplotlib-inline==0.1.6


### PR DESCRIPTION
Sync-engine uses lxml to parse carddav contact format and we don't use this functionality ourselves so the risk of breakage for us is really low.
