### PR TITLE
Use local gevent wheel on aarch64

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.png binary
 *.jpg binary
 *.ics binary
+*.whl binary

--- a/local_wheels/README.md
+++ b/local_wheels/README.md
@@ -1,0 +1,25 @@
+Rebuilding ARM64 wheels locally
+-------------------------------
+
+Building ARM64 wheels on x86_64 Github runners is slow due to emulation. At the time of writing Gevent did not provide
+aarch64 wheels for Python 3.8. Gevent takes ~30 minutes to build. We can instead build it locally and commit it into the repository to speed up the builds.
+
+First make sure you have `cibuildwheel` installed
+
+```bash
+pipx install cibuildwheel
+```
+
+Download sdist (source distribution) for the verion of gevent you want to use. You can find the link by browsing PyPI.
+
+```bash
+wget https://files.pythonhosted.org/packages/27/24/a3a7b713acfcf1177207f49ec25c665123f8972f42bee641bcc9f32961f4/gevent-24.2.1.tar.gz
+```
+
+Finally build it
+
+```
+CIBW_BUILD='cp38-manylinux_aarch64' pipx run cibuildwheel --platform linux --output-dir local_wheels gevent-24.2.1.tar.gz
+```
+
+Now you can commit that file and also make sure to make changes to `requirements/prod.txt` with the new version.

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -29,7 +29,10 @@ tld==0.12.6
 Flask==2.2.5
 Flask-RESTful==0.3.9
 gdata==2.0.18
-gevent==24.2.1
+gevent==24.2.1; platform_machine != 'aarch64'
+# Building gevent from source is too slow on GitHub Actions emulating aarch64.
+# See local_wheels/README.md for more information.
+./local_wheels/gevent-24.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl; platform_machine == 'aarch64'
 greenlet==3.0.3
 gunicorn==22.0.0
 guppy3==3.1.2


### PR DESCRIPTION
We are currently building gevent ARM64 wheel on x86_64. Using prebuilt wheel we can speed up CI a lot.

Before:

![image](https://github.com/closeio/sync-engine/assets/754356/aa2e6624-5410-448b-8a35-719dee61183b)


After

![image](https://github.com/closeio/sync-engine/assets/754356/2bb5a609-04f1-4eca-bfb7-38f537991140)
