### PR TITLE
Bump webob & zipp

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -81,9 +81,9 @@ typing_extensions==4.0.1
 urllib3==1.26.20
 vobject==0.9.6.1
 wcwidth==0.2.6
-WebOb==1.8.7
+WebOb==1.8.8
 Werkzeug==3.0.3
-zipp==3.6.0
+zipp==3.20.2
 zope.event==4.5.0
 zope.interface==5.4.0
 zstandard==0.23.0


### PR DESCRIPTION
Bumping to the latest versions since I had no problems with both in the past, no breaking changes, only bugfixes and new features

webob
------

<img width="914" alt="Screenshot 2024-09-23 at 09 27 26" src="https://github.com/user-attachments/assets/d9eb3a47-ceda-4db9-8cfb-95ba75cddced">


[Changelog](https://docs.pylonsproject.org/projects/webob/en/stable/changes.html)

```

1.8.7 (2021-02-17)
Bugfix

    Decoding deflate-encoded responses now supports data which is packed in a zlib container as it is supposed to be. The old, non-standard behaviour is still supported.

    See https://github.com/Pylons/webob/pull/426


```

zipp
----

<img width="919" alt="Screenshot 2024-09-23 at 09 29 30" src="https://github.com/user-attachments/assets/f4b11b5a-d347-48b3-9183-290f20441326">

[Changelog](https://zipp.readthedocs.io/en/latest/history.html)

```
v3.20.2

13 Sep 2024
Bugfixes

    Make zipp.compat.overlay.zipfile hashable. ([#126](https://github.com/jaraco/zipp/issues/126))

v3.20.1

26 Aug 2024
Bugfixes

    Replaced SanitizedNames with a more surgical fix for infinite loops, restoring support for names with special characters in the archive. (python/cpython#123270)

v3.20.0

11 Aug 2024
Features

    Made the zipfile compatibility overlay available as zipp.compat.overlay.

v3.19.3

11 Aug 2024
Bugfixes

    Also match directories in Path.glob. ([#121](https://github.com/jaraco/zipp/issues/121))

v3.19.2

04 Jun 2024

No significant changes.
v3.19.1

31 May 2024
Bugfixes

    Improved handling of malformed zip files. ([#119](https://github.com/jaraco/zipp/issues/119))

v3.19.0

26 May 2024
Features

    Implement is_symlink. ([#117](https://github.com/jaraco/zipp/issues/117))

v3.18.2

16 May 2024

No significant changes.
v3.18.1

14 Mar 2024

No significant changes.
v3.18.0

12 Mar 2024
Features

    Bypass ZipFile.namelist in glob for better performance. ([#106](https://github.com/jaraco/zipp/issues/106))

    Refactored glob functionality to support a more generalized solution with support for platform-specific path separators. ([#108](https://github.com/jaraco/zipp/issues/108))

Bugfixes

    Add special accounting for pypy when computing the stack level for text encoding warnings. ([#114](https://github.com/jaraco/zipp/issues/114))

v3.17.0

18 Sep 2023
Features

    Added CompleteDirs.inject classmethod to make available for use elsewhere.

Bugfixes

    Avoid matching path separators for ‘?’ in glob.

v3.16.2

14 Jul 2023
Bugfixes

    In Path.match, Windows path separators are no longer honored. The fact that they were was incidental and never supported. ([#92](https://github.com/jaraco/zipp/issues/92))

    Fixed name/suffix/suffixes/stem operations when no filename is present and the Path is not at the root of the zipfile. ([#96](https://github.com/jaraco/zipp/issues/96))

    Reworked glob utilizing the namelist directly. ([#101](https://github.com/jaraco/zipp/issues/101))

v3.16.1

12 Jul 2023
Bugfixes

    Replaced the fnmatch.translate with a fresh glob-to-regex translator for more correct matching behavior. ([#98](https://github.com/jaraco/zipp/issues/98))

v3.16.0

08 Jul 2023
Features

    Require Python 3.8 or later.

v3.15.0

24 Feb 2023

    [gh-102209](http://bugs.python.org/issue102209): test_implied_dirs_performance now tests measures the time complexity experimentally.

v3.14.0

17 Feb 2023

    Minor cleanup in tests, including [#93](https://github.com/jaraco/zipp/issues/93).

v3.13.0

09 Feb 2023

    In tests, add a fallback when func_timeout isn’t available.

v3.12.1

05 Feb 2023

    [gh-101566](http://bugs.python.org/issue101566): In CompleteDirs, override ZipFile.getinfo to supply a ZipInfo for implied dirs.

v3.12.0

27 Jan 2023

    [gh-101144](http://bugs.python.org/issue101144): Honor encoding as positional parameter to Path.open() and Path.read_text().

v3.11.0

25 Nov 2022

    [#85](https://github.com/jaraco/zipp/issues/85): Added support for new methods on Path:

        match

        glob and rglob

        relative_to

        is_symlink

v3.10.0

23 Oct 2022

    zipp is now a package.

v3.9.1

23 Oct 2022

    Removed ‘print’ expression in test_pickle.

    [bpo-43651](http://bugs.python.org/issue43651): Apply io.text_encoding on Python 3.10 and later.

v3.9.0

08 Oct 2022

    [#81](https://github.com/jaraco/zipp/issues/81): Path objects are now pickleable if they’ve been constructed from pickleable objects. Any restored objects will re-construct the zip file with the original arguments.

v3.8.1

12 Jul 2022

Refreshed packaging.

Enrolled with Tidelift.
v3.8.0

03 Apr 2022

Removed compatibility code.
v3.7.0

30 Dec 2021

Require Python 3.7 or later.
```