### PR TITLE
Fix variable shadowing

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -363,10 +363,9 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
                     if isinstance(e, ValueError) and not isinstance(
                         e, UnicodeEncodeError
                     ):
-                        message = e.args[0] if e.args else ""
-                        if (
-                            message
-                            != "string argument should contain only ASCII characters"
+                        error_msg = e.args[0] if e.args else ""
+                        if error_msg != (
+                            "string argument should contain only ASCII characters"
                         ):
                             raise
 


### PR DESCRIPTION
The variable renamed here was shadowing the variable `message` from the outer scope.