### PR TITLE
Bugfix: Fix signal handler

### DIFF
--- a/bin/inbox-start.py
+++ b/bin/inbox-start.py
@@ -10,6 +10,7 @@ import platform
 import signal
 import socket
 import sys
+import types
 
 import click
 import setproctitle
@@ -149,8 +150,12 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
         exit_after_min=exit_after_min,
         exit_after_max=exit_after_max,
     )
-    signal.signal(signal.SIGTERM, sync_service.stop)
-    signal.signal(signal.SIGINT, sync_service.stop)
+
+    def signal_handler(signum: int, frame: types.FrameType) -> None:
+        sync_service.stop()
+
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
     http_frontend = SyncHTTPFrontend(
         sync_service, port, enable_tracer, enable_profiler_api
     )


### PR DESCRIPTION
In [here](https://github.com/closeio/sync-engine/pull/827/files) I removed what I though was unused argument. But it was used to consume signal handler parameters...

As a result of that change the signal handler is not working anymore and the process won't stop if you send it SIGTERM or SIGINT. Instead it will be killed by k8s after ~5 minutes. I realized that because deploys have become much after this change.

That's what I got for sneaking unrelated changes 🤡

I chose to consume the arguments in another function, because consuming them inside a method on a greenlet is confusing IMHO.