### PR TITLE
Syncback: remove some gevent APIs

### DIFF
--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -122,7 +122,7 @@ class SyncbackService(gevent.Greenlet):
         self.batch_size = batch_size
 
         self.keep_running = True
-        self.workers = gevent.pool.Group()
+        self.workers = []
         # Dictionary account_id -> semaphore to serialize action syncback for
         # any particular account.
         # TODO(emfree): We really only need to serialize actions that operate
@@ -480,7 +480,7 @@ class SyncbackService(gevent.Greenlet):
     def _restart_workers(self):
         while len(self.workers) < self.num_workers:
             worker = SyncbackWorker(self)
-            self.workers.add(worker)
+            self.workers.append(worker)
             self.num_idle_workers += 1
             worker.start()
 
@@ -497,7 +497,8 @@ class SyncbackService(gevent.Greenlet):
 
     def stop(self):
         self.keep_running = False
-        self.workers.kill()
+        for worker in self.workers:
+            worker.kill()
 
     def _run(self):
         self.log.info(

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -8,16 +8,15 @@ talking to the same database backend things could go really badly.
 
 """
 
+import queue
 import random
+import threading
 import weakref
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import DefaultDict, Optional, Set
 
 import gevent
-import gevent.event
-from gevent.lock import BoundedSemaphore
-from gevent.queue import Queue
 from sqlalchemy import desc
 
 from inbox.actions.base import (
@@ -130,8 +129,8 @@ class SyncbackService(gevent.Greenlet):
         # on any given object. But IMAP actions are already effectively
         # serialized by using an IMAP connection pool of size 1, so it doesn't
         # matter too much.
-        self.account_semaphores: DefaultDict[int, BoundedSemaphore] = defaultdict(
-            lambda: BoundedSemaphore(1)
+        self.account_semaphores: DefaultDict[int, threading.BoundedSemaphore] = (
+            defaultdict(lambda: threading.BoundedSemaphore(1))
         )
         # This SyncbackService performs syncback for only and all the accounts
         # on shards it is reponsible for; shards are divided up between
@@ -156,11 +155,11 @@ class SyncbackService(gevent.Greenlet):
         self.log = logger.new(component="syncback")
         self.num_workers = num_workers
         self.num_idle_workers = 0
-        self.worker_did_finish = gevent.event.Event()
+        self.worker_did_finish = threading.Event()
         self.worker_did_finish.clear()
-        self.task_queue = Queue()
+        self.task_queue = queue.Queue()
         self.running_action_ids = set()
-        gevent.Greenlet.__init__(self)
+        super().__init__()
 
     def _has_recent_move_action(self, db_session, log_entries):
         """
@@ -818,7 +817,7 @@ class SyncbackWorker(gevent.Greenlet):
         self.parent_service = weakref.ref(parent_service)
         self.task_timeout = task_timeout
         self.log = logger.new(component="syncback-worker")
-        gevent.Greenlet.__init__(self)
+        super().__init__()
 
     def _run(self):
         while self.parent_service().keep_running:


### PR DESCRIPTION
Remove some gevent APIs that we can easily remove in the syncback process:

`gevent.event.Event` -> `threading.Event`
`gevent.lock.BoundSemaphore` -> `threading.BoundSemaphore`
`gevent.queue.Queue` -> `queue.Queue`
`gevent.pool.Group` -> `list`

Things still collaborate with gevent event loop due to monkey patching.
