### PR TITLE
Gunicorn JSON logs, the universal way

### DIFF
--- a/inbox/api/wsgi.py
+++ b/inbox/api/wsgi.py
@@ -2,12 +2,10 @@ import gevent.monkey
 
 gevent.monkey.patch_all()
 
-import errno
-import socket
+import logging
 import sys
 
-import gunicorn.glogging
-from gevent.pywsgi import WSGIHandler, WSGIServer
+import json_log_formatter
 from gunicorn.workers.ggevent import GeventWorker
 
 from inbox.instrumentation import Tracer
@@ -16,105 +14,22 @@ from inbox.logging import configure_logging, get_logger
 log = get_logger()
 
 
-class NylasWSGIHandler(WSGIHandler):
-    """Custom WSGI handler class to customize request logging. Based on
-    gunicorn.workers.ggevent.PyWSGIHandler.
-    """
-
-    def log_request(self):
-        # gevent.pywsgi tries to call log.write(), but Python logger objects
-        # implement log.debug(), log.info(), etc., so we need to monkey-patch
-        # log_request(). See
-        # http://stackoverflow.com/questions/9444405/gunicorn-and-websockets
-        log = self.server.log
-        length = self.response_length
-        if self.time_finish:
-            request_time = round(self.time_finish - self.time_start, 6)
-        if isinstance(self.client_address, tuple):
-            client_address = self.client_address[0]
-        else:
-            client_address = self.client_address
-
-        # client_address is '' when requests are forwarded from nginx via
-        # Unix socket. In that case, replace with a meaningful value
-        if client_address == "":
-            client_address = self.headers.get("X-Forwarded-For")
-        status = getattr(self, "code", None)
-        requestline = getattr(self, "requestline", None)
-        method = getattr(self, "command", None)
-
-        # To use this, generate a unique ID at your termination proxy (e.g.
-        # haproxy or nginx) and set it as a header on the request
-        request_uid = self.headers.get("X-Unique-Id")
-
-        additional_context = self.environ.get("log_context") or {}
-
-        # Since not all users may implement this, don't log null values
-        if request_uid is not None:
-            additional_context["request_uid"] = request_uid
-
-        # pywsgi negates the status code if there was a socket error
-        # (https://github.com/gevent/gevent/blob/master/src/gevent/pywsgi.py#L706)
-        # To make the logs clearer, use the positive status code and include
-        # the socket error
-        if status and status < 0:
-            additional_context["error"] = "socket.error"
-            additional_context["error_message"] = getattr(self, "status", None)
-            status = abs(status)
-
-        log.info(
-            "request handled",
-            response_bytes=length,
-            request_time=request_time,
-            remote_addr=client_address,
-            http_status=status,
-            http_request=requestline,
-            request_method=method,
-            **additional_context
-        )
-
-    def get_environ(self):
-        env = super().get_environ()
-        env["gunicorn.sock"] = self.socket
-        env["RAW_URI"] = self.path
-        return env
-
-    def handle_error(self, type, value, tb):
-        # Suppress tracebacks when e.g. a client disconnects from the streaming
-        # API.
-        if (
-            issubclass(type, socket.error)
-            and value.args[0] == errno.EPIPE
-            and self.response_length
-        ):
-            self.server.log.info("Socket error", exc=value)
-            self.close_connection = True
-        else:
-            super().handle_error(type, value, tb)
-
-
 class NylasWSGIWorker(GeventWorker):
     """Custom worker class for gunicorn. Based on
     gunicorn.workers.ggevent.GeventPyWSGIWorker.
     """
 
-    server_class = WSGIServer
-    wsgi_handler = NylasWSGIHandler
-
     def init_process(self):
         print("Python", sys.version, file=sys.stderr)
+
+        maybe_enable_rollbar()
+
+        configure_logging(log_level=LOGLEVEL)
 
         if MAX_BLOCKING_TIME:
             self.tracer = Tracer(max_blocking_time=MAX_BLOCKING_TIME)
             self.tracer.start()
         super().init_process()
-
-
-class NylasGunicornLogger(gunicorn.glogging.Logger):
-    def __init__(self, cfg):
-        gunicorn.glogging.Logger.__init__(self, cfg)
-        configure_logging(log_level=LOGLEVEL)
-        self.error_log = log
 
 
 from inbox.config import config
@@ -123,23 +38,57 @@ from inbox.error_handling import maybe_enable_rollbar
 MAX_BLOCKING_TIME = config.get("MAX_BLOCKING_TIME", 1.0)
 LOGLEVEL = config.get("LOGLEVEL", 10)
 
-# legacy names for backcompat
-InboxWSGIWorker = NylasWSGIWorker
-GunicornLogger = NylasGunicornLogger
+
+class JsonRequestFormatter(json_log_formatter.JSONFormatter):
+    """Custom JSON log formatter for gunicorn access logs.
+
+    Adapted from https://til.codeinthehole.com/posts/how-to-get-gunicorn-to-log-as-json/
+    """
+
+    def json_record(
+        self,
+        message: str,
+        extra: "dict[str, str | int | float]",
+        record: logging.LogRecord,
+    ) -> "dict[str, str | int | float]":
+        # Convert the log record to a JSON object.
+        # See https://docs.gunicorn.org/en/stable/settings.html#access-log-format
+
+        url = record.args["U"]
+        if record.args["q"]:
+            url += f"?{record.args['q']}"
+
+        method = record.args["m"]
+        log_context = record.args.get("{log_context}e", {})
+
+        return dict(
+            response_bytes=record.args["B"],
+            request_time=float(record.args["L"]),
+            remote_address=record.args["h"],
+            http_status=record.args["s"],
+            http_request=f"{method} {url}",
+            request_method=method,
+            **log_context,
+        )
 
 
-class RollbarWSGIWorker(NylasWSGIWorker):
-    def init_process(self):
-        maybe_enable_rollbar()
+class JsonErrorFormatter(json_log_formatter.JSONFormatter):
+    """Custom JSON log formatter for gunicorn error logs.
 
-        super().init_process()
+    Adapted from https://til.codeinthehole.com/posts/how-to-get-gunicorn-to-log-as-json/
+    """
+
+    def json_record(
+        self,
+        message: str,
+        extra: "dict[str, str | int | float]",
+        record: logging.LogRecord,
+    ) -> "dict[str, str | int | float]":
+        payload: "dict[str, str | int | float]" = super().json_record(
+            message, extra, record
+        )
+        payload["level"] = record.levelname
+        return payload
 
 
-__all__ = [
-    "NylasWSGIHandler",
-    "NylasWSGIWorker",
-    "NylasGunicornLogger",
-    "InboxWSGIWorker",
-    "RollbarWSGIWorker",
-    "GunicornLogger",
-]
+__all__ = ["NylasWSGIWorker"]

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -42,6 +42,7 @@ ipython==8.10.0
 itsdangerous==2.1.2
 Jinja2==3.1.4
 jmespath==0.9.3
+json_log_formatter==1.0
 limitlion==0.10.0
 lxml==5.1.0
 Mako==1.2.2


### PR DESCRIPTION
Adapted from https://til.codeinthehole.com/posts/how-to-get-gunicorn-to-log-as-json/.

Previously the way logging was done was hacky, i.e. we were subclassing internals of the gevent worker to make it work. This is not portable between different worker implementations (i.e. thread and gevent) and the implementation is just ugly. Gunicorn has a standard logging syntax described here https://docs.gunicorn.org/en/stable/settings.html#access-log-format that works between all of them. Also note that Gunicorn is not really designed to use structlog, it's just easier to bite the bullet and format stdlib logging with one of the JSON formatters like `json_log_formatter`.

I already deployed this to single workers to confirm that everything keeps working as expected.

The actual logdict configuration needs to go to the downstream as we maintain Gunicorn configuration there:

```
# Ensure the two named loggers that Gunicorn uses are configured to use a custom
# JSON formatter.
logconfig_dict = {
    "version": 1,
    "formatters": {
        "json_request": {
            "()": JsonRequestFormatter,
        },
        "json_error": {
            "()": JsonErrorFormatter,
        },
    },
    "handlers": {
        "json_request": {
            "class": "logging.StreamHandler",
            "stream": sys.stdout,
            "formatter": "json_request",
        },
        "json_error": {
            "class": "logging.StreamHandler",
            "stream": sys.stdout,
            "formatter": "json_error",
        },
    },
    "root": {"level": "INFO", "handlers": []},
    "loggers": {
        "gunicorn.access": {
            "level": "INFO",
            "handlers": ["json_request"],
            "propagate": False,
        },
        "gunicorn.error": {
            "level": "INFO",
            "handlers": ["json_error"],
            "propagate": False,
        },
    },
}
```

I will open another PR there.