### PR TITLE
Provide a way to disable gevent for mysql driver

### DIFF
--- a/inbox/config.py
+++ b/inbox/config.py
@@ -115,6 +115,7 @@ def _update_config_from_env_variables(config):
         or config.get("CALENDAR_POLL_FREQUENCY", 300)
     )
     config["CALENDAR_POLL_FREQUENCY"] = calendar_poll_frequencey
+    config["USE_GEVENT"] = bool(int(os.environ.get("USE_GEVENT", "1")))
 
 
 def _get_process_name(config):


### PR DESCRIPTION
I will be porting off from Gevent one process at a time. I need a selective way to disable MySQL driver Gevent integration per pod because of that since all of the pods share the same db logic. This will be controlled by a environment variable for now. 