### PR TITLE
Improve docker build in CI

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -1,9 +1,7 @@
 name: Build and Release
 
 on:
-  push:
-    branches:
-      - '*'
+  push
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}
@@ -47,13 +45,12 @@ jobs:
     strategy:
       matrix:
         include:
+          # Make sure only one of the builds have dockerhub_push: true
           - arch: amd64
-            build_name: py3.8
             dockerhub_push: true
             python_version: "3.8"
             run_tests: true
           - arch: amd64
-            build_name: py3.9
             dockerhub_push: false
             python_version: "3.9"
             run_tests: true
@@ -71,18 +68,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
       - name: Prepare environment
         run: |
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
             echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
           fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}${{ matrix.dockerhub_push && '' || format('-{0}', matrix.python_version) }}-${{ matrix.arch }}" >> $GITHUB_ENV
         shell: bash
 
       - name: Set up QEMU
@@ -143,27 +134,7 @@ jobs:
       - build
 
     runs-on: ubuntu-20.04
-    
-    strategy:
-      matrix:
-        include:
-          - build_name: py3.8
-
     steps:
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
-      - name: Prepare environment
-        run: |
-          if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
-            echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
-          fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}" >> $GITHUB_ENV
-        shell: bash
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -172,6 +143,7 @@ jobs:
 
       - name: Create manifest
         run: |
+          DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}
           docker buildx imagetools create \
             -t ${{ env.DOCKER_IMAGE_TAG }} \
             ${{ env.DOCKER_IMAGE_TAG }}-amd64

--- a/.github/workflows/build-arm64.yaml
+++ b/.github/workflows/build-arm64.yaml
@@ -1,9 +1,7 @@
 name: Build arm64
 
 on:
-  push:
-    branches:
-      - '*'
+  push
 
 concurrency:
   group: build-arm64-${{ github.event.pull_request.number || github.ref }}
@@ -12,38 +10,20 @@ concurrency:
 env:
   DOCKERHUB_NAMESPACE: closeio
   PROJECT: sync-engine
+  python_version: "3.8"
+  arch: arm64
 
 jobs:
   build-arm64:
     runs-on: ubuntu-20.04
-
-    strategy:
-      matrix:
-        include:
-          - arch: arm64
-            build_name: py3.8
-            dockerhub_push: true
-            python_version: "3.8"
-            run_tests: false
-  
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
       - name: Prepare environment
         run: |
-          if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
-            echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
-          fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}-${{ matrix.arch }}" >> $GITHUB_ENV
-        shell: bash
-        
+          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}-${{ env.arch }}" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -68,30 +48,14 @@ jobs:
       - name: Build and push sync-engine images
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/${{ matrix.arch }}
+          platforms: linux/${{ env.arch }}
           push: false
           load: true
           build-args:
-            PYTHON_VERSION=${{ matrix.python_version }}
-          tags: |
-            ${{ env.DOCKER_IMAGE_TAG }}
+            PYTHON_VERSION=${{ env.python_version }}
+          tags: ${{ env.DOCKER_IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Run tests
-        if: ${{ matrix.run_tests }}
-        run: |
-          docker tag ${{ env.DOCKER_IMAGE_TAG }} ${{ env.PROJECT }}_app
-          if [[ -z $SKIP_TESTS ]]; then
-            docker-compose run app bash -ec '
-              bin/wait-for-it.sh mysql:3306 \
-              && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
-              && coverage html -d pythoncov
-            '
-          else
-            echo Skipping tests
-          fi
-
       - name: Push image
         if: ${{ matrix.dockerhub_push }}
         run: |
@@ -102,27 +66,7 @@ jobs:
       - build-arm64
 
     runs-on: ubuntu-20.04
-    
-    strategy:
-      matrix:
-        include:
-          - build_name: py3.8
-
     steps:
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
-      - name: Prepare environment
-        run: |
-          if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
-            echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
-          fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}" >> $GITHUB_ENV
-        shell: bash
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -133,6 +77,7 @@ jobs:
       # be appended to the existing manifest created by `build-and-release.yaml`.
       - name: Create manifest
         run: |
+          DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}
           docker buildx imagetools create --append \
             -t ${{ env.DOCKER_IMAGE_TAG }} \
             ${{ env.DOCKER_IMAGE_TAG }}-arm64


### PR DESCRIPTION
This uses full SHA commit IDs like we did before, and drops the -py3.x part of the tag - only one interpreter is supported/used.

There's also some general cleanup and simplification of the GHA workflow.