### PR TITLE
Upgrade gevent and greenlet

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -29,8 +29,8 @@ tld==0.12.6
 Flask==2.2.5
 Flask-RESTful==0.3.9
 gdata==2.0.18
-gevent==23.9.1
-greenlet==3.0.0
+gevent==24.2.1
+greenlet==3.0.3
 gunicorn==22.0.0
 guppy3==3.1.2
 hiredis==2.3.2


### PR DESCRIPTION
No security patches but some crashes fixed here and there, so want to keep this up to date.

gevent changelog

```
24.2.1 (2024-02-14)
===================


Bugfixes
--------

- Add support for Python patch releases 3.11.8 and 3.12.2, which changed
  internal details of threading.

  As a result of these changes, note that it is no longer possible to
  change the ``__class__`` of a ``gevent.threading._DummyThread``
  object on those versions.

  See :issue:`2020`.

Other
-----

Other updates for compatibility with the standard library include:

  - Errors raised from ``subprocess.Popen`` may not have a filename set.
  - ``SSLSocket.recv_into`` and ``SSLSocket.read`` no longer require the
    buffer to implement ``len`` and now work with buffers whose size is
    not 1.
  - gh-108310: Fix CVE-2023-40217: Check for & avoid the ssl pre-close
    flaw.

In addition:

  - Drop ``setuptools`` to a soft test dependency.
  - Drop support for very old versions of CFFI.
  - Update bundled c-ares from 1.19.1 to 1.26.0.
  - Locks created by gevent, but acquired from multiple different
    threads (not recommended), no longer spin to implement timeouts
    and interruptible blocking. Instead, they use the native
    functionality of the Python 3 lock. This may improve some scenarios.
    See :issue:`2013`.
```

greenlet changelog

```

3.0.3 (2023-12-21)
==================

- Python 3.12: Restore the full ability to walk the stack of a suspended
  greenlet; previously only the innermost frame was exposed. See `issue 388
  <https://github.com/python-greenlet/greenlet/issues/388>`_. Fix by
  Joshua Oreman in `PR 393
  <https://github.com/python-greenlet/greenlet/pull/393/>`_.

3.0.2 (2023-12-08)
==================

- Packaging: Add a minimal ``pyproject.toml`` to sdists.
- Packaging: Various updates to macOS wheels.
- Fix a test case on Arm32. Note that this is not a supported platform
  (there is no CI for it) and support is best effort; there may be
  other issues lurking. See `issue 385 <https://github.com/python-greenlet/greenlet/issues/385>`_


3.0.1 (2023-10-25)
==================

- Fix a potential crash on Python 3.8 at interpreter shutdown time.
  This was a regression from earlier 3.0.x releases. Reported by Matt
  Wozniski in `issue 376 <https://github.com/python-greenlet/greenlet/issues/376>`_.
```