### PR TITLE
Multistage Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:20.04 AS stage_0
 
 RUN groupadd -g 5000 sync-engine \
   && useradd -d /home/sync-engine -m -u 5000 -g 5000 sync-engine
@@ -16,18 +16,13 @@ RUN echo $BUILD_WEEK && apt-get update \
   && apt-get install --no-install-recommends -y \
     tzdata \
     locales \
-    make \
     curl \
     gpg \
     gpg-agent \
     dirmngr \
-    gcc \
-    git \
-    python3.9-dev \
-    python3-pip \
+    python3.9 \
     gettext-base \
-    libmysqlclient-dev \
-    mysql-client \
+    libmysqlclient21 \
     vim \
   && locale-gen en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*
@@ -41,14 +36,32 @@ RUN mkdir /etc/inboxapp && \
   mkdir /opt/venv && \
   chown sync-engine:sync-engine /opt/venv
 
+
+FROM stage_0 AS stage_1
+
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+    make \
+    gcc \
+    git \
+    python3.9-dev \
+    python3-pip \
+    libmysqlclient-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY /requirements/ /requirements/
+RUN python3.9 -m pip install pip==24.0 virtualenv==20.25.1 && \
+  python3.9 -m virtualenv /opt/venv && \
+  /opt/venv/bin/python3.9 -m pip install --no-cache --no-deps -r /requirements/prod.txt -r /requirements/test.txt && \
+  /opt/venv/bin/python3.9 -m pip check
+
+
+FROM stage_0
+
 USER sync-engine
 
 WORKDIR /opt/app
 
-COPY --chown=sync-engine:sync-engine ./ ./
-RUN python3.9 -m pip install pip==24.2 virtualenv==20.26.3 && \
-  python3.9 -m virtualenv /opt/venv && \
-  /opt/venv/bin/python3.9 -m pip install --no-cache --no-deps -r requirements/prod.txt -r requirements/test.txt && \
-  /opt/venv/bin/python3.9 -m pip check
-
+COPY --from=stage_1 --chown=sync-engine:sync-engine /opt/venv /opt/venv
 RUN ln -s /opt/app/bin/wait-for-it.sh /opt/venv/bin/
+COPY --chown=sync-engine:sync-engine ./ /opt/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# --- Stage 0 --- #
+# This first stage is responsible for installing any dependencies the app needs
+# to run, and updating any base dependencies.
 FROM ubuntu:20.04 AS stage_0
 
 RUN groupadd -g 5000 sync-engine \
@@ -39,6 +42,10 @@ RUN mkdir /etc/inboxapp && \
   chown sync-engine:sync-engine /opt/venv
 
 
+# --- Stage 1 --- #
+# This stage is responsible for installing the build time dependencies for
+# Python packages, building those packages, and then installing them
+# into the virtual environment.
 FROM stage_0 AS stage_1
 
 RUN apt-get update \
@@ -58,6 +65,9 @@ RUN python3.9 -m pip install pip==24.0 virtualenv==20.25.1 && \
   /opt/venv/bin/python3.9 -m pip check
 
 
+# --- Stage 2 --- #
+# This stage is responsible for copying the virtual environment from the
+# previous stage, and then copying the application code into the image.
 FROM stage_0
 
 USER sync-engine

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN echo $BUILD_WEEK && apt-get update \
   && apt-get install --no-install-recommends -y \
     tzdata \
     locales \
+    ca-certificates \
     curl \
     gpg \
     gpg-agent \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN echo $BUILD_WEEK && apt-get update \
     python3.9 \
     gettext-base \
     libmysqlclient21 \
+    mysql-client \
     vim \
   && locale-gen en_US.UTF-8 \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This was prompted by an security alert from our security solution. It's claiming that linux package needs an update:

<img width="566" alt="Screenshot 2024-08-26 at 15 45 07" src="https://github.com/user-attachments/assets/f8a39b12-7223-430f-9b2b-bdfeb38de38d">

but querying dpkg shows that no `linux` package is present:

```
sync-engine@c1d3b7d8cc12:/opt/app$ dpkg -l | grep linux
ii  binutils-aarch64-linux-gnu 2.34-6ubuntu1.9                   arm64        GNU binary utilities, for aarch64-linux-gnu target
ii  libselinux1:arm64          3.0-1build2                       arm64        SELinux runtime shared libraries
ii  linux-libc-dev:arm64       5.4.0-193.213                     arm64        Linux Kernel Headers for development
ii  util-linux                 2.34-0.1ubuntu9.6                 arm64        miscellaneous system utilities
```

Nonetheless you can see that `linux-libc-dev` is present with the version matching the alert.

This is because unlike in other projects we are still using single stage Dockerfile. We can get rid of this packages by splitting the dockerfile to 3 stages like elsewhere. This way any Python package build time dependencies are not present in the final image.


```
sync-engine@9266855b4611:/opt/app$ dpkg -l | grep linux
ii  libselinux1:arm64          3.0-1build2                       arm64        SELinux runtime shared libraries
ii  util-linux                 2.34-0.1ubuntu9.6                 arm64        miscellaneous system utilities
```

The additional perk of multistage Dockerfile is reduced image size: from 896MB to 581MB.
Combined with the savings from [this PR](https://github.com/closeio/sync-engine/pull/864) we managed to make the image 2 times smaller.