### PR TITLE
Drop gevent in delete account pods

### DIFF
--- a/bin/delete-marked-accounts.py
+++ b/bin/delete-marked-accounts.py
@@ -18,9 +18,6 @@ from concurrent.futures import ThreadPoolExecutor
 import click
 
 from inbox.config import config
-
-config["USE_GEVENT"] = False
-
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.logging import configure_logging, get_logger
 from inbox.models.util import batch_delete_namespaces, get_accounts_to_delete

--- a/bin/delete-marked-accounts.py
+++ b/bin/delete-marked-accounts.py
@@ -18,6 +18,9 @@ from concurrent.futures import ThreadPoolExecutor
 import click
 
 from inbox.config import config
+
+config["USE_GEVENT"] = False
+
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.logging import configure_logging, get_logger
 from inbox.models.util import batch_delete_namespaces, get_accounts_to_delete

--- a/inbox/config.py
+++ b/inbox/config.py
@@ -115,6 +115,7 @@ def _update_config_from_env_variables(config):
         or config.get("CALENDAR_POLL_FREQUENCY", 300)
     )
     config["CALENDAR_POLL_FREQUENCY"] = calendar_poll_frequencey
+    config["USE_GEVENT"] = bool(int(os.environ.get("USE_GEVENT", "1")))
 
 
 def _get_process_name(config):


### PR DESCRIPTION
This is the simplest of our processes that can be trivially ported to threads.

- Remove gevent monkey patching
- Use a threadpool instead of list of greenlets
- Don't use gevent APIs, only sleep here. joinall is not needed because the context manager waits for all the threads to end.


<!-- start git-machete generated -->

# Based on PR #894

## Full chain of PRs as of 2024-09-18

* PR #895:
  `drop-gevent-delete-account` ➔ `use-gevent`
* PR #894:
  `use-gevent` ➔ `master`

<!-- end git-machete generated -->
