### PR TITLE
Bugfix: one more get_raw_mime instead of get_from_blockstore

### DIFF
--- a/inbox/models/block.py
+++ b/inbox/models/block.py
@@ -117,7 +117,7 @@ class Block(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAtMi
 
                 # Try to fetch the message from S3 first.
                 with statsd_client.timer(f"{statsd_string}.blockstore_latency"):
-                    raw_mime = blockstore.get_from_blockstore(message.data_sha256)
+                    raw_mime = blockstore.get_raw_mime(message.data_sha256)
 
                 # If it's not there, get it from the provider.
                 if raw_mime is None:


### PR DESCRIPTION
I've missed one place where we need to read RAW mime, we need to decompress it after reading from the blockstore (S3).

This happens when trying to import ical files for events (which we don't use in CRM since we read them directly from the calendar APIs). Nonetheless this triggers a Rollbar and should be fixed.