### PR TITLE
Update gunicorn

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -31,7 +31,7 @@ Flask-RESTful==0.3.9
 gdata==2.0.18
 gevent==23.9.1
 greenlet==3.0.0
-gunicorn==20.1.0
+gunicorn==22.0.0
 guppy3==3.1.2
 hiredis==2.3.2
 html2text==2020.1.16


### PR DESCRIPTION
Changelog

```

22.0.0 - 2024-04-17

    use utime to notify workers liveness

    migrate setup to pyproject.toml

    fix numerous security vulnerabilities in HTTP parser (closing some request smuggling vectors)

    parsing additional requests is no longer attempted past unsupported request framing

    on HTTP versions < 1.1 support for chunked transfer is refused (only used in exploits)

    requests conflicting configured or passed SCRIPT_NAME now produce a verbose error

    Trailer fields are no longer inspected for headers indicating secure scheme

    support Python 3.12

** Breaking changes **

    minimum version is Python 3.7

    the limitations on valid characters in the HTTP method have been bounded to Internet Standards

    requests specifying unsupported transfer coding (order) are refused by default (rare)

    HTTP methods are no longer casefolded by default (IANA method registry contains none affected)

    HTTP methods containing the number sign (#) are no longer accepted by default (rare)

    HTTP versions < 1.0 or >= 2.0 are no longer accepted by default (rare, only HTTP/1.1 is supported)

    HTTP versions consisting of multiple digits or containing a prefix/suffix are no longer accepted

    HTTP header field names Gunicorn cannot safely map to variables are silently dropped, as in other software

    HTTP headers with empty field name are refused by default (no legitimate use cases, used in exploits)

    requests with both Transfer-Encoding and Content-Length are refused by default (such a message might indicate an attempt to perform request smuggling)

    empty transfer codings are no longer permitted (reportedly seen with really old & broken proxies)

** SECURITY **

    fix CVE-2024-1135


```