### PR TITLE
Revert "Sync pods: Use greenlet.kill() instead of gevent.kill(greenlet) (#827)"

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -295,7 +295,7 @@ class GmailFolderSyncEngine(FolderSyncEngine):
         finally:
             if change_poller is not None:
                 # schedule change_poller to die
-                change_poller.kill()
+                gevent.kill(change_poller)
 
     def resync_uids_impl(self):
         with session_scope(self.namespace_id) as db_session:

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -459,7 +459,7 @@ class FolderSyncEngine(Greenlet):
         finally:
             if change_poller is not None:
                 # schedule change_poller to die
-                change_poller.kill()
+                gevent.kill(change_poller)
 
     def should_idle(self, crispin_client):
         if not hasattr(self, "_should_idle"):

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -359,14 +359,14 @@ class SyncService:
                 return False
         return True
 
-    def stop(self) -> None:
+    def stop(self, *args):
         self.log.info("stopping mail sync process")
         for _, v in self.email_sync_monitors.items():
-            v.kill()
+            gevent.kill(v)
         for _, v in self.contact_sync_monitors.items():
-            v.kill()
+            gevent.kill(v)
         for _, v in self.event_sync_monitors.items():
-            v.kill()
+            gevent.kill(v)
         self.keep_running = False
 
     def stop_sync(self, account_id):


### PR DESCRIPTION
I discovered in production that after merging reverted PR the shutdown time of sync containers has become much slower (20s versus almost 5 minutes).

So there's for sure a difference in practice between the two methods of killing the greenlets or some other factor that I do not know about yet that plays important role here.

I will investigate separately, for now let's revert it.