### PR TITLE
Remove guppy

### DIFF
--- a/inbox/util/rdb.py
+++ b/inbox/util/rdb.py
@@ -16,15 +16,6 @@ log = get_logger()
 doc = """
 This is the Nylas console - you can use it to interact with mailsync and track memory leaks.
 
-Guppy is installed. To start tracking leaks, you probably want to setup guppy like this:
->>> from guppy import hpy
->>> global hp # put this in the global space so it persists between connections
->>> hp = hpy()
->>> hp.setrelheap()
-
-and then inspect the heap, like this:
->>> hp.heap()
-
 Happy hacking!
 
 """

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -32,7 +32,6 @@ gdata==2.0.18
 gevent==24.2.1
 greenlet==3.0.3
 gunicorn==22.0.0
-guppy3==3.1.2
 hiredis==2.3.2
 html2text==2020.1.16
 icalendar==4.0.9


### PR DESCRIPTION
This is very similar to https://github.com/closeio/sync-engine/pull/793.

Guppy is memory profiler and I have not used it in 3 years. I would probably use [memray ](https://github.com/bloomberg/memray) anyway these days which is far better. We don't ship profilers in the image to production anywhere elsewhere. It has C extensions that needs to be built from source on ARM and slows CI/CD down.