### PR TITLE
Upgrade urllib

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -78,7 +78,7 @@ tldextract==3.1.2
 structlog==21.4.0
 traitlets==5.9.0
 typing_extensions==4.0.1
-urllib3==1.26.18
+urllib3==1.26.20
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.7


### PR DESCRIPTION
Resolves this alert, but also upgrading to the last version 1.26.20.

<img width="921" alt="Screenshot 2024-09-05 at 11 29 35" src="https://github.com/user-attachments/assets/73382003-1533-4751-a1e1-c9472ba545b6">

[Changelog](https://raw.githubusercontent.com/urllib3/urllib3/main/CHANGES.rst):

```
1.26.20 (2024-08-29)
====================

* Fixed a crash where certain standard library hash functions were absent in
  FIPS-compliant environments.
  (`#3432 <https://github.com/urllib3/urllib3/issues/3432>`__)
* Replaced deprecated dash-separated setuptools entries in ``setup.cfg``.
  (`#3461 <https://github.com/urllib3/urllib3/pull/3461>`__)
* Took into account macOS setting ``ECONNRESET`` instead of ``EPROTOTYPE`` in
  its newer versions.
  (`#3416 <https://github.com/urllib3/urllib3/pull/3416>`__)
* Backported changes to our tests and CI configuration from v2.x to support
  testing with CPython 3.12 and 3.13.
  (`#3436 <https://github.com/urllib3/urllib3/pull/3436>`__)

1.26.19 (2024-06-17)
====================

* Added the ``Proxy-Authorization`` header to the list of headers to strip from requests when redirecting to a different host. As before, different headers can be set via ``Retry.remove_headers_on_redirect``.
* Fixed handling of OpenSSL 3.2.0 new error message for misconfiguring an HTTP proxy as HTTPS. (`#3405 <https://github.com/urllib3/urllib3/issues/3405>`__)
```