### PR TITLE
Upgrade pynacl

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -64,7 +64,7 @@ pyinstrument==3.2.0
 pyinstrument-cext==0.2.2
 pymongo==3.0  # For json_util in bson
 Pympler==0.9
-PyNaCl==1.4.0
+PyNaCl==1.5.0
 python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==5.4.1


### PR DESCRIPTION
sync-engine uses pynacl to encode/decode passwords and encode/decode S3 blobs.

ARM wheels are available: https://pypi.org/project/PyNaCl/1.5.0/#files

[Changelog](https://github.com/pyca/pynacl/blob/31dc2c1f401a192743b5a3b34125c9baab9df8bc/CHANGELOG.rst?plain=1#L7-L16):
```
1.5.0 (2022-01-07)

    BACKWARDS INCOMPATIBLE: Removed support for Python 2.7 and Python 3.5.
    BACKWARDS INCOMPATIBLE: We no longer distribute manylinux1 wheels.
    Added manylinux2014, manylinux_2_24, musllinux, and macOS universal2 wheels (the latter supports macOS arm64).
    Update libsodium to 1.0.18-stable (July 25, 2021 release).
    Add inline type hints.

```

* [ ] Test if sync works after this upgrade in a production pod where my account runs