### PR TITLE
Upgrade werkzeug

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -87,7 +87,7 @@ urllib3==1.26.18
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.7
-Werkzeug==3.0.1
+Werkzeug==3.0.3
 zipp==3.6.0
 zope.event==4.5.0
 zope.interface==5.4.0


### PR DESCRIPTION
Upgrade werkzeug


<img width="914" alt="Screenshot 2024-05-23 at 11 19 21" src="https://github.com/closeio/sync-engine/assets/754356/b21abdf3-4fd5-4d35-8627-aef3b3ed5259">

Changelog

```
Version 3.0.3
-------------

Released 2024-05-05

-   Only allow ``localhost``, ``.localhost``, ``127.0.0.1``, or the specified
    hostname when running the dev server, to make debugger requests. Additional
    hosts can be added by using the debugger middleware directly. The debugger
    UI makes requests using the full URL rather than only the path.
    :ghsa:`2g68-c3qc-8985`
-   Make reloader more robust when ``""`` is in ``sys.path``. :pr:`2823`
-   Better TLS cert format with ``adhoc`` dev certs. :pr:`2891`
-   Inform Python < 3.12 how to handle ``itms-services`` URIs correctly, rather
    than using an overly-broad workaround in Werkzeug that caused some redirect
    URIs to be passed on without encoding. :issue:`2828`
-   Type annotation for ``Rule.endpoint`` and other uses of ``endpoint`` is
    ``Any``. :issue:`2836`

-   Make reloader more robust when ``""`` is in ``sys.path``. :pr:`2823`


Version 3.0.2
-------------

Released 2024-04-01

-   Ensure setting ``merge_slashes`` to ``False`` results in ``NotFound`` for
    repeated-slash requests against single slash routes. :issue:`2834`
-   Fix handling of ``TypeError`` in ``TypeConversionDict.get()`` to match
    ``ValueError``. :issue:`2843`
-   Fix ``response_wrapper`` type check in test client. :issue:`2831`
-   Make the return type of ``MultiPartParser.parse`` more precise.
    :issue:`2840`
-   Raise an error if converter arguments cannot be parsed. :issue:`2822`
```