### PR TITLE
Revert subscription eventTypes change

### DIFF
--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -387,7 +387,6 @@ class GoogleEventsProvider(AbstractEventsProvider):
         try:
             r = requests.post(
                 watch_url,
-                params={"eventTypes": "default"},
                 data=json.dumps(data),
                 headers=headers,
                 auth=OAuthRequestsWrapper(token),


### PR DESCRIPTION
Originally in https://github.com/closeio/sync-engine/pull/664 we starting passing `eventTypes`. Today when I was doing unrelated changes I realized that the changes aren't arriving close to realtime and the webhooks about changes in the calendar are not delivered anymore. I think Google jinxed themselves and the webhooks API is not working correctly with their new APIs.

Through several manual tests I confirmed that fetching the events works while filtering with `eventTypes`, but webhooks are not delivered (although the subscription is created successfully) with the new parameter.

The rest of the logic will keep working as expected because we only update a timestamp in the database in the API pods, and then in the SYNC pods we fetch changes between the time we last synced and that timestamp. Since sync pods filter out by `eventTypes` even if we receive webhook about changes we are not interested we will just fetch empty resultset from Google.
