### PR TITLE
Remove Python 3.9 from the build matrix

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -49,13 +49,6 @@ jobs:
         include:
           - arch: amd64
             build_name: py3.8
-            dockerhub_push: true
-            python_version: "3.8"
-            run_tests: true
-          - arch: amd64
-            build_name: py3.9
-            dockerhub_push: false
-            python_version: "3.9"
             run_tests: true
           
           # The qemu arm64 builds are *very* slow so they are split out into 
@@ -63,8 +56,6 @@ jobs:
 
           # - arch: arm64
           #   build_name: py3.8
-          #   dockerhub_push: true
-          #   python_version: "3.8"
           #   run_tests: false
 
     steps:
@@ -112,15 +103,12 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           push: false
           load: true
-          build-args:
-            PYTHON_VERSION=${{ matrix.python_version }}
           tags: |
             ${{ env.DOCKER_IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Run tests
-        if: ${{ matrix.run_tests }}
         run: |
           docker tag ${{ env.DOCKER_IMAGE_TAG }} ${{ env.PROJECT }}_app
           if [[ -z $SKIP_TESTS ]]; then
@@ -134,7 +122,6 @@ jobs:
           fi
 
       - name: Push image
-        if: ${{ matrix.dockerhub_push }}
         run: |
           docker push ${{ env.DOCKER_IMAGE_TAG }}
 

--- a/.github/workflows/build-arm64.yaml
+++ b/.github/workflows/build-arm64.yaml
@@ -22,9 +22,6 @@ jobs:
         include:
           - arch: arm64
             build_name: py3.8
-            dockerhub_push: true
-            python_version: "3.8"
-            run_tests: false
   
     steps:
       - name: Checkout
@@ -71,29 +68,12 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           push: false
           load: true
-          build-args:
-            PYTHON_VERSION=${{ matrix.python_version }}
           tags: |
             ${{ env.DOCKER_IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Run tests
-        if: ${{ matrix.run_tests }}
-        run: |
-          docker tag ${{ env.DOCKER_IMAGE_TAG }} ${{ env.PROJECT }}_app
-          if [[ -z $SKIP_TESTS ]]; then
-            docker-compose run app bash -ec '
-              bin/wait-for-it.sh mysql:3306 \
-              && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
-              && coverage html -d pythoncov
-            '
-          else
-            echo Skipping tests
-          fi
-
       - name: Push image
-        if: ${{ matrix.dockerhub_push }}
         run: |
           docker push ${{ env.DOCKER_IMAGE_TAG }}
 


### PR DESCRIPTION
We've recently adapted github actions into this project. That work was based on a very old branch from 2.5 years ago we had at the beginning when we were only starting to port to ARM64. This was an experiment. That branch coincided with the time I was porting sync-engine to different versions of Python and it was 3.8 and 3.9 at the time. That's why we have them in matrix now but now Python 3.9 workflow just builds Python 3.8 images so it's defunct, complicates yaml file and only wasting us time and $.

