### PR TITLE
Events: Periodically switch out of the event parsing loop

### DIFF
--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -91,14 +91,16 @@ class GoogleEventsProvider(AbstractEventsProvider):
             A list of uncommited Event instances
         """
         updates = []
-        items = self._get_raw_events(calendar_uid, sync_from_time)
+        raw_events = self._get_raw_events(calendar_uid, sync_from_time)
         read_only_calendar = self.calendars_table.get(calendar_uid, True)
-        for item in iterate_and_periodically_switch_to_gevent(items):
+        for raw_event in iterate_and_periodically_switch_to_gevent(raw_events):
             try:
-                parsed = parse_event_response(item, read_only_calendar)
+                parsed = parse_event_response(raw_event, read_only_calendar)
                 updates.append(parsed)
             except (arrow.parser.ParserError, ValueError):
-                self.log.warning("Skipping unparseable event", exc_info=True, raw=item)
+                self.log.warning(
+                    "Skipping unparseable event", exc_info=True, raw=raw_event
+                )
 
         return updates
 

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -27,6 +27,7 @@ from inbox.events.util import (
 from inbox.models import Account, Calendar
 from inbox.models.backends.oauth import token_manager
 from inbox.models.event import EVENT_STATUSES, Event
+from inbox.util.concurrency import iterate_and_periodically_switch_to_gevent
 
 CALENDARS_URL = "https://www.googleapis.com/calendar/v3/users/me/calendarList"
 STATUS_MAP = {
@@ -92,7 +93,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
         updates = []
         items = self._get_raw_events(calendar_uid, sync_from_time)
         read_only_calendar = self.calendars_table.get(calendar_uid, True)
-        for item in items:
+        for item in iterate_and_periodically_switch_to_gevent(items):
             try:
                 parsed = parse_event_response(item, read_only_calendar)
                 updates.append(parsed)

--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -27,6 +27,7 @@ from inbox.models.backends.outlook import MICROSOFT_CALENDAR_SCOPES
 from inbox.models.calendar import Calendar
 from inbox.models.event import Event, RecurringEvent
 from inbox.models.session import session_scope
+from inbox.util.concurrency import iterate_and_periodically_switch_to_gevent
 
 URL_PREFIX = config.get("API_URL", "")
 
@@ -135,7 +136,7 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
             ),
         )
         read_only = self.calendars_table.get(calendar_uid, True)
-        for raw_event in raw_events:
+        for raw_event in iterate_and_periodically_switch_to_gevent(raw_events):
             if not validate_event(raw_event):
                 self.log.warning("Invalid event", raw_event=raw_event)
                 continue


### PR DESCRIPTION
Normally these loops parse a very limited number of events, but at the initial sync the implementation will fetch all the events into a list and then start parsing them all. This might block the loop for a little too long and result in the calendar syncing greenlet being interrupted and killed.