### PR TITLE
Rename `inbox.basicauth` to `inbox.exceptions`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ inbox/test/.cache
 /src
 
 # virtualenv
+venv
+.venv
+virtualenv
 /include
 /local
 bin/py*

--- a/bin/inbox-auth.py
+++ b/bin/inbox-auth.py
@@ -13,9 +13,9 @@ from setproctitle import setproctitle
 setproctitle("inbox-auth")
 
 from inbox.auth.base import handler_from_provider
-from inbox.basicauth import NotSupportedError
 from inbox.config import config
 from inbox.error_handling import maybe_enable_rollbar
+from inbox.exceptions import NotSupportedError
 from inbox.logging import configure_logging
 from inbox.models import Account
 from inbox.models.session import session_scope

--- a/inbox/auth/base.py
+++ b/inbox/auth/base.py
@@ -2,8 +2,8 @@ import socket
 
 from imapclient import IMAPClient
 
-from inbox.basicauth import NotSupportedError, UserRecoverableConfigError
 from inbox.crispin import CrispinClient
+from inbox.exceptions import NotSupportedError, UserRecoverableConfigError
 from inbox.logging import get_logger
 from inbox.sendmail.smtp.postel import SMTPClient
 

--- a/inbox/auth/generic.py
+++ b/inbox/auth/generic.py
@@ -5,7 +5,7 @@ import attr
 from imapclient import IMAPClient
 
 from inbox.auth.utils import auth_is_invalid, auth_requires_app_password
-from inbox.basicauth import AppPasswordError, ValidationError
+from inbox.exceptions import AppPasswordError, ValidationError
 from inbox.logging import get_logger
 from inbox.models import Namespace
 from inbox.models.backends.generic import GenericAccount

--- a/inbox/auth/google.py
+++ b/inbox/auth/google.py
@@ -1,8 +1,8 @@
 import attr
 
-from inbox.basicauth import ImapSupportDisabledError, OAuthError
 from inbox.config import config
 from inbox.crispin import GmailCrispinClient
+from inbox.exceptions import ImapSupportDisabledError, OAuthError
 from inbox.logging import get_logger
 from inbox.models import Namespace
 from inbox.models.backends.gmail import GmailAccount

--- a/inbox/auth/microsoft.py
+++ b/inbox/auth/microsoft.py
@@ -1,7 +1,7 @@
 import attr
 
-from inbox.basicauth import OAuthError
 from inbox.config import config
+from inbox.exceptions import OAuthError
 from inbox.models import Namespace
 from inbox.models.backends.outlook import OutlookAccount
 from inbox.models.secret import SecretType

--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -13,8 +13,8 @@ from authalligator_client.enums import AccountErrorCode, ProviderType
 from authalligator_client.exceptions import AccountError
 from imapclient import IMAPClient
 
-from inbox.basicauth import ConnectionError, ImapSupportDisabledError, OAuthError
 from inbox.config import config
+from inbox.exceptions import ConnectionError, ImapSupportDisabledError, OAuthError
 from inbox.logging import get_logger
 from inbox.models.backends.oauth import OAuthAccount, token_manager
 from inbox.models.secret import SecretType

--- a/inbox/auth/utils.py
+++ b/inbox/auth/utils.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from imapclient import IMAPClient
 
-from inbox.basicauth import SSLNotSupportedError
+from inbox.exceptions import SSLNotSupportedError
 from inbox.logging import get_logger
 
 log = get_logger()

--- a/inbox/contacts/google.py
+++ b/inbox/contacts/google.py
@@ -15,8 +15,8 @@ if sys.version_info < (3,):
 import gevent
 
 from inbox.auth.google import GoogleAuthHandler
-from inbox.basicauth import ConnectionError, OAuthError, ValidationError
 from inbox.contacts.abc import AbstractContactsProvider
+from inbox.exceptions import ConnectionError, OAuthError, ValidationError
 from inbox.logging import get_logger
 from inbox.models import Contact
 from inbox.models.backends.gmail import GmailAccount

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -56,7 +56,7 @@ from gevent.lock import BoundedSemaphore
 from gevent.queue import Queue
 from sqlalchemy.orm import joinedload
 
-from inbox.basicauth import GmailSettingError
+from inbox.exceptions import GmailSettingError
 from inbox.folder_edge_cases import localized_folder_names
 from inbox.logging import get_logger
 from inbox.models import Account

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -15,7 +15,6 @@ import gevent
 import requests
 
 from inbox.auth.oauth import OAuthRequestsWrapper
-from inbox.basicauth import AccessNotEnabledError, OAuthError
 from inbox.config import config
 from inbox.events.abstract import AbstractEventsProvider, CalendarGoneException
 from inbox.events.util import (
@@ -24,6 +23,7 @@ from inbox.events.util import (
     parse_datetime,
     parse_google_time,
 )
+from inbox.exceptions import AccessNotEnabledError, OAuthError
 from inbox.models import Account, Calendar
 from inbox.models.backends.oauth import token_manager
 from inbox.models.event import EVENT_STATUSES, Event

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -4,12 +4,12 @@ from typing import Any, List, Tuple, Type
 import more_itertools
 from requests.exceptions import HTTPError
 
-from inbox.basicauth import AccessNotEnabledError, OAuthError
 from inbox.config import config
 from inbox.contacts.processing import update_contacts_from_event
 from inbox.events.abstract import AbstractEventsProvider, CalendarGoneException
 from inbox.events.google import URL_PREFIX
 from inbox.events.recurring import link_events
+from inbox.exceptions import AccessNotEnabledError, OAuthError
 from inbox.logging import get_logger
 from inbox.models import Calendar, Event
 from inbox.models.account import Account

--- a/inbox/exceptions.py
+++ b/inbox/exceptions.py
@@ -1,7 +1,3 @@
-# TODO(emfree): this is now legitimately just a grab-bag of nebulous
-# exceptions.  Rename module and clean up.
-
-
 class AuthError(Exception):
     pass
 

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -73,7 +73,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 
-from inbox.basicauth import ValidationError
+from inbox.exceptions import ValidationError
 from inbox.logging import get_logger
 from inbox.util.concurrency import retry_with_logging
 from inbox.util.debug import bind_context

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -2,8 +2,8 @@ from gevent import sleep
 from gevent.lock import BoundedSemaphore
 from gevent.pool import Group
 
-from inbox.basicauth import ValidationError
 from inbox.crispin import connection_pool, retry_crispin
+from inbox.exceptions import ValidationError
 from inbox.logging import get_logger
 from inbox.mailsync.backends.base import BaseMailSyncMonitor
 from inbox.mailsync.backends.imap.generic import FolderSyncEngine

--- a/inbox/models/backends/oauth.py
+++ b/inbox/models/backends/oauth.py
@@ -10,7 +10,7 @@ from sqlalchemy import Column, ForeignKey
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship
 
-from inbox.basicauth import OAuthError
+from inbox.exceptions import OAuthError
 from inbox.logging import get_logger
 from inbox.models.secret import Secret, SecretType
 

--- a/inbox/providers.py
+++ b/inbox/providers.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from inbox.basicauth import NotSupportedError
+from inbox.exceptions import NotSupportedError
 
 __all__ = ["provider_info", "providers"]
 

--- a/inbox/search/backends/gmail.py
+++ b/inbox/search/backends/gmail.py
@@ -5,7 +5,7 @@ from sqlalchemy import desc
 
 from inbox.api.kellogs import APIEncoder
 from inbox.auth.oauth import OAuthRequestsWrapper
-from inbox.basicauth import OAuthError
+from inbox.exceptions import OAuthError
 from inbox.logging import get_logger
 from inbox.models import Account, Message, Thread
 from inbox.models.backends.oauth import token_manager

--- a/inbox/search/backends/imap.py
+++ b/inbox/search/backends/imap.py
@@ -5,8 +5,8 @@ from imapclient import IMAPClient
 from sqlalchemy import desc
 
 from inbox.api.kellogs import APIEncoder
-from inbox.basicauth import NotSupportedError, ValidationError
 from inbox.crispin import CrispinClient, FolderMissingError
+from inbox.exceptions import NotSupportedError, ValidationError
 from inbox.logging import get_logger
 from inbox.mailsync.backends.imap.generic import UidInvalid, uidvalidity_cb
 from inbox.models import Account, Folder, Message, Thread

--- a/inbox/sendmail/smtp/postel.py
+++ b/inbox/sendmail/smtp/postel.py
@@ -7,7 +7,7 @@ import ssl
 from inbox.logging import get_logger
 
 log = get_logger()
-from inbox.basicauth import OAuthError
+from inbox.exceptions import OAuthError
 from inbox.models.backends.generic import GenericAccount
 from inbox.models.backends.imap import ImapAccount
 from inbox.models.backends.oauth import token_manager

--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -1,6 +1,6 @@
 from gevent import Greenlet, event, sleep
 
-from inbox.basicauth import ConnectionError, ValidationError
+from inbox.exceptions import ConnectionError, ValidationError
 from inbox.heartbeat.store import HeartbeatStatusProxy
 from inbox.logging import get_logger
 from inbox.models import Account

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -9,7 +9,7 @@ import attr
 import dns
 import pytest
 
-from inbox.basicauth import ValidationError
+from inbox.exceptions import ValidationError
 from inbox.util.file import get_data
 
 FILENAMES = [

--- a/tests/api/test_searching.py
+++ b/tests/api/test_searching.py
@@ -236,7 +236,7 @@ def imap_connection(monkeypatch):
 
 @fixture
 def invalid_imap_connection(monkeypatch):
-    from inbox.basicauth import ValidationError
+    from inbox.exceptions import ValidationError
 
     def raise_401(*args):
         raise ValidationError()
@@ -269,7 +269,7 @@ def patch_gmail_search_response():
 
 @fixture
 def invalid_gmail_token(monkeypatch):
-    from inbox.basicauth import OAuthError
+    from inbox.exceptions import OAuthError
 
     def raise_401(*args):
         raise OAuthError()

--- a/tests/api/test_sending.py
+++ b/tests/api/test_sending.py
@@ -8,7 +8,7 @@ from flanker import mime
 
 import inbox.api.ns_api
 import inbox.logging
-from inbox.basicauth import OAuthError
+from inbox.exceptions import OAuthError
 from inbox.models import Event, Message
 from inbox.sendmail.smtp.postel import _substitute_bcc
 

--- a/tests/auth/providers/mock_gmail.py
+++ b/tests/auth/providers/mock_gmail.py
@@ -12,7 +12,7 @@ foobar+no_all_mail@gmail.com.
 """
 
 from inbox.auth.gmail import GmailAuthHandler
-from inbox.basicauth import (
+from inbox.exceptions import (
     GmailSettingError,
     ImapSupportDisabledError,
     OAuthError,

--- a/tests/auth/test_generic_auth.py
+++ b/tests/auth/test_generic_auth.py
@@ -4,7 +4,7 @@ import attr
 import pytest
 
 from inbox.auth.generic import GenericAccountData, GenericAuthHandler
-from inbox.basicauth import SettingUpdateError, ValidationError
+from inbox.exceptions import SettingUpdateError, ValidationError
 from inbox.models.account import Account
 from inbox.util.url import parent_domain
 

--- a/tests/auth/test_gmail_auth.py
+++ b/tests/auth/test_gmail_auth.py
@@ -2,7 +2,7 @@ import attr
 import pytest
 
 from inbox.auth.google import GoogleAccountData, GoogleAuthHandler
-from inbox.basicauth import ImapSupportDisabledError
+from inbox.exceptions import ImapSupportDisabledError
 from inbox.models.account import Account
 from inbox.models.secret import SecretType
 

--- a/tests/events/test_google_events.py
+++ b/tests/events/test_google_events.py
@@ -8,8 +8,8 @@ import pytest
 import requests
 
 from inbox.api.kellogs import _encode
-from inbox.basicauth import AccessNotEnabledError
 from inbox.events.google import GoogleEventsProvider, parse_event_response
+from inbox.exceptions import AccessNotEnabledError
 from inbox.models import Calendar, Event
 from inbox.models.event import RecurringEvent, RecurringEventOverride
 

--- a/tests/general/test_provider_resolution.py
+++ b/tests/general/test_provider_resolution.py
@@ -3,7 +3,7 @@ import pytest
 from inbox.auth.base import handler_from_provider
 from inbox.auth.generic import GenericAuthHandler
 from inbox.auth.google import GoogleAuthHandler
-from inbox.basicauth import NotSupportedError
+from inbox.exceptions import NotSupportedError
 from inbox.util.url import InvalidEmailAddressError, provider_from_address
 
 

--- a/tests/general/test_required_folders.py
+++ b/tests/general/test_required_folders.py
@@ -2,8 +2,8 @@
 import pytest
 
 from inbox.auth.google import GoogleAuthHandler
-from inbox.basicauth import GmailSettingError
 from inbox.crispin import GmailCrispinClient
+from inbox.exceptions import GmailSettingError
 
 
 class AccountStub:

--- a/tests/imap/test_full_imap_enabled.py
+++ b/tests/imap/test_full_imap_enabled.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from imapclient import IMAPClient
 
 from inbox.auth.generic import GenericAuthHandler
-from inbox.basicauth import UserRecoverableConfigError
+from inbox.exceptions import UserRecoverableConfigError
 
 
 class MockIMAPClient(IMAPClient):


### PR DESCRIPTION
The comment at the top of this module already said:
> TODO(emfree): this is now legitimately just a grab-bag of nebulous
> exceptions. Rename module and clean up.