### PR TITLE
Remove pymongo dependency from this project

### DIFF
--- a/inbox/sqlalchemy_ext/json_util.py
+++ b/inbox/sqlalchemy_ext/json_util.py
@@ -15,56 +15,14 @@
 """Tools for using Python's :mod:`json` module with BSON documents.
 
 This module provides two helper methods `dumps` and `loads` that wrap the
-native :mod:`json` methods and provide explicit BSON conversion to and from
-json.  This allows for specialized encoding and decoding of BSON documents
-into `Mongo Extended JSON
+native :mod:`json` methods and provide explicit datetime.datetime conversion to and from
+json.  This is a very stripped version of `Mongo Extended JSON
 <http://www.mongodb.org/display/DOCS/Mongo+Extended+JSON>`_'s *Strict*
-mode.  This lets you encode / decode BSON documents to JSON even when
-they use special BSON types.
+mode handling just datetime.dateime fields because we don't serialize any
+other types that are not handled by JSON.
 
-Example usage (serialization):
-
-.. doctest::
-
-   >>> from bson import Binary, Code
-   >>> from bson.json_util import dumps
-   >>> dumps([{'foo': [1, 2]},
-   ...        {'bar': {'hello': 'world'}},
-   ...        {'code': Code("function x() { return 1; }")},
-   ...        {'bin': Binary("\x01\x02\x03\x04")}])
-   '[{"foo": [1, 2]}, {"bar": {"hello": "world"}}, {"code": {"$code": "function x() { return 1; }", "$scope": {}}}, {"bin": {"$binary": "AQIDBA==", "$type": "00"}}]'
-
-Example usage (deserialization):
-
-.. doctest::
-
-   >>> from bson.json_util import loads
-   >>> loads('[{"foo": [1, 2]}, {"bar": {"hello": "world"}}, {"code": {"$scope": {}, "$code": "function x() { return 1; }"}}, {"bin": {"$type": "00", "$binary": "AQIDBA=="}}]')
-   [{u'foo': [1, 2]}, {u'bar': {u'hello': u'world'}}, {u'code': Code('function x() { return 1; }', {})}, {u'bin': Binary('...', 0)}]
-
-Alternatively, you can manually pass the `default` to :func:`json.dumps`.
-It won't handle :class:`~bson.binary.Binary` and :class:`~bson.code.Code`
-instances (as they are extended strings you can't provide custom defaults),
-but it will be faster as there is less recursion.
-
-.. versionchanged:: 2.8
-   The output format for :class:`~bson.timestamp.Timestamp` has changed from
-   '{"t": <int>, "i": <int>}' to '{"$timestamp": {"t": <int>, "i": <int>}}'.
-   This new format will be decoded to an instance of
-   :class:`~bson.timestamp.Timestamp`. The old format will continue to be
-   decoded to a python dict as before. Encoding to the old format is no longer
-   supported as it was never correct and loses type information.
-   Added support for $numberLong and $undefined - new in MongoDB 2.6 - and
-   parsing $date in ISO-8601 format.
-
-.. versionchanged:: 2.7
-   Preserves order when rendering SON, Timestamp, Code, Binary, and DBRef
-   instances.
-
-.. versionchanged:: 2.3
-   Added dumps and loads helpers to automatically handle conversion to and
-   from json and supports :class:`~bson.binary.Binary` and
-   :class:`~bson.code.Code`
+The original unstripped version of this module can be found at
+https://github.com/mongodb/mongo-python-driver/blob/18328a909545ece6e1cd7e172e28271a59e367d5/bson/json_util.py.
 """
 
 import calendar
@@ -77,27 +35,19 @@ EPOCH_NAIVE = datetime.datetime.utcfromtimestamp(0)
 def dumps(obj, *args, **kwargs):
     """Helper function that wraps :class:`json.dumps`.
 
-    Recursive function that handles all BSON types including
-    :class:`~bson.binary.Binary` and :class:`~bson.code.Code`.
-
-    .. versionchanged:: 2.7
-       Preserves order when rendering SON, Timestamp, Code, Binary, and DBRef
-       instances.
+    Recursive function that handles all datetime.datetime type.
     """
     return json.dumps(_json_convert(obj), *args, **kwargs)
 
 
 def loads(s, *args, **kwargs):
-    """Helper function that wraps :class:`json.loads`.
-
-    Automatically passes the object_hook for BSON type conversion.
-    """
+    """Helper function that wraps :class:`json.loads`."""
     kwargs["object_hook"] = lambda dct: object_hook(dct)
     return json.loads(s, *args, **kwargs)
 
 
 def _json_convert(obj):
-    """Recursive helper method that converts BSON types so they can be
+    """Recursive helper method that converts datetime.datetime type so it can be
     converted into json.
     """
     if hasattr(obj, "items"):
@@ -119,10 +69,7 @@ def object_hook(dct):
 
 
 def default(obj):
-    # We preserve key order when rendering SON, DBRef, etc. as JSON by
-    # returning a SON for those types instead of a dict.
     if isinstance(obj, datetime.datetime):
-        # TODO share this code w/ bson.py?
         if obj.utcoffset() is not None:
             obj = obj - obj.utcoffset()
         millis = int(calendar.timegm(obj.timetuple()) * 1000 + obj.microsecond / 1000)

--- a/inbox/sqlalchemy_ext/json_util.py
+++ b/inbox/sqlalchemy_ext/json_util.py
@@ -176,7 +176,7 @@ def object_hook(dct):
         return MaxKey()
     if "$binary" in dct:
         if isinstance(dct["$type"], int):
-            dct["$type"] = "%02x" % dct["$type"]
+            dct["$type"] = format(dct["$type"], "02x")
         subtype = int(dct["$type"], 16)
         if subtype >= 0xFFFFFF80:  # Handle mongoexport values
             subtype = int(dct["$type"][6:], 16)
@@ -239,11 +239,11 @@ def default(obj):
         return SON(
             [
                 ("$binary", base64.b64encode(obj).decode()),
-                ("$type", "%02x" % obj.subtype),
+                ("$type", format(obj.subtype, "02x")),
             ]
         )
     if PY3 and isinstance(obj, bytes):
         return SON([("$binary", base64.b64encode(obj).decode()), ("$type", "00")])
     if isinstance(obj, uuid.UUID):
         return {"$uuid": obj.hex}
-    raise TypeError("%r is not JSON serializable" % obj)
+    raise TypeError(f"{obj!r} is not JSON serializable")

--- a/inbox/sqlalchemy_ext/json_util.py
+++ b/inbox/sqlalchemy_ext/json_util.py
@@ -75,7 +75,7 @@ import json
 import re
 import uuid
 
-from bson import EPOCH_AWARE, RE_TYPE, SON
+from bson import RE_TYPE, SON
 from bson.binary import Binary
 from bson.code import Code
 from bson.dbref import DBRef
@@ -87,6 +87,8 @@ from bson.py3compat import PY3, iteritems, string_type, text_type
 from bson.regex import Regex
 from bson.timestamp import Timestamp
 from bson.tz_util import utc
+
+EPOCH_NAIVE = datetime.datetime.utcfromtimestamp(0)
 
 _RE_OPT_TABLE = {"i": re.I, "l": re.L, "m": re.M, "s": re.S, "u": re.U, "x": re.X}
 
@@ -163,7 +165,7 @@ def object_hook(dct):
         # mongoexport before 2.6
         else:
             secs = float(dtm) / 1000.0
-        return EPOCH_AWARE + datetime.timedelta(seconds=secs)
+        return EPOCH_NAIVE + datetime.timedelta(seconds=secs)
     if "$regex" in dct:
         flags = 0
         # PyMongo always adds $options but some other tools may not.

--- a/inbox/sqlalchemy_ext/json_util.py
+++ b/inbox/sqlalchemy_ext/json_util.py
@@ -1,0 +1,249 @@
+# Copyright 2009-2015 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for using Python's :mod:`json` module with BSON documents.
+
+This module provides two helper methods `dumps` and `loads` that wrap the
+native :mod:`json` methods and provide explicit BSON conversion to and from
+json.  This allows for specialized encoding and decoding of BSON documents
+into `Mongo Extended JSON
+<http://www.mongodb.org/display/DOCS/Mongo+Extended+JSON>`_'s *Strict*
+mode.  This lets you encode / decode BSON documents to JSON even when
+they use special BSON types.
+
+Example usage (serialization):
+
+.. doctest::
+
+   >>> from bson import Binary, Code
+   >>> from bson.json_util import dumps
+   >>> dumps([{'foo': [1, 2]},
+   ...        {'bar': {'hello': 'world'}},
+   ...        {'code': Code("function x() { return 1; }")},
+   ...        {'bin': Binary("\x01\x02\x03\x04")}])
+   '[{"foo": [1, 2]}, {"bar": {"hello": "world"}}, {"code": {"$code": "function x() { return 1; }", "$scope": {}}}, {"bin": {"$binary": "AQIDBA==", "$type": "00"}}]'
+
+Example usage (deserialization):
+
+.. doctest::
+
+   >>> from bson.json_util import loads
+   >>> loads('[{"foo": [1, 2]}, {"bar": {"hello": "world"}}, {"code": {"$scope": {}, "$code": "function x() { return 1; }"}}, {"bin": {"$type": "00", "$binary": "AQIDBA=="}}]')
+   [{u'foo': [1, 2]}, {u'bar': {u'hello': u'world'}}, {u'code': Code('function x() { return 1; }', {})}, {u'bin': Binary('...', 0)}]
+
+Alternatively, you can manually pass the `default` to :func:`json.dumps`.
+It won't handle :class:`~bson.binary.Binary` and :class:`~bson.code.Code`
+instances (as they are extended strings you can't provide custom defaults),
+but it will be faster as there is less recursion.
+
+.. versionchanged:: 2.8
+   The output format for :class:`~bson.timestamp.Timestamp` has changed from
+   '{"t": <int>, "i": <int>}' to '{"$timestamp": {"t": <int>, "i": <int>}}'.
+   This new format will be decoded to an instance of
+   :class:`~bson.timestamp.Timestamp`. The old format will continue to be
+   decoded to a python dict as before. Encoding to the old format is no longer
+   supported as it was never correct and loses type information.
+   Added support for $numberLong and $undefined - new in MongoDB 2.6 - and
+   parsing $date in ISO-8601 format.
+
+.. versionchanged:: 2.7
+   Preserves order when rendering SON, Timestamp, Code, Binary, and DBRef
+   instances.
+
+.. versionchanged:: 2.3
+   Added dumps and loads helpers to automatically handle conversion to and
+   from json and supports :class:`~bson.binary.Binary` and
+   :class:`~bson.code.Code`
+"""
+
+import base64
+import calendar
+import collections
+import datetime
+import json
+import re
+import uuid
+
+from bson import EPOCH_AWARE, RE_TYPE, SON
+from bson.binary import Binary
+from bson.code import Code
+from bson.dbref import DBRef
+from bson.int64 import Int64
+from bson.max_key import MaxKey
+from bson.min_key import MinKey
+from bson.objectid import ObjectId
+from bson.py3compat import PY3, iteritems, string_type, text_type
+from bson.regex import Regex
+from bson.timestamp import Timestamp
+from bson.tz_util import utc
+
+_RE_OPT_TABLE = {"i": re.I, "l": re.L, "m": re.M, "s": re.S, "u": re.U, "x": re.X}
+
+
+def dumps(obj, *args, **kwargs):
+    """Helper function that wraps :class:`json.dumps`.
+
+    Recursive function that handles all BSON types including
+    :class:`~bson.binary.Binary` and :class:`~bson.code.Code`.
+
+    .. versionchanged:: 2.7
+       Preserves order when rendering SON, Timestamp, Code, Binary, and DBRef
+       instances.
+    """
+    return json.dumps(_json_convert(obj), *args, **kwargs)
+
+
+def loads(s, *args, **kwargs):
+    """Helper function that wraps :class:`json.loads`.
+
+    Automatically passes the object_hook for BSON type conversion.
+    """
+    kwargs["object_hook"] = lambda dct: object_hook(dct)
+    return json.loads(s, *args, **kwargs)
+
+
+def _json_convert(obj):
+    """Recursive helper method that converts BSON types so they can be
+    converted into json.
+    """
+    if hasattr(obj, "iteritems") or hasattr(obj, "items"):  # PY3 support
+        return SON(((k, _json_convert(v)) for k, v in iteritems(obj)))
+    elif hasattr(obj, "__iter__") and not isinstance(obj, (text_type, bytes)):
+        return list((_json_convert(v) for v in obj))
+    try:
+        return default(obj)
+    except TypeError:
+        return obj
+
+
+def object_hook(dct):
+    if "$oid" in dct:
+        return ObjectId(str(dct["$oid"]))
+    if "$ref" in dct:
+        return DBRef(dct["$ref"], dct["$id"], dct.get("$db", None))
+    if "$date" in dct:
+        dtm = dct["$date"]
+        # mongoexport 2.6 and newer
+        if isinstance(dtm, string_type):
+            aware = datetime.datetime.strptime(
+                dtm[:23], "%Y-%m-%dT%H:%M:%S.%f"
+            ).replace(tzinfo=utc)
+            offset = dtm[23:]
+            if not offset or offset == "Z":
+                # UTC
+                return aware
+            else:
+                if len(offset) == 5:
+                    # Offset from mongoexport is in format (+|-)HHMM
+                    secs = int(offset[1:3]) * 3600 + int(offset[3:]) * 60
+                elif ":" in offset and len(offset) == 6:
+                    # RFC-3339 format (+|-)HH:MM
+                    hours, minutes = offset[1:].split(":")
+                    secs = int(hours) * 3600 + int(minutes) * 60
+                else:
+                    # Not RFC-3339 compliant or mongoexport output.
+                    raise ValueError("invalid format for offset")
+                if offset[0] == "-":
+                    secs *= -1
+                return aware - datetime.timedelta(seconds=secs)
+        # mongoexport 2.6 and newer, time before the epoch (SERVER-15275)
+        elif isinstance(dtm, collections.Mapping):
+            secs = float(dtm["$numberLong"]) / 1000.0
+        # mongoexport before 2.6
+        else:
+            secs = float(dtm) / 1000.0
+        return EPOCH_AWARE + datetime.timedelta(seconds=secs)
+    if "$regex" in dct:
+        flags = 0
+        # PyMongo always adds $options but some other tools may not.
+        for opt in dct.get("$options", ""):
+            flags |= _RE_OPT_TABLE.get(opt, 0)
+        return Regex(dct["$regex"], flags)
+    if "$minKey" in dct:
+        return MinKey()
+    if "$maxKey" in dct:
+        return MaxKey()
+    if "$binary" in dct:
+        if isinstance(dct["$type"], int):
+            dct["$type"] = "%02x" % dct["$type"]
+        subtype = int(dct["$type"], 16)
+        if subtype >= 0xFFFFFF80:  # Handle mongoexport values
+            subtype = int(dct["$type"][6:], 16)
+        return Binary(base64.b64decode(dct["$binary"].encode()), subtype)
+    if "$code" in dct:
+        return Code(dct["$code"], dct.get("$scope"))
+    if "$uuid" in dct:
+        return uuid.UUID(dct["$uuid"])
+    if "$undefined" in dct:
+        return None
+    if "$numberLong" in dct:
+        return Int64(dct["$numberLong"])
+    if "$timestamp" in dct:
+        tsp = dct["$timestamp"]
+        return Timestamp(tsp["t"], tsp["i"])
+    return dct
+
+
+def default(obj):
+    # We preserve key order when rendering SON, DBRef, etc. as JSON by
+    # returning a SON for those types instead of a dict.
+    if isinstance(obj, ObjectId):
+        return {"$oid": str(obj)}
+    if isinstance(obj, DBRef):
+        return _json_convert(obj.as_doc())
+    if isinstance(obj, datetime.datetime):
+        # TODO share this code w/ bson.py?
+        if obj.utcoffset() is not None:
+            obj = obj - obj.utcoffset()
+        millis = int(calendar.timegm(obj.timetuple()) * 1000 + obj.microsecond / 1000)
+        return {"$date": millis}
+    if isinstance(obj, (RE_TYPE, Regex)):
+        flags = ""
+        if obj.flags & re.IGNORECASE:
+            flags += "i"
+        if obj.flags & re.LOCALE:
+            flags += "l"
+        if obj.flags & re.MULTILINE:
+            flags += "m"
+        if obj.flags & re.DOTALL:
+            flags += "s"
+        if obj.flags & re.UNICODE:
+            flags += "u"
+        if obj.flags & re.VERBOSE:
+            flags += "x"
+        if isinstance(obj.pattern, text_type):
+            pattern = obj.pattern
+        else:
+            pattern = obj.pattern.decode("utf-8")
+        return SON([("$regex", pattern), ("$options", flags)])
+    if isinstance(obj, MinKey):
+        return {"$minKey": 1}
+    if isinstance(obj, MaxKey):
+        return {"$maxKey": 1}
+    if isinstance(obj, Timestamp):
+        return {"$timestamp": SON([("t", obj.time), ("i", obj.inc)])}
+    if isinstance(obj, Code):
+        return SON([("$code", str(obj)), ("$scope", obj.scope)])
+    if isinstance(obj, Binary):
+        return SON(
+            [
+                ("$binary", base64.b64encode(obj).decode()),
+                ("$type", "%02x" % obj.subtype),
+            ]
+        )
+    if PY3 and isinstance(obj, bytes):
+        return SON([("$binary", base64.b64encode(obj).decode()), ("$type", "00")])
+    if isinstance(obj, uuid.UUID):
+        return {"$uuid": obj.hex}
+    raise TypeError("%r is not JSON serializable" % obj)

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -6,7 +6,6 @@ import uuid
 import weakref
 from typing import Any, MutableMapping, Optional, Tuple
 
-from bson import EPOCH_NAIVE
 from sqlalchemy import String, Text, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.mutable import Mutable
@@ -17,10 +16,6 @@ from sqlalchemy.types import BINARY, TypeDecorator
 from inbox.logging import get_logger
 from inbox.sqlalchemy_ext import json_util
 from inbox.util.encoding import base36decode, base36encode
-
-# Monkeypatch to not include tz_info in decoded JSON.
-# Kind of a ridiculous solution, but works.
-json_util.EPOCH_AWARE = EPOCH_NAIVE
 
 log = get_logger()
 

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -6,12 +6,7 @@ import uuid
 import weakref
 from typing import Any, MutableMapping, Optional, Tuple
 
-from bson import EPOCH_NAIVE, json_util
-
-# Monkeypatch to not include tz_info in decoded JSON.
-# Kind of a ridiculous solution, but works.
-json_util.EPOCH_AWARE = EPOCH_NAIVE
-
+from bson import EPOCH_NAIVE
 from sqlalchemy import String, Text, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.mutable import Mutable
@@ -20,7 +15,12 @@ from sqlalchemy.sql import operators
 from sqlalchemy.types import BINARY, TypeDecorator
 
 from inbox.logging import get_logger
+from inbox.sqlalchemy_ext import json_util
 from inbox.util.encoding import base36decode, base36encode
+
+# Monkeypatch to not include tz_info in decoded JSON.
+# Kind of a ridiculous solution, but works.
+json_util.EPOCH_AWARE = EPOCH_NAIVE
 
 log = get_logger()
 

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -164,8 +164,8 @@ class Base36UID(TypeDecorator):
 
 
 # http://bit.ly/1LbMnqu
-# Can simply use this as is because though we use bson.json_util, loads()
-# dumps() return standard Python dicts like the json.* equivalents
+# Can simply use this as is because though we use inbox.sqlalchemy_ext.json_util,
+# loads() dumps() return standard Python dicts like the json.* equivalents
 # (because these are simply called under the hood)
 class MutableDict(Mutable, dict):
     @classmethod

--- a/migrations/versions/057_consolidate_account_sync_status_columns.py
+++ b/migrations/versions/057_consolidate_account_sync_status_columns.py
@@ -12,7 +12,8 @@ down_revision = "4b4c5579c083"
 
 import sqlalchemy as sa
 from alembic import op
-from bson import json_util
+
+from inbox.sqlalchemy_ext import json_util
 
 
 def upgrade():

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -62,7 +62,6 @@ pycparser==2.21
 pygments==2.17.2
 pyinstrument==3.2.0
 pyinstrument-cext==0.2.2
-pymongo==3.0  # For json_util in bson
 Pympler==0.9
 PyNaCl==1.5.0
 python-dateutil==2.8.2


### PR DESCRIPTION
The original authors of this project chose to use pymongo's bson utils to handle JSON serialization and deserialization into various VARCHAR types in MySQL.

We have an unresolved security issue related to pymongo.

![image](https://github.com/closeio/sync-engine/assets/754356/548e235a-4140-4529-8aaa-78d778668196)

I've had questions in the past why are we using pymongo here, it suggests that sync-engine uses MongoDB while it does not. I think it's time to break that dependency because it just brings confusion, and pymongo will continue to receive security patches often as it contains C code which makes it prone to security bugs.

MongoDB's extended JSON syntax can serialize more types than stdlib's json module. [The docs](https://www.mongodb.com/docs/manual/reference/mongodb-extended-json/).

Pymongo's implementation sits in here https://github.com/mongodb/mongo-python-driver/blob/18328a909545ece6e1cd7e172e28271a59e367d5/bson/json_util.py. As you can see it handles many extra types. I analyzed all the call sites and data in those columns for `\$\w` references and concluded that we are only using `"field": {"$date": <timestmp>}` syntax in sync-engine.

Example

```json
{"sync_disabled_by": null, "sync_start_time": {"$date": 1717004873429}, "original_start_time": {"$date": 1522779878389}, "sync_error": null, "sync_disabled_on": null, "sync_end_time": null, "sync_disabled_reason": null}
```

I've vendored the code and then stripped it to only include the parts that we are using.

Separately I think it makes sense to [completely get rid of this $date syntax](https://github.com/closeio/sync-engine/issues/775) as I don't find it particularly readable.

I've already tested those changes first on my account in production and also on an entire cluster (nylas-e) and did not see any problems.

<details>
<summary>My intenral monologue about columns using JSON types</summary>

* `actionlog.extra_args` https://github.com/closeio/sync-engine/blob/64e70ec06139ab63f676c98c51db9eaccfbbbe6d/inbox/models/action_log.py#L67

```sql
SELECT DISTINCT extra_args FROM (SELECT extra_args from actionlog a LIMIT 500000) As a;
```

|extra_args|
|----------|
|{"unread": false}|
|{"added_labels": [], "removed_labels": ["\\Inbox"]}|
|{"destination": "INBOX.Archive"}|
|{"destination": "INBOX"}|
|{"added_labels": ["\\Trash"], "removed_labels": ["\\Inbox"]}|
|{"added_labels": ["\\Inbox"], "removed_labels": []}|
|{"added_labels": [], "removed_labels": ["\\Inbox", "\\Trash"]}|
|{"added_labels": ["\\Important", "\\All"], "removed_labels": []}|
|{"added_labels": ["\\Important"], "removed_labels": []}|


* `account.sync_status` https://github.com/closeio/sync-engine/blob/c064bf8f55bc190298b7f43504442c8f535089a4/inbox/models/account.py#L182

```sql
SELECT account._sync_status FROM account LIMIT 1;
```

|_sync_status|
|------------|
|{"sync_disabled_by": null, "sync_start_time": {"$date": 1717004873429}, "original_start_time": {"$date": 1522779878389}, "sync_error": null, "sync_disabled_on": null, "sync_end_time": null, "sync_disabled_reason": null}|


```sql
SELECT DISTINCT REGEXP_SUBSTR(account._sync_status, "\\$\\w+") FROM account WHERE account._sync_status LIKE "%$%";
```

|REGEXP_SUBSTR(account._sync_status, "\\$\\w+")|
|----------------------------------------------|
|$date|


* `imapuid.extra_flags` https://github.com/closeio/sync-engine/blob/1b7f90d353ec667e2e94828c367683d311f67382/inbox/models/backends/imap.py#L125

```sql
SELECT DISTINCT extra_flags FROM (SELECT extra_flags from imapuid a LIMIT 50000) As a;
```

|extra_flags|
|-----------|
|[]|
|["$NotJunk", "NotJunk"]|
|["$Forwarded", "Forwarded"]|
|["$Forwarded", "$NotJunk", "NotJunk"]|
|["$Forwarded"]|
|["$Phishing"]|
|["$NotJunk", "JunkRecorded", "NotJunk"]|
|["$Forwarded", "$NotJunk", "Forwarded", "JunkRecorded", "NotJunk"]|
|["$MailFlagBit0", "$NotJunk", "JunkRecorded", "NotJunk"]|
|["$MailFlagBit0", "$MailFlagBit2"]|
|["$MailFlagBit0"]|
|["$Forwarded", "$NotJunk", "Forwarded", "NotJunk"]|
|["$MailFlagBit0", "$MailFlagBit2", "$NotJunk", "JunkRecorded", "NotJunk"]|
|["$MailFlagBit1", "$NotJunk", "JunkRecorded", "NotJunk"]|
|["$MailFlagBit1"]|
|["$MailFlagBit0", "$MailFlagBit2", "$Phishing"]|

* `imapuid.g_labels` https://github.com/closeio/sync-engine/blob/1b7f90d353ec667e2e94828c367683d311f67382/inbox/models/backends/imap.py#L128

```sql
SELECT DISTINCT g_labels FROM (SELECT g_labels from imapuid a LIMIT 500000) As a;
```

|g_labels|
|--------|
|[]|

* `message.from_addr` `message.sender_addr` `message.reply_to` `message.to_addr` `message.cc_addr` `message.bcc_adr` `message.in_reply_to` https://github.com/closeio/sync-engine/blob/1b7f90d353ec667e2e94828c367683d311f67382/inbox/models/message.py#L133-L139

```sql
SELECT from_addr, sender_addr, reply_to, to_addr, cc_addr, bcc_addr, in_reply_to FROM message LIMIT 100;
```

Looks like json encoded:
from_addr list[tuple[str, str]]
sender_addr list[tuple[str, str]]
reply_to list[tuple[str, str]]
to_addr list[tuple[str, str]]
cc_addr list[tuple[str, str]]
bcc_addr list[truple[str, str]]
in_reply_to str

* `metadata.value` https://github.com/closeio/sync-engine/blob/05bc8c9414319f28248ffe7fd3e2c4e40f5f6725/inbox/models/metadata.py#L50-L51

This table is empty

* `event.participants` https://github.com/closeio/sync-engine/blob/1b7f90d353ec667e2e94828c367683d311f67382/inbox/models/event.py#L176


list[{"status": enum, notes: str, guests: list[?], name: str, email: str}]  
<details>