### PR TITLE
Sync pods: replace gevent.sleep with time.sleep

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -51,7 +51,6 @@ import threading
 from collections import defaultdict, namedtuple
 from email.parser import HeaderParser
 
-import gevent
 from gevent import socket
 from gevent.lock import BoundedSemaphore
 from gevent.queue import Queue
@@ -332,7 +331,7 @@ def _exc_callback(exc):
     log.info(
         "Connection broken with error; retrying with new connection", exc_info=True
     )
-    gevent.sleep(5)
+    time.sleep(5)
 
 
 retry_crispin = functools.partial(

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -4,6 +4,7 @@ import datetime
 import email.utils
 import json
 import random
+import time
 import urllib.parse
 import uuid
 from typing import Any, Dict, List, Optional
@@ -11,7 +12,6 @@ from typing import Any, Dict, List, Optional
 import arrow
 import attrs
 import attrs.validators
-import gevent
 import requests
 
 from inbox.auth.oauth import OAuthRequestsWrapper
@@ -172,7 +172,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
                     url=url,
                     exc_info=True,
                 )
-                gevent.sleep(30 + random.randrange(0, 60))
+                time.sleep(30 + random.randrange(0, 60))
                 continue
             except requests.HTTPError as e:
                 self.log.warning(
@@ -192,7 +192,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
                     continue
                 elif r.status_code in (500, 503):
                     self.log.warning("Backend error in calendar API; retrying")
-                    gevent.sleep(30 + random.randrange(0, 60))
+                    time.sleep(30 + random.randrange(0, 60))
                     continue
                 elif r.status_code == 403:
                     try:
@@ -206,7 +206,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
                         r.raise_for_status()
                     if reason == "userRateLimitExceeded":
                         self.log.warning("API request was rate-limited; retrying")
-                        gevent.sleep(30 + random.randrange(0, 60))
+                        time.sleep(30 + random.randrange(0, 60))
                         continue
                     elif reason in ["accessNotConfigured", "notACalendarUser"]:
                         self.log.warning(
@@ -452,7 +452,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
                 )
             if reason == "userRateLimitExceeded":
                 # Sleep before proceeding (naive backoff)
-                gevent.sleep(30 + random.randrange(0, 60))
+                time.sleep(30 + random.randrange(0, 60))
                 self.log.warning("API request was rate-limited")
             elif reason == "accessNotConfigured":
                 self.log.warning("API not enabled.")

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -20,6 +20,7 @@ user always gets the full thread when they look at mail.
 
 """
 
+import time
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Dict, List
@@ -526,7 +527,7 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 # messages for this batch are synced.
                 # Note this is an approx. limit since we use the #(uids),
                 # not the #(messages).
-                gevent.sleep(THROTTLE_WAIT)
+                time.sleep(THROTTLE_WAIT)
 
     @property
     def throttled(self):

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -455,7 +455,7 @@ class FolderSyncEngine(Greenlet):
                     # messages per folder are synced.
                     # Note this is an approx. limit since we use the #(uids),
                     # not the #(messages).
-                    gevent.sleep(THROTTLE_WAIT)
+                    time.sleep(THROTTLE_WAIT)
         finally:
             if change_poller is not None:
                 # schedule change_poller to die
@@ -497,7 +497,7 @@ class FolderSyncEngine(Greenlet):
                 idling = False
         # Close IMAP connection before sleeping
         if not idling:
-            gevent.sleep(self.poll_frequency)
+            time.sleep(self.poll_frequency)
 
     def resync_uids_impl(self):
         # First, let's check if the UIVDALIDITY change was spurious, if

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -1,4 +1,5 @@
-from gevent import sleep
+import time
+
 from gevent.lock import BoundedSemaphore
 from gevent.pool import Group
 
@@ -141,7 +142,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
                 self.folder_monitors.start(thread)
 
             while thread.state != "poll" and not thread.ready():
-                sleep(self.heartbeat)
+                time.sleep(self.heartbeat)
 
             if thread.ready():
                 log.info(
@@ -166,7 +167,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
             self.start_delete_handler()
             self.start_new_folder_sync_engines()
             while True:
-                sleep(self.refresh_frequency)
+                time.sleep(self.refresh_frequency)
                 self.start_new_folder_sync_engines()
         except ValidationError as exc:
             log.error(

--- a/inbox/mailsync/gc.py
+++ b/inbox/mailsync/gc.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 
 import gevent
 from sqlalchemy import func
@@ -81,7 +82,7 @@ class DeleteHandler(gevent.Greenlet):
         self.check(current_time)
         self.gc_deleted_categories()
         self.gc_deleted_threads(current_time)
-        gevent.sleep(self.message_ttl.total_seconds())
+        time.sleep(self.message_ttl.total_seconds())
 
     def check(self, current_time):
         with session_scope(self.namespace_id) as db_session:

--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -1,4 +1,6 @@
-from gevent import Greenlet, event, sleep
+import time
+
+from gevent import Greenlet, event
 
 from inbox.exceptions import ConnectionError, ValidationError
 from inbox.heartbeat.store import HeartbeatStatusProxy
@@ -81,8 +83,8 @@ class BaseSyncMonitor(Greenlet):
         # 2x poll frequency.
         except ConnectionError:
             self.log.error("Error while polling", exc_info=True)
-            sleep(self.poll_frequency)
-        sleep(self.poll_frequency)
+            time.sleep(self.poll_frequency)
+        time.sleep(self.poll_frequency)
 
     def sync(self):
         """Subclasses should override this to do work"""

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -85,7 +85,7 @@ def retry(
 
             # Sleep a bit so that we don't poll too quickly and re-encounter
             # the error. Also add a random delay to prevent herding effects.
-            gevent.sleep(backoff_delay + int(random.uniform(1, 10)))
+            time.sleep(backoff_delay + int(random.uniform(1, 10)))
 
     return wrapped
 
@@ -178,7 +178,7 @@ def iterate_and_periodically_switch_to_gevent(
     last_sleep_time = time.monotonic()
     for item in iterable:
         if time.monotonic() - last_sleep_time >= switch_period.total_seconds():
-            gevent.sleep(0)
+            time.sleep(0)
             last_sleep_time = time.monotonic()
 
         yield item

--- a/tests/events/test_google_events.py
+++ b/tests/events/test_google_events.py
@@ -1,9 +1,9 @@
 import email
 import json
+import time
 from unittest import mock
 
 import arrow
-import gevent
 import pytest
 import requests
 
@@ -540,7 +540,7 @@ def test_handle_http_401():
     assert len(provider._get_access_token.mock_calls) == 2
 
 
-@pytest.mark.usefixtures("mock_gevent_sleep")
+@pytest.mark.usefixtures("mock_time_sleep")
 def test_handle_quota_exceeded():
     first_response = requests.Response()
     first_response.status_code = 403
@@ -569,11 +569,11 @@ def test_handle_quota_exceeded():
     provider._get_access_token = mock.Mock(return_value="token")
     items = provider._get_resource_list("https://googleapis.com/testurl")
     # Check that we slept, then retried.
-    assert gevent.sleep.called
+    assert time.sleep.called
     assert items == ["A", "B", "C"]
 
 
-@pytest.mark.usefixtures("mock_gevent_sleep")
+@pytest.mark.usefixtures("mock_time_sleep")
 def test_handle_internal_server_error():
     first_response = requests.Response()
     first_response.status_code = 503
@@ -587,7 +587,7 @@ def test_handle_internal_server_error():
     provider._get_access_token = mock.Mock(return_value="token")
     items = provider._get_resource_list("https://googleapis.com/testurl")
     # Check that we slept, then retried.
-    assert gevent.sleep.called
+    assert time.sleep.called
     assert items == ["A", "B", "C"]
 
 

--- a/tests/general/test_concurrency.py
+++ b/tests/general/test_concurrency.py
@@ -33,7 +33,7 @@ class FailingFunction:
             raise self.exc_type
 
 
-@pytest.mark.usefixtures("mock_gevent_sleep")
+@pytest.mark.usefixtures("mock_time_sleep")
 def test_retry_with_logging():
     logger = MockLogger()
     failing_function = FailingFunction(ValueError)
@@ -60,7 +60,7 @@ def test_selective_retry():
     assert failing_function.call_count == 1
 
 
-@pytest.mark.usefixtures("mock_gevent_sleep")
+@pytest.mark.usefixtures("mock_time_sleep")
 def test_no_logging_until_many_transient_error():
     transient = [
         socket.timeout,
@@ -111,7 +111,7 @@ def test_no_logging_until_many_transient_error():
         failing_function = FailingFunction(socket.error, max_executions=2)
 
 
-@pytest.mark.usefixtures("mock_gevent_sleep")
+@pytest.mark.usefixtures("mock_time_sleep")
 def test_logging_on_critical_error():
     critical = [
         TypeError("Example TypeError"),

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -701,8 +701,8 @@ def add_fake_msg_with_calendar_part(db_session, account, ics_str, thread=None):
 
 
 @fixture
-def mock_gevent_sleep(monkeypatch):
-    monkeypatch.setattr("gevent.sleep", mock.Mock())
+def mock_time_sleep(monkeypatch):
+    monkeypatch.setattr("time.sleep", mock.Mock())
     yield
     monkeypatch.undo()
 


### PR DESCRIPTION
Component: sync pods

Sync-engine calls `gevent.monkey.patch_all()` before importing other modules.

`gevent.sleep()` is the same as patched `time.sleep()`, by using stdlib API we get closer to removing since `time.sleep()` works with `threading.Thread` as well.