### PR TITLE
Better covering index for hot queries

### DIFF
--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -33,7 +33,7 @@ log = get_logger()
 
 
 def local_uids(account_id, session, folder_id, limit=None):
-    q = session.query(ImapUid.msg_uid)
+    q = session.query(ImapUid.msg_uid).with_hint(ImapUid, "FORCE INDEX (pawel_test)")
     q = q.filter(
         ImapUid.account_id == bindparam("account_id"),
         ImapUid.folder_id == bindparam("folder_id"),
@@ -46,7 +46,9 @@ def local_uids(account_id, session, folder_id, limit=None):
 
 
 def lastseenuid(account_id, session, folder_id):
-    q = session.query(func.max(ImapUid.msg_uid))
+    q = session.query(func.max(ImapUid.msg_uid)).with_hint(
+        ImapUid, "FORCE INDEX (pawel_test)"
+    )
     q = q.filter(
         ImapUid.account_id == bindparam("account_id"),
         ImapUid.folder_id == bindparam("folder_id"),

--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -33,7 +33,9 @@ log = get_logger()
 
 
 def local_uids(account_id, session, folder_id, limit=None):
-    q = session.query(ImapUid.msg_uid).with_hint(ImapUid, "FORCE INDEX (pawel_test)")
+    q = session.query(ImapUid.msg_uid).with_hint(
+        ImapUid, "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)"
+    )
     q = q.filter(
         ImapUid.account_id == bindparam("account_id"),
         ImapUid.folder_id == bindparam("folder_id"),
@@ -47,7 +49,7 @@ def local_uids(account_id, session, folder_id, limit=None):
 
 def lastseenuid(account_id, session, folder_id):
     q = session.query(func.max(ImapUid.msg_uid)).with_hint(
-        ImapUid, "FORCE INDEX (pawel_test)"
+        ImapUid, "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)"
     )
     q = q.filter(
         ImapUid.account_id == bindparam("account_id"),

--- a/inbox/models/backends/imap.py
+++ b/inbox/models/backends/imap.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     Integer,
     String,
     desc,
-    text,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref, object_session, relationship
@@ -225,9 +224,9 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
         # by 15% - 20%.
         Index(
             "ix_imapuid_account_id_folder_id_msg_uid_desc",
-            "account_id",
-            "folder_id",
-            text("msg_uid DESC"),
+            account_id,
+            folder_id,
+            msg_uid.desc(),
             unique=True,
         ),
     )

--- a/inbox/models/backends/imap.py
+++ b/inbox/models/backends/imap.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     Integer,
     String,
     desc,
+    text,
 )
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref, object_session, relationship
@@ -215,7 +216,10 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
         categories.add(self.folder.category)
         return categories
 
-    __table_args__ = (UniqueConstraint("folder_id", "msg_uid", "account_id"),)
+    __table_args__ = (
+        UniqueConstraint("folder_id", "msg_uid", "account_id"),
+        Index("pawel_test", "account_id", "folder_id", text("msg_uid DESC")),
+    )
 
 
 # make pulling up all messages in a given folder fast

--- a/inbox/models/backends/imap.py
+++ b/inbox/models/backends/imap.py
@@ -218,7 +218,18 @@ class ImapUid(MailSyncBase, UpdatedAtMixin, DeletedAtMixin):
 
     __table_args__ = (
         UniqueConstraint("folder_id", "msg_uid", "account_id"),
-        Index("pawel_test", "account_id", "folder_id", text("msg_uid DESC")),
+        # This index is used to quickly retrieve IMAP uids
+        # in local_uids and lastseenuid functions.
+        # Those queries consistently stay in top 5 most busy SELECTs
+        # and having dedicated index helps to reduce the load on the database
+        # by 15% - 20%.
+        Index(
+            "ix_imapuid_account_id_folder_id_msg_uid_desc",
+            "account_id",
+            "folder_id",
+            text("msg_uid DESC"),
+            unique=True,
+        ),
     )
 
 

--- a/migrations/versions/261_add_ix_imapuid_account_id_folder_id_msg_uid_desc.py
+++ b/migrations/versions/261_add_ix_imapuid_account_id_folder_id_msg_uid_desc.py
@@ -1,0 +1,27 @@
+"""add ix_imapuid_account_id_folder_id_msg_uid_desc
+
+Revision ID: e3cf974d07a5
+Revises: fe0488decbd1
+Create Date: 2024-08-27 09:47:53.661863
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e3cf974d07a5"
+down_revision = "fe0488decbd1"
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade():
+    op.create_index(
+        "ix_imapuid_account_id_folder_id_msg_uid_desc",
+        "imapuid",
+        ["account_id", "folder_id", sa.text("msg_uid DESC")],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index("ix_imapuid_account_id_folder_id_msg_uid_desc", table_name="imapuid")


### PR DESCRIPTION
This optimizes our hot running queries by using a better covering index, as I presented in front of the company.

The queries in question are:

```
SELECT imapuid.msg_uid AS imapuid_msg_uid FROM imapuid WHERE imapuid.account_id = 66368 AND imapuid.folder_id = 402004

SELECT MAX (imapuid.msg_uid) AS max_1 FROM imapuid WHERE imapuid.account_id = 66368 AND imapuid.folder_id = 402004

SELECT imapuid.msg_uid AS imapuid_msg_uid FROM imapuid WHERE imapuid.account_id = 66368 AND imapuid.folder_id = 402004 ORDER BY imapuid.msg_uid DESC LIMIT 100
```

Talking from experience it's not uncommon for those queries to return millions of message for a single folder. It's not uncommon to never delete your mail in 2024. That's why it's so important to have a dedicated index here.

The new index is faster because the queries in the WHERE clause come first and the retrieved column comes last, this lets MySQL scan smaller subset of the index.

Then the fact that I specified `DESC` for the last column makes the index sorted in exact order for the last query, which means it does not need to sort it in RAM after scanning the index. For the second query MAX value will be at the top of the index so no sorting in RAM needed as well. The first query does not care about ordering, but the client will receive ordered results which is fine because it does not make any assumptions about it.

To do this fast and safely, for each cluster and *not in parallel* to minimize customer impact & sync delays:
- tear down all the sync pods during early Europe morning, this effectively pauses syncing but otherwise MySQL will run so hot that bad things will start happening.
- run the migration, I expect this to take less than 15 minutes based on my previous tests
- bring back sync pods, they will restart syncing where we left

I will add exact procedure that takes into account specifics of our devops setup in the other repository.

The SQL

```sql
-- Running upgrade fe0488decbd1 -> e3cf974d07a5

CREATE UNIQUE INDEX ix_imapuid_account_id_folder_id_msg_uid_desc ON imapuid (account_id, folder_id, msg_uid DESC);

SET SQL_SAFE_UPDATES = 0; -- quirk of production MySQL shell configuration

UPDATE alembic_version SET version_num='e3cf974d07a5' WHERE alembic_version.version_num = 'fe0488decbd1';
```