### PR TITLE
Cleanup GHA workflows

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -48,14 +48,12 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            build_name: py3.8
             run_tests: true
           
           # The qemu arm64 builds are *very* slow so they are split out into 
           # their own workflow
 
           # - arch: arm64
-          #   build_name: py3.8
           #   run_tests: false
 
     steps:
@@ -73,7 +71,7 @@ jobs:
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
             echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
           fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.arch }}" >> $GITHUB_ENV
         shell: bash
 
       - name: Set up QEMU
@@ -124,42 +122,3 @@ jobs:
       - name: Push image
         run: |
           docker push ${{ env.DOCKER_IMAGE_TAG }}
-
-  multi-arch-manifest:
-    needs:
-      - build
-
-    runs-on: ubuntu-20.04
-    
-    strategy:
-      matrix:
-        include:
-          - build_name: py3.8
-
-    steps:
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
-      - name: Prepare environment
-        run: |
-          if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
-            echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
-          fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Create manifest
-        run: |
-          docker buildx imagetools create \
-            -t ${{ env.DOCKER_IMAGE_TAG }} \
-            ${{ env.DOCKER_IMAGE_TAG }}-amd64
-            # ${{ env.DOCKER_IMAGE_TAG }}-arm64

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -48,13 +48,11 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            run_tests: true
           
           # The qemu arm64 builds are *very* slow so they are split out into 
           # their own workflow
 
           # - arch: arm64
-          #   run_tests: false
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -65,7 +65,7 @@ jobs:
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
             echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
           fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}" >> $GITHUB_ENV
         shell: bash
 
       - name: Set up QEMU

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -60,18 +60,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
       - name: Prepare environment
         run: |
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
             echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
           fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}-${{ matrix.arch }}" >> $GITHUB_ENV
         shell: bash
 
       - name: Set up QEMU

--- a/.github/workflows/build-arm64.yaml
+++ b/.github/workflows/build-arm64.yaml
@@ -26,18 +26,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
       - name: Prepare environment
         run: |
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
             echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
           fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}-${{ matrix.arch }}" >> $GITHUB_ENV
         shell: bash
         
       - name: Set up QEMU

--- a/.github/workflows/build-arm64.yaml
+++ b/.github/workflows/build-arm64.yaml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            build_name: py3.8
   
     steps:
       - name: Checkout
@@ -38,7 +37,7 @@ jobs:
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
             echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
           fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.arch }}" >> $GITHUB_ENV
         shell: bash
         
       - name: Set up QEMU
@@ -76,43 +75,3 @@ jobs:
       - name: Push image
         run: |
           docker push ${{ env.DOCKER_IMAGE_TAG }}
-
-  multi-arch-manifest:
-    needs:
-      - build-arm64
-
-    runs-on: ubuntu-20.04
-    
-    strategy:
-      matrix:
-        include:
-          - build_name: py3.8
-
-    steps:
-      - name: Get short sha
-        id: vars
-        run: |
-          echo ::set-output name=sha_short::${GITHUB_SHA::16}
-        shell: bash
-
-      - name: Prepare environment
-        run: |
-          if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
-            echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
-          fi
-          echo "DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ steps.vars.outputs.sha_short }}-${{ matrix.build_name}}" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      # Because the arm64 builds are so much slower, we assume they will just 
-      # be appended to the existing manifest created by `build-and-release.yaml`.
-      - name: Create manifest
-        run: |
-          docker buildx imagetools create --append \
-            -t ${{ env.DOCKER_IMAGE_TAG }} \
-            ${{ env.DOCKER_IMAGE_TAG }}-arm64


### PR DESCRIPTION
This is another cleanup after we switched from CircleCI to GHA.

The downstream private repository expects the images to look like this:

for x86_64: `closeio/sync-engine:<sha>`
for arm64: `closeio/sync-engine:<sha>-arm64`

Because we had been using different format at the time we originally wrote GHA we didn't build ARM64 final images for like 2 months and I also had to fiddle manually with Dockerfiles there instead of using normal tooling we had, but that was not affecting production as we don't run ARM there. As I will be doing more work on sync-engine soon it's important to me that I can test things end to end locally on ARM.

We also don't build multiarch images anywhere else at Close, we experimented with this early when porting but then decided not to do it. I just deleted those steps because there's no point in maintaing something we dont use.