### PR TITLE
Override enable_tracer without gevent

### DIFF
--- a/bin/inbox-start.py
+++ b/bin/inbox-start.py
@@ -124,6 +124,11 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
     print(file=sys.stderr)
     print("Python", sys.version, file=sys.stderr)
 
+    if enable_tracer and not config.get("USE_GEVENT", True):
+        enable_tracer = False
+
+        log.warning("Disabling the stuck greenlet tracer because USE_GEVENT is False")
+
     if enable_profiler:
         inbox_config["DEBUG_PROFILING_ON"] = True
 

--- a/bin/syncback-service.py
+++ b/bin/syncback-service.py
@@ -19,7 +19,7 @@ from setproctitle import setproctitle
 
 from inbox.config import config as inbox_config
 from inbox.error_handling import maybe_enable_rollbar
-from inbox.logging import configure_logging
+from inbox.logging import configure_logging, get_logger
 from inbox.mailsync.frontend import SyncbackHTTPFrontend
 from inbox.transactions.actions import SyncbackService
 from inbox.util.logging_helper import reconfigure_logging
@@ -70,6 +70,12 @@ def main(prod, config, process_num, syncback_id, enable_tracer, enable_profiler)
     level = os.environ.get("LOGLEVEL", inbox_config.get("LOGLEVEL"))
     configure_logging(log_level=level)
     reconfigure_logging()
+
+    if enable_tracer and not config.get("USE_GEVENT", True):
+        enable_tracer = False
+
+        log = get_logger()
+        log.warning("Disabling the stuck greenlet tracer because USE_GEVENT is False")
 
     total_processes = int(os.environ.get("SYNCBACK_PROCESSES", 1))
 


### PR DESCRIPTION
Greenlet tracers are used in sync & syncback processes (on by default), by they are not compatible with threading. They are responsible for detecting greenlets that did not switch to the event loop for too long and can optionally kill them. Those problems are greenlet specific but nonetheless happen from time to time especially in sync processes when parsing larger emails. With threads, even if something gets CPU bound, the Python VM will switch between threads after 5 milliseconds (or whatever you set in `setswitchinterval`), so those are not relevant anymore.

I want to keep the code for now if we need to rollback sync and/or syncback to greenlets because of any problems. At the end of porting I will remove `USE_GEVENT` flag and all the code that effectively becomes dead code.
