### PR TITLE
Remove pyinstrument

### DIFF
--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -60,7 +60,6 @@ from inbox.api.validation import (
     strict_bool,
     strict_parse_args,
     timestamp,
-    valid_account,
     valid_category_type,
     valid_delta_object_types,
     valid_display_name,
@@ -157,11 +156,6 @@ with open(mt_path) as f:
         assert extensions, "Must have at least one extension per mimetype"
         common_extensions[mime_type.lower()] = extensions[0]
 
-
-if config.get("DEBUG_PROFILING_ON"):
-    from inbox.util.debug import attach_pyinstrument_profiler
-
-    attach_pyinstrument_profiler()
 
 APIFeatures = namedtuple("APIFeatures", ["optimistic_updates"])
 

--- a/inbox/util/debug.py
+++ b/inbox/util/debug.py
@@ -1,40 +1,5 @@
 """Utilities for debugging failures in development/staging."""
 
-import signal
-from functools import wraps
-
-from pyinstrument import Profiler
-
-
-def profile(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        profiler = Profiler()
-        profiler.start()
-        r = func(*args, **kwargs)
-        profiler.stop()
-        print(profiler.output_text(color=True))
-        return r
-
-    return wrapper
-
-
-def attach_pyinstrument_profiler():
-    """Run the pyinstrument profiler in the background and dump its output to
-    stdout when the process receives SIGTRAP. In general, you probably want to
-    use the facilities in inbox.util.profiling instead.
-    """
-    profiler = Profiler()
-    profiler.start()
-
-    def handle_signal(signum, frame):
-        print(profiler.output_text(color=True))
-        # Work around an arguable bug in pyinstrument in which output gets
-        # frozen after the first call to profiler.output_text()
-        delattr(profiler, "_root_frame")
-
-    signal.signal(signal.SIGTRAP, handle_signal)
-
 
 def bind_context(gr, role, account_id, *args):
     """Bind a human-interpretable "context" to the greenlet `gr`, for

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -60,8 +60,6 @@ prompt-toolkit==3.0.36
 pure-eval==0.2.2
 pycparser==2.21
 pygments==2.17.2
-pyinstrument==3.2.0
-pyinstrument-cext==0.2.2
 Pympler==0.9
 PyNaCl==1.5.0
 python-dateutil==2.8.2


### PR DESCRIPTION
pyinstrument is a stack profiler for Python. I've never needed to use it in almost 3 years since most problems with sync-engine are connection/imap related and we don't really permanently install profilers into images anywhere else at Close. Would love to get rid off this as it has a c extension which slows down ARM builds.
