### PR TITLE
Bugfix: Override enable_tracer without gevent

### DIFF
--- a/bin/inbox-start.py
+++ b/bin/inbox-start.py
@@ -124,7 +124,7 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
     print(file=sys.stderr)
     print("Python", sys.version, file=sys.stderr)
 
-    if enable_tracer and not config.get("USE_GEVENT", True):
+    if enable_tracer and not inbox_config.get("USE_GEVENT", True):
         enable_tracer = False
 
         log.warning("Disabling the stuck greenlet tracer because USE_GEVENT is False")

--- a/bin/syncback-service.py
+++ b/bin/syncback-service.py
@@ -71,7 +71,7 @@ def main(prod, config, process_num, syncback_id, enable_tracer, enable_profiler)
     configure_logging(log_level=level)
     reconfigure_logging()
 
-    if enable_tracer and not config.get("USE_GEVENT", True):
+    if enable_tracer and not inbox_config.get("USE_GEVENT", True):
         enable_tracer = False
 
         log = get_logger()


### PR DESCRIPTION
This is a bugfix to https://github.com/closeio/sync-engine/pull/904.

When testing the previous version end to end I checked out the wrong branch and did not realize.

In both scripts the `config` is imported as `inbox_config` because `config` is a local variable for the main entrypoint :-/
Also if we had working mypy/type checking this kind of error would be caught early.