### PR TITLE
Control if attached events are imported by config

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -84,6 +84,7 @@ from inbox.util.stats import statsd_client
 from inbox.util.threading import MAX_THREAD_LENGTH, fetch_corresponding_thread
 
 log = get_logger()
+from inbox.config import config
 from inbox.crispin import FolderMissingError, RawMessage, connection_pool, retry_crispin
 from inbox.events.ical import import_attached_events
 from inbox.heartbeat.store import HeartbeatStatusProxy
@@ -585,7 +586,10 @@ class FolderSyncEngine(Greenlet):
         # obvious place (like Message.create_from_synced) because the function
         # requires new_uid.message to have been flushed.
         # This is necessary because the import_attached_events does db lookups.
-        if new_uid.message.has_attached_events:
+        if (
+            config.get("IMPORT_ATTACHED_EVENTS", True)
+            and new_uid.message.has_attached_events
+        ):
             with db_session.no_autoflush:
                 import_attached_events(db_session, account, new_uid.message)
 


### PR DESCRIPTION
Sync-engine can import events from ICS email message attachments. We don't use this, actually simply ignore them in CRM, since we rely on Google / Microsoft APIs tht are much better to sync those. Until now this only slows down the whole syncing process, uses extra db storage and also generates fair amount of Rollbars since we don't really maintain this code.

I will turn this config option off in the upstream repository.