### PR TITLE
Slim down docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,37 +3,33 @@ FROM ubuntu:20.04
 RUN groupadd -g 5000 sync-engine \
   && useradd -d /home/sync-engine -m -u 5000 -g 5000 sync-engine
 
-ENV TZ="Etc/GMT"
-ENV DEBIAN_FRONTEND=noninteractive
+ENV \
+  TZ="Etc/GMT" \
+  LANG="en_US.UTF-8" \
+  LC_ALL="en_US.UTF-8" \
+  DEBIAN_FRONTEND=noninteractive \
+  PATH="/opt/venv/bin:$PATH"
+
 ARG BUILD_WEEK=0
 RUN echo $BUILD_WEEK && apt-get update \
   && apt-get dist-upgrade -y \
-  && apt-get install -y \
+  && apt-get install --no-install-recommends -y \
     tzdata \
-    build-essential \
+    locales \
+    make \
     curl \
-    dnsutils \
+    gpg \
+    gpg-agent \
+    dirmngr \
     gcc \
-    g++ \
     git \
     python3-dev \
     python3-pip \
-    wget \
     gettext-base \
-    language-pack-en \
-    libcurl4-openssl-dev \
     libmysqlclient-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libxslt1-dev \
     mysql-client \
-    pkg-config \
-    lsof \
-    net-tools \
-    shared-mime-info \
-    telnet \
     vim \
-    libffi-dev \
+  && locale-gen en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /etc/inboxapp && \
@@ -49,16 +45,10 @@ USER sync-engine
 
 WORKDIR /opt/app
 
-ENV PATH="/opt/venv/bin:$PATH"
-
 COPY --chown=sync-engine:sync-engine ./ ./
 RUN python3 -m pip install pip==24.0 virtualenv==20.25.1 && \
   python3 -m virtualenv /opt/venv && \
-  /opt/venv/bin/python3 -m pip install --no-deps -r requirements/prod.txt -r requirements/test.txt && \
+  /opt/venv/bin/python3 -m pip install --no-cache --no-deps -r requirements/prod.txt -r requirements/test.txt && \
   /opt/venv/bin/python3 -m pip check
 
 RUN ln -s /opt/app/bin/wait-for-it.sh /opt/venv/bin/
-
-ENV \
-  LANG="en_US.UTF-8" \
-  LC_ALL="en_US.UTF-8"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,7 +11,6 @@ jedi==0.18.2
 boto==2.49.0
 boto3==1.19.4
 botocore==1.22.9
-cchardet==2.1.7
 certifi==2023.7.22
 cffi==1.15.1
 chardet==3.0.4


### PR DESCRIPTION
I was revising the Docker image to realize that we have quite a number of packages that are not needed. Most of them used to be build time dependencies of Python packages that can be now installed from binary wheels.

This:

- Removes dependencies we don't use, so there's less of security updates needed
- Makes the images smaller ( 1.12GB -> 896MB )
- Makes the builds faster