### PR TITLE
Sync pods: Replace gevent.event.Event with threading.Event

### DIFF
--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -1,6 +1,7 @@
+import threading
 import time
 
-from gevent import Greenlet, event
+from gevent import Greenlet
 
 from inbox.exceptions import ConnectionError, ValidationError
 from inbox.heartbeat.store import HeartbeatStatusProxy
@@ -45,7 +46,7 @@ class BaseSyncMonitor(Greenlet):
 
         self.log = logger.new(account_id=account_id)
 
-        self.shutdown = event.Event()
+        self.shutdown = threading.Event()
         self.heartbeat_status = HeartbeatStatusProxy(
             self.account_id, folder_id, folder_name, email_address, provider_name
         )


### PR DESCRIPTION
Sync-engine calls gevent.monkey.patch_all() before importing other modules.

[`gevent.event.Event`](https://www.gevent.org/api/gevent.event.html) APIs are the same as with `threading.Event` and we can use the latter with threads.

```python
>>> import gevent.monkey
>>> gevent.monkey.patch_all()
True
>>> import threading
>>> threading.Event
<class 'gevent._gevent_cevent.Event'>
```