### PR TITLE
Sync pods: Replace gevent.pool.Group with a list

### DIFF
--- a/inbox/mailsync/backends/base.py
+++ b/inbox/mailsync/backends/base.py
@@ -91,4 +91,5 @@ class BaseMailSyncMonitor(Greenlet):
         with session_scope(self.namespace_id) as mailsync_db_session:
             for x in self.folder_monitors:
                 x.set_stopped(mailsync_db_session)
-        self.folder_monitors.kill()
+        for monitor in self.folder_monitors:
+            monitor.kill()

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -138,8 +138,8 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
                     self.provider_name,
                     self.syncmanager_lock,
                 )
-                thread.start()
                 self.folder_monitors.append(thread)
+                thread.start()
 
             while thread.state != "poll" and not thread.ready():
                 time.sleep(self.heartbeat)


### PR DESCRIPTION
`gevent.pool.Group` has no equivalent in stdlib, but sync-engine uses such a small part of its API that we can easily substitute it with a list.

Conceptually a `gevent.pool.Group` is a container that keeps track of greenlets started in it. It also automatically removes `ready()` (greenlets that exited either successfully or because there was an exception) from the group.

The code in question is the account email sync parent greenlet that in a loop:
- asks IMAP what folders (Inbox, Sent, Trash, ...) are available 
- starts folder sync greenlets for the ones that are not already started, this is done with a group

Instead we can:
- start folders sync greenlet by calling their `.start()` explicitely and adding them to a list  (calling `gevent.pool.Group` starts a greenlet and adds it to the group)
- every time a greenlet is `.ready()` we just `.remove()` it from the list (this is done implicitely by a `gevent.pool.Group`)