### PR TITLE
Use `docker compose` instead of `docker-compose`

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -102,7 +102,7 @@ jobs:
         run: |
           docker tag ${{ env.DOCKER_IMAGE_TAG }} ${{ env.PROJECT }}_app
           if [[ -z $SKIP_TESTS ]]; then
-            docker-compose run app bash -ec '
+            docker compose run app bash -ec '
               bin/wait-for-it.sh mysql:3306 \
               && NYLAS_ENV=test pytest --cov-report= --cov=inbox tests/ \
               && coverage html -d pythoncov


### PR DESCRIPTION
Docker deprecated `docker-compose` in favor of `docker compose`:

https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose

This change has no impact outside of the build and release process.