### PR TITLE
Upgrade redis-py to 5.0.2

### DIFF
--- a/inbox/heartbeat/store.py
+++ b/inbox/heartbeat/store.py
@@ -161,7 +161,7 @@ class HeartbeatStore:
         assert isinstance(timestamp, float)
         # Update the folder timestamp index for this specific account, too
         client = heartbeat_config.get_redis_client(key.account_id)
-        client.zadd(key.account_id, timestamp, key.folder_id)
+        client.zadd(key.account_id, {key.folder_id: timestamp})
 
     def update_accounts_index(self, key):
         # Find the oldest heartbeat from the account-folder index
@@ -170,7 +170,7 @@ class HeartbeatStore:
             f, oldest_heartbeat = client.zrange(
                 key.account_id, 0, 0, withscores=True
             ).pop()
-            client.zadd("account_index", oldest_heartbeat, key.account_id)
+            client.zadd("account_index", {key.account_id: oldest_heartbeat})
         except Exception:
             # If all heartbeats were deleted at the same time as this, the pop
             # will fail -- ignore it.

--- a/inbox/models/transaction.py
+++ b/inbox/models/transaction.py
@@ -188,4 +188,4 @@ def bump_redis_txn_id(session):
         if (obj in session.new and isinstance(obj, Transaction) and obj.id)
     }
     if mappings:
-        redis_txn.zadd(TXN_REDIS_KEY, **mappings)
+        redis_txn.zadd(TXN_REDIS_KEY, mapping=mappings)

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -32,7 +32,7 @@ gevent==23.9.1
 greenlet==3.0.0
 gunicorn==20.1.0
 guppy3==3.1.2
-hiredis==1.1.0
+hiredis==2.3.2
 html2text==2020.1.16
 icalendar==4.0.9
 idna==3.4
@@ -67,7 +67,7 @@ PyNaCl==1.5.0
 python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==5.4.1
-redis==2.10.6
+redis==4.6.0
 regex==2021.11.10
 requests==2.31.0
 requests-file==1.5.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,6 +5,7 @@ asn1crypto==0.24.0
 asttokens==2.2.1
 attrs==23.1.0
 git+https://github.com/closeio/authalligator-client.git@e7cc8e0bc5b1f2285ab5997e2590a8eb056fc627#egg=authalligator_client
+async_timeout==4.0.3
 backcall==0.2.0
 jedi==0.18.2
 boto==2.49.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -68,7 +68,7 @@ PyNaCl==1.5.0
 python-dateutil==2.8.2
 pytz==2021.3
 PyYAML==5.4.1
-redis==4.6.0
+redis==5.0.2
 regex==2021.11.10
 requests==2.31.0
 requests-file==1.5.1

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -723,6 +723,13 @@ def mock_client():
         return [k for k in mock_client.zrange(key, 0, -1) if k.startswith(match)]
 
     mock_client.zscan_iter = zscan_iter_patch
+
+    def zadd_patch(key, mapping):
+        return mock_client.zadd_orig(key, **mapping)
+
+    mock_client.zadd_orig = mock_client.zadd
+    mock_client.zadd = zadd_patch
+
     return mock_client
 
 

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -725,7 +725,10 @@ def mock_client():
     mock_client.zscan_iter = zscan_iter_patch
 
     def zadd_patch(key, mapping):
-        return mock_client.zadd_orig(key, **mapping)
+        # as of pyredis 3.0, Redis.zadd takes a mapping of {member: score} instead of
+        # the old Redis.zadd method that takes *args of score, member, score,
+        # member or a kwarg mapping of {member: score}
+        return mock_client.zadd_orig(key, **{str(k): v for k, v in mapping.items()})
 
     mock_client.zadd_orig = mock_client.zadd
     mock_client.zadd = zadd_patch


### PR DESCRIPTION
Closes #481 

Upgrades the redis-py library to 5.0.2.  
This also upgrades hiredis to the latest version.

A few usage changes were required due to a breaking API change for `zadd`:
>  * ZADD now requires all element names/scores be specified in a single dictionary argument named mapping. This was required to allow the NX, XX, CH and INCR options to be specified.

We're still using the `mockredis` package to mock redis calls, but that hasn't been updated. I added a patch to translate to the old API still used by `mockredis`. 