### PR TITLE
Upgrade certifi & cryprography

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,14 +11,14 @@ jedi==0.18.2
 boto==2.49.0
 boto3==1.19.4
 botocore==1.22.9
-certifi==2023.7.22
+certifi==2024.8.30
 cffi==1.15.1
 chardet==3.0.4
 charset-normalizer==3.1.0
 ciso8601==2.2.0
 click==8.1.7
 colorlog==6.5.0
-cryptography==42.0.4
+cryptography==43.0.1
 decorator==5.1.1
 dnspython==2.6.1
 executing==1.2.0


### PR DESCRIPTION
We are not affected by any of the backward incompatible changes

Cryptography
--------------

<img width="922" alt="Screenshot 2024-09-26 at 10 34 27" src="https://github.com/user-attachments/assets/4186497f-3e4d-4442-ba88-5319b8682039">


[Changelog](https://cryptography.io/en/latest/changelog/)

```
43.0.1 - 2024-09-03[](https://cryptography.io/en/latest/changelog/#v43-0-1)

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.3.2.

43.0.0 - 2024-07-20[](https://cryptography.io/en/latest/changelog/#v43-0-0)

    BACKWARDS INCOMPATIBLE: Support for OpenSSL less than 1.1.1e has been removed. Users on older version of OpenSSL will need to upgrade.

    BACKWARDS INCOMPATIBLE: Dropped support for LibreSSL < 3.8.

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.3.1.

    Updated the minimum supported Rust version (MSRV) to 1.65.0, from 1.63.0.

    [generate_private_key()](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key) now enforces a minimum RSA key size of 1024-bit. Note that 1024-bit is still considered insecure, users should generally use a key size of 2048-bits.

    [serialize_certificates()](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.pkcs7.serialize_certificates) now emits ASN.1 that more closely follows the recommendations in [RFC 2315](https://datatracker.ietf.org/doc/html/rfc2315.html).

    Added new [Decrepit cryptography](https://cryptography.io/en/latest/hazmat/decrepit/) module which contains outdated and insecure cryptographic primitives. [CAST5](https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.algorithms.CAST5), [SEED](https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.algorithms.SEED), [IDEA](https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.algorithms.IDEA), and [Blowfish](https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.algorithms.Blowfish), which were deprecated in 37.0.0, have been added to this module. They will be removed from the cipher module in 45.0.0.

    Moved [TripleDES](https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.algorithms.TripleDES) and [ARC4](https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.algorithms.ARC4) into [Decrepit cryptography](https://cryptography.io/en/latest/hazmat/decrepit/) and deprecated them in the cipher module. They will be removed from the cipher module in 48.0.0.

    Added support for deterministic [ECDSA](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/ec/#cryptography.hazmat.primitives.asymmetric.ec.ECDSA) ([RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979.html))

    Added support for client certificate verification to the [X.509 path validation](https://cryptography.io/en/latest/x509/verification/#module-cryptography.x509.verification) APIs in the form of [ClientVerifier](https://cryptography.io/en/latest/x509/verification/#cryptography.x509.verification.ClientVerifier), [VerifiedClient](https://cryptography.io/en/latest/x509/verification/#cryptography.x509.verification.VerifiedClient), and PolicyBuilder [build_client_verifier()](https://cryptography.io/en/latest/x509/verification/#cryptography.x509.verification.PolicyBuilder.build_client_verifier).

    Added Certificate [public_key_algorithm_oid](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Certificate.public_key_algorithm_oid) and Certificate Signing Request [public_key_algorithm_oid](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.CertificateSigningRequest.public_key_algorithm_oid) to determine the [PublicKeyAlgorithmOID](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.oid.PublicKeyAlgorithmOID) Object Identifier of the public key found inside the certificate.

    Added [invalidity_date_utc](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.InvalidityDate.invalidity_date_utc), a timezone-aware alternative to the naïve datetime attribute [invalidity_date](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.InvalidityDate.invalidity_date).

    Added support for parsing empty DN string in [from_rfc4514_string()](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Name.from_rfc4514_string).

    Added the following properties that return timezone-aware datetime objects: [produced_at_utc()](https://cryptography.io/en/latest/x509/ocsp/#cryptography.x509.ocsp.OCSPResponse.produced_at_utc), [revocation_time_utc()](https://cryptography.io/en/latest/x509/ocsp/#cryptography.x509.ocsp.OCSPResponse.revocation_time_utc), [this_update_utc()](https://cryptography.io/en/latest/x509/ocsp/#cryptography.x509.ocsp.OCSPResponse.this_update_utc), [next_update_utc()](https://cryptography.io/en/latest/x509/ocsp/#cryptography.x509.ocsp.OCSPResponse.next_update_utc), [revocation_time_utc()](https://cryptography.io/en/latest/x509/ocsp/#cryptography.x509.ocsp.OCSPSingleResponse.revocation_time_utc), [this_update_utc()](https://cryptography.io/en/latest/x509/ocsp/#cryptography.x509.ocsp.OCSPSingleResponse.this_update_utc), [next_update_utc()](https://cryptography.io/en/latest/x509/ocsp/#cryptography.x509.ocsp.OCSPSingleResponse.next_update_utc), These are timezone-aware variants of existing properties that return naïve datetime objects.

    Added [rsa_recover_private_exponent()](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#cryptography.hazmat.primitives.asymmetric.rsa.rsa_recover_private_exponent)

    Added [reset_nonce()](https://cryptography.io/en/latest/hazmat/primitives/symmetric-encryption/#cryptography.hazmat.primitives.ciphers.CipherContext.reset_nonce) for altering the nonce of a cipher context without initializing a new instance. See the docs for additional restrictions.

    [NameAttribute](https://cryptography.io/en/latest/x509/reference/#cryptography.x509.NameAttribute) now raises an exception when attempting to create a common name whose length is shorter or longer than [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280.html) permits.

    Added basic support for PKCS7 encryption (including SMIME) via [PKCS7EnvelopeBuilder](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.pkcs7.PKCS7EnvelopeBuilder).

42.0.8 - 2024-06-04[](https://cryptography.io/en/latest/changelog/#v42-0-8)

    Updated Windows, macOS, and Linux wheels to be compiled with OpenSSL 3.2.2.

42.0.7 - 2024-05-06[](https://cryptography.io/en/latest/changelog/#v42-0-7)

    Restored Windows 7 compatibility for our pre-built wheels. Note that we do not test on Windows 7 and wheels for our next release will not support it. Microsoft no longer provides support for Windows 7 and users are encouraged to upgrade.

42.0.6 - 2024-05-04[](https://cryptography.io/en/latest/changelog/#v42-0-6)

    Fixed compilation when using LibreSSL 3.9.1.

42.0.5 - 2024-02-23[](https://cryptography.io/en/latest/changelog/#v42-0-5)

    Limit the number of name constraint checks that will be performed in [X.509 path validation](https://cryptography.io/en/latest/x509/verification/#module-cryptography.x509.verification) to protect against denial of service attacks.

    Upgrade pyo3 version, which fixes building on PowerPC.
```

Certifi
------

<img width="927" alt="Screenshot 2024-09-26 at 10 54 11" src="https://github.com/user-attachments/assets/b9734248-c701-42cb-a6dc-16a78753884f">

Mozilla's [investigation](https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/XpknYMPO8dI?pli=1)
