### PR TITLE
Google: Pass eventTypes

### DIFF
--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -132,9 +132,10 @@ class GoogleEventsProvider(AbstractEventsProvider):
         url = "https://www.googleapis.com/calendar/v3/calendars/{}/events".format(
             urllib.parse.quote(calendar_uid)
         )
-        params = {"eventTypes": "default"}
         try:
-            return self._get_resource_list(url, updatedMin=sync_from_time_str, **params)
+            return self._get_resource_list(
+                url, updatedMin=sync_from_time_str, eventTypes="default"
+            )
         except requests.exceptions.HTTPError as exc:
             assert exc.response is not None
             if exc.response.status_code == 410:

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -1,4 +1,5 @@
 """Provide Google Calendar events."""
+
 import datetime
 import email.utils
 import json
@@ -131,8 +132,9 @@ class GoogleEventsProvider(AbstractEventsProvider):
         url = "https://www.googleapis.com/calendar/v3/calendars/{}/events".format(
             urllib.parse.quote(calendar_uid)
         )
+        params = {"eventTypes": "default"}
         try:
-            return self._get_resource_list(url, updatedMin=sync_from_time_str)
+            return self._get_resource_list(url, updatedMin=sync_from_time_str, **params)
         except requests.exceptions.HTTPError as exc:
             assert exc.response is not None
             if exc.response.status_code == 410:
@@ -382,6 +384,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
         try:
             r = requests.post(
                 watch_url,
+                params={"eventTypes": "default"},
                 data=json.dumps(data),
                 headers=headers,
                 auth=OAuthRequestsWrapper(token),


### PR DESCRIPTION
Google will soon start returning other event types in their APIs that we don't care about. This change ensures that everything keeps working as before.

https://developers.google.com/calendar/api/v3/reference/events/list

```
eventTypes 	string 	Event types to return. Optional. This parameter can be repeated multiple times to return events of different types. The default is ["default", "focusTime", "outOfOffice"].

Acceptable values are:

    "default": Regular events.
    "focusTime": Focus time events.
    "outOfOffice": Out of office events.
    "workingLocation": Working location events.
```

![image](https://github.com/closeio/sync-engine/assets/754356/68036949-0304-49eb-a5ab-23c627737a4f)

