### PR TITLE
Sync pods: Replace gevent.lock.(Bounded)?Semaphore with threading.(Bounded)?Semaphore

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -50,9 +50,9 @@ import functools
 import threading
 from collections import defaultdict, namedtuple
 from email.parser import HeaderParser
+from threading import BoundedSemaphore
 
 from gevent import socket
-from gevent.lock import BoundedSemaphore
 from gevent.queue import Queue
 from sqlalchemy.orm import joinedload
 

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -23,10 +23,10 @@ user always gets the full thread when they look at mail.
 import time
 from collections import OrderedDict
 from datetime import datetime, timedelta
+from threading import Semaphore
 from typing import Dict, List
 
 import gevent
-from gevent.lock import Semaphore
 from sqlalchemy.orm import joinedload, load_only
 
 from inbox.logging import get_logger

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -1,6 +1,6 @@
 import time
+from threading import BoundedSemaphore
 
-from gevent.lock import BoundedSemaphore
 from gevent.pool import Group
 
 from inbox.crispin import connection_pool, retry_crispin

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -1,10 +1,10 @@
 import platform
 import random
 import time
+from threading import BoundedSemaphore
 from typing import Type
 
 import gevent
-from gevent.lock import BoundedSemaphore
 from sqlalchemy import and_, or_
 from sqlalchemy.exc import OperationalError
 

--- a/tests/imap/test_folder_sync.py
+++ b/tests/imap/test_folder_sync.py
@@ -1,8 +1,8 @@
 # flake8: noqa: F401, F811
 from hashlib import sha256
+from threading import BoundedSemaphore
 
 import pytest
-from gevent.lock import BoundedSemaphore
 from sqlalchemy.orm.exc import ObjectDeletedError
 
 from inbox.mailsync.backends.base import MailsyncDone


### PR DESCRIPTION
Sync-engine calls gevent.monkey.patch_all() before importing other modules.

gevent APIs are the same as patched stdlib APIs, by using stdlib API we get closer to removing gevent and stdlib works with threading.Thread as well.