### PR TITLE
Sync pods: New style super

### DIFF
--- a/inbox/contacts/remote_sync.py
+++ b/inbox/contacts/remote_sync.py
@@ -54,8 +54,7 @@ class ContactSync(BaseSyncMonitor):
         provider_cls = CONTACT_SYNC_PROVIDER_MAP[self.provider_name]
         self.provider: AbstractContactsProvider = provider_cls(account_id, namespace_id)
 
-        BaseSyncMonitor.__init__(
-            self,
+        super().__init__(
             account_id,
             namespace_id,
             email_address,

--- a/inbox/events/remote_sync.py
+++ b/inbox/events/remote_sync.py
@@ -54,8 +54,7 @@ class EventSync(BaseSyncMonitor):
             account_id=account_id, component="calendar sync", provider=provider_name
         )
 
-        BaseSyncMonitor.__init__(
-            self,
+        super().__init__(
             account_id,
             namespace_id,
             email_address,

--- a/inbox/mailsync/backends/base.py
+++ b/inbox/mailsync/backends/base.py
@@ -47,7 +47,7 @@ class BaseMailSyncMonitor(Greenlet):
         self.email_address = account.email_address
         self.provider_name = account.verbose_provider
 
-        Greenlet.__init__(self)
+        super().__init__()
 
     def _run(self):
         try:

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -54,7 +54,7 @@ MAX_DOWNLOAD_COUNT = 1
 
 class GmailSyncMonitor(ImapSyncMonitor):
     def __init__(self, *args, **kwargs):
-        ImapSyncMonitor.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.sync_engine_class = GmailFolderSyncEngine
 
         # We start a label refresh whenever we find a new labels

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -179,7 +179,7 @@ class FolderSyncEngine(Greenlet):
         }
 
         self.setup_heartbeats()
-        Greenlet.__init__(self)
+        super().__init__()
 
         # Some generic IMAP servers are throwing UIDVALIDITY
         # errors forever. Instead of resyncing those servers

--- a/inbox/mailsync/gc.py
+++ b/inbox/mailsync/gc.py
@@ -68,7 +68,7 @@ class DeleteHandler(gevent.Greenlet):
         self.log = log.new(account_id=account_id)
         self.message_ttl = datetime.timedelta(seconds=message_ttl)
         self.thread_ttl = datetime.timedelta(seconds=thread_ttl)
-        gevent.Greenlet.__init__(self)
+        super().__init__()
 
     def _run(self):
         while True:
@@ -211,7 +211,7 @@ class LabelRenameHandler(gevent.Greenlet):
         self.label_name = label_name
         self.log = log.new(account_id=account_id)
         self.semaphore = semaphore
-        gevent.Greenlet.__init__(self)
+        super().__init__()
 
     def _run(self):
         return retry_with_logging(self._run_impl, account_id=self.account_id)

--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -47,7 +47,7 @@ class BaseSyncMonitor(Greenlet):
         self.heartbeat_status = HeartbeatStatusProxy(
             self.account_id, folder_id, folder_name, email_address, provider_name
         )
-        Greenlet.__init__(self)
+        super().__init__()
 
     def _run(self):
         # Bind greenlet-local logging context.


### PR DESCRIPTION
Component: sync pods

One of the things that I will need to do to port this to threading is switch all the places where sync-engine subclasses `gevent.Greenlet` to a similar `threading.Thread` class. Using `super()` This makes it easier because the subclass is not repeated in two places.