### PR TITLE
Sync pods: Use greenlet.kill() instead of gevent.kill(greenlet)

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -295,7 +295,7 @@ class GmailFolderSyncEngine(FolderSyncEngine):
         finally:
             if change_poller is not None:
                 # schedule change_poller to die
-                gevent.kill(change_poller)
+                change_poller.kill()
 
     def resync_uids_impl(self):
         with session_scope(self.namespace_id) as db_session:

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -459,7 +459,7 @@ class FolderSyncEngine(Greenlet):
         finally:
             if change_poller is not None:
                 # schedule change_poller to die
-                gevent.kill(change_poller)
+                change_poller.kill()
 
     def should_idle(self, crispin_client):
         if not hasattr(self, "_should_idle"):

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -359,14 +359,14 @@ class SyncService:
                 return False
         return True
 
-    def stop(self, *args):
+    def stop(self) -> None:
         self.log.info("stopping mail sync process")
         for _, v in self.email_sync_monitors.items():
-            gevent.kill(v)
+            v.kill()
         for _, v in self.contact_sync_monitors.items():
-            gevent.kill(v)
+            v.kill()
         for _, v in self.event_sync_monitors.items():
-            gevent.kill(v)
+            v.kill()
         self.keep_running = False
 
     def stop_sync(self, account_id):


### PR DESCRIPTION
`greenlet.kill()` and `gevent.kill(greenlet)` do exactly the same thing.

By using OOO version we get get rid of `gevent` APIs. Python threads don't support `thread.kill()` but later when we switch to threads I'll implement a polyfill for this that emulates greenlet behavior as close as possible.