### PR TITLE
Some more FORCE INDEX

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -325,7 +325,7 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 .options(
                     load_only("msg_uid"), joinedload("message").load_only("g_msgid")
                 )
-                .filter_by(
+                .filter(
                     ImapUid.account_id == self.account_id,
                     ImapUid.folder_id == self.folder_id,
                 )

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -325,7 +325,14 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 .options(
                     load_only("msg_uid"), joinedload("message").load_only("g_msgid")
                 )
-                .filter_by(account_id=self.account_id, folder_id=self.folder_id)
+                .filter_by(
+                    ImapUid.account_id == self.account_id,
+                    ImapUid.folder_id == self.folder_id,
+                )
+                .with_hint(
+                    ImapUid,
+                    "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)",
+                )
             )
 
             chunk_size = 1000

--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -163,7 +163,9 @@ def update_metadata(account_id, folder_id, folder_role, new_flags, session):
             ImapUid.folder_id == folder_id,
             ImapUid.msg_uid.in_(new_flags),
         )
-        .with_hint("FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)")
+        .with_hint(
+            ImapUid, "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)"
+        )
     ):
         flags = new_flags[item.msg_uid].flags
         labels = getattr(new_flags[item.msg_uid], "labels", None)
@@ -208,7 +210,10 @@ def remove_deleted_uids(account_id, folder_id, uids):
                     ImapUid.folder_id == folder_id,
                     ImapUid.msg_uid == uid,
                 )
-                .with_hint("FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)")
+                .with_hint(
+                    ImapUid,
+                    "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)",
+                )
                 .first()
             )
             if imapuid is None:

--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -156,10 +156,14 @@ def update_metadata(account_id, folder_id, folder_role, new_flags, session):
 
     account = Account.get(account_id, session)
     change_count = 0
-    for item in session.query(ImapUid).filter(
-        ImapUid.account_id == account_id,
-        ImapUid.msg_uid.in_(new_flags),
-        ImapUid.folder_id == folder_id,
+    for item in (
+        session.query(ImapUid)
+        .filter(
+            ImapUid.account_id == account_id,
+            ImapUid.folder_id == folder_id,
+            ImapUid.msg_uid.in_(new_flags),
+        )
+        .with_hint("FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)")
     ):
         flags = new_flags[item.msg_uid].flags
         labels = getattr(new_flags[item.msg_uid], "labels", None)
@@ -204,6 +208,7 @@ def remove_deleted_uids(account_id, folder_id, uids):
                     ImapUid.folder_id == folder_id,
                     ImapUid.msg_uid == uid,
                 )
+                .with_hint("FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)")
                 .first()
             )
             if imapuid is None:

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -522,7 +522,9 @@ class FolderSyncEngine(Greenlet):
                     ImapUid.account_id == self.account_id,
                     ImapUid.folder_id == self.folder_id,
                 )
-                .with_hint("FORCE INDEX(ix_imapuid_account_id_folder_id_msg_uid_desc)")
+                .with_hint(
+                    ImapUid, "FORCE INDEX(ix_imapuid_account_id_folder_id_msg_uid_desc)"
+                )
             }
         with self.syncmanager_lock:
             common.remove_deleted_uids(self.account_id, self.folder_id, invalid_uids)

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -518,7 +518,7 @@ class FolderSyncEngine(Greenlet):
             invalid_uids = {
                 uid
                 for uid, in db_session.query(ImapUid.msg_uid)
-                .filter_by(
+                .filter(
                     ImapUid.account_id == self.account_id,
                     ImapUid.folder_id == self.folder_id,
                 )

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -517,9 +517,12 @@ class FolderSyncEngine(Greenlet):
         with session_scope(self.namespace_id) as db_session:
             invalid_uids = {
                 uid
-                for uid, in db_session.query(ImapUid.msg_uid).filter_by(
-                    account_id=self.account_id, folder_id=self.folder_id
+                for uid, in db_session.query(ImapUid.msg_uid)
+                .filter_by(
+                    ImapUid.account_id == self.account_id,
+                    ImapUid.folder_id == self.folder_id,
                 )
+                .with_hint("FORCE INDEX(ix_imapuid_account_id_folder_id_msg_uid_desc)")
             }
         with self.syncmanager_lock:
             common.remove_deleted_uids(self.account_id, self.folder_id, invalid_uids)


### PR DESCRIPTION
This rewrites one query which is off the beaten path and not that important from the performance point of view, I am doing this rather for consistency because this query *could* be faster. It also makes all those queries easier to find in the source code. This part of code is only executed if there's a new message in your folder which is "rare" compared to everything else that happens.

Also the code before actually fetches the row (to know the id) and we are only interested to know if it exists. That's what EXISTS clause in SQL exists for. This way we can read everything from the index and not look at the table at all because all the columns involved are already in the index.

Before

```sql
SELECT * FROM imapuid WHERE imapuid.account_id = %s AND imapuid.folder_id = %s AND imapuid.msg_uid = %s
```

After

```sql
SELECT EXISTS (SELECT 1 
FROM imapuid FORCE INDEX(ix_imapuid_account_id_folder_id_msg_uid_desc) 
WHERE imapuid.account_id = %s AND imapuid.folder_id = %s AND imapuid.msg_uid = %s) AS anon_1
```

It also adds the hints in some other parts just to switch away from the old index to the new index, my objective is to be sure that I can safely remove the old index.

Memo, how to check that index is no longer used in MySQL:

```sql
select COUNT_STAR from performance_schema.table_io_waits_summary_by_index_usage where object_schema = 'inbox' AND object_name = 'imapuid' AND index_name
= 'folder_id'\G
```