### PR TITLE
Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN echo $BUILD_WEEK && apt-get update \
     dirmngr \
     gcc \
     git \
-    python3-dev \
+    python3.9-dev \
     python3-pip \
     gettext-base \
     libmysqlclient-dev \
@@ -46,9 +46,9 @@ USER sync-engine
 WORKDIR /opt/app
 
 COPY --chown=sync-engine:sync-engine ./ ./
-RUN python3 -m pip install pip==24.0 virtualenv==20.25.1 && \
-  python3 -m virtualenv /opt/venv && \
-  /opt/venv/bin/python3 -m pip install --no-cache --no-deps -r requirements/prod.txt -r requirements/test.txt && \
-  /opt/venv/bin/python3 -m pip check
+RUN python3.9 -m pip install pip==24.2 virtualenv==20.26.3 && \
+    python3.9 -m virtualenv /opt/venv && \
+   /opt/venv/bin/python3.9 -m pip install --no-cache --no-deps -r requirements/prod.txt -r requirements/test.txt && \
+   /opt/venv/bin/python3.9 -m pip check
 
 RUN ln -s /opt/app/bin/wait-for-it.sh /opt/venv/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ WORKDIR /opt/app
 
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN python3.9 -m pip install pip==24.2 virtualenv==20.26.3 && \
-    python3.9 -m virtualenv /opt/venv && \
-   /opt/venv/bin/python3.9 -m pip install --no-cache --no-deps -r requirements/prod.txt -r requirements/test.txt && \
-   /opt/venv/bin/python3.9 -m pip check
+  python3.9 -m virtualenv /opt/venv && \
+  /opt/venv/bin/python3.9 -m pip install --no-cache --no-deps -r requirements/prod.txt -r requirements/test.txt && \
+  /opt/venv/bin/python3.9 -m pip check
 
 RUN ln -s /opt/app/bin/wait-for-it.sh /opt/venv/bin/


### PR DESCRIPTION
*I am not gonna deploy this on Friday, gonna wait til next week*

Ubuntu 20.04 LTS shipped with both 3.8 and 3.9, 3.8 is the default. We can switch to 3.9 and since this package is part of official Ubuntu repositories it will receive security updates in a way that is recognized by our security monitoring solution. My objective is going to 3.10, or maybe 3.11 (stretch) but since MySQL driver dropped support for gevent and the last version that supports gevent no longer works on 3.10 we are going through 3.9 first.

Going through 3.9 gives a one year safety runway if removing gevent proves to be more difficult than I think based on my PoCs.

<img width="822" alt="Screenshot 2024-08-21 at 16 36 37" src="https://github.com/user-attachments/assets/dae2c6ba-d28c-4639-85b6-d66e677d6c83">

I already did end 2 end manual testing and everything seems to be working, nonetheless I will be monitoring CPU, memory and ongoing syncs and be ready to revert. I will first roll this out to a subset of the infrastructure before rolling out to everybody.

