### PR TITLE
Synback: Remove gevent

### DIFF
--- a/bin/syncback-service.py
+++ b/bin/syncback-service.py
@@ -14,10 +14,6 @@ import click
 from setproctitle import setproctitle
 
 from inbox.config import config as inbox_config
-
-# TODO: set this with environment variables
-inbox_config["USE_GEVENT"] = False
-
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.logging import configure_logging, get_logger
 from inbox.mailsync.frontend import SyncbackHTTPFrontend

--- a/bin/syncback-service.py
+++ b/bin/syncback-service.py
@@ -7,10 +7,6 @@ also starts up the syncback service.)
 """
 
 
-from gevent import monkey
-
-monkey.patch_all()
-
 import os
 import sys
 
@@ -18,6 +14,10 @@ import click
 from setproctitle import setproctitle
 
 from inbox.config import config as inbox_config
+
+# TODO: set this with environment variables
+inbox_config["USE_GEVENT"] = False
+
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.logging import configure_logging, get_logger
 from inbox.mailsync.frontend import SyncbackHTTPFrontend

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -73,7 +73,7 @@ def retry(
         while True:
             try:
                 return func(*args, **kwargs)
-            # Note that GreenletExit isn't actually a subclass of Exception
+            # Note that InterruptibleThreadExit isn't actually a subclass of Exception
             # (It's a subclass of BaseException) so it won't be caught here.
             # This is also considered to be a successful execution
             # (somebody intentionally killed the greenlet).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,8 @@
 """Fixtures don't go here; see util/base.py and friends."""
 
-# Monkeypatch first, to prevent "AttributeError: 'module' object has no
-# attribute 'poll'" errors when tests import socket, then monkeypatch.
-from gevent import monkey
-
-monkey.patch_all(aggressive=False)
-
 import os
 
+os.environ["USE_GEVENT"] = "0"
 os.environ["NYLAS_ENV"] = "test"
 
 from pytest import fixture

--- a/tests/general/test_concurrency.py
+++ b/tests/general/test_concurrency.py
@@ -1,10 +1,11 @@
+import socket
 import time
 
 import _mysql_exceptions
 import pytest
-from gevent import GreenletExit, socket
 from sqlalchemy.exc import StatementError
 
+from inbox.interruptible_threading import InterruptibleThreadExit
 from inbox.util.concurrency import retry_with_logging
 
 
@@ -44,8 +45,8 @@ def test_retry_with_logging():
 
 def test_no_logging_on_greenlet_exit():
     logger = MockLogger()
-    failing_function = FailingFunction(GreenletExit)
-    with pytest.raises(GreenletExit):
+    failing_function = FailingFunction(InterruptibleThreadExit)
+    with pytest.raises(InterruptibleThreadExit):
         retry_with_logging(failing_function, logger=logger)
     assert logger.call_count == 0
     assert failing_function.call_count == 1

--- a/tests/util/base.py
+++ b/tests/util/base.py
@@ -703,6 +703,7 @@ def add_fake_msg_with_calendar_part(db_session, account, ics_str, thread=None):
 @fixture
 def mock_time_sleep(monkeypatch):
     monkeypatch.setattr("time.sleep", mock.Mock())
+    monkeypatch.setattr("inbox.interruptible_threading.sleep", mock.Mock())
     yield
     monkeypatch.undo()
 


### PR DESCRIPTION
Stacked on: https://github.com/closeio/sync-engine/pull/944

Remove gevent from syncback using interruptible threads. As you can see the diff is minimal. I already tested this end to end.

This also removes gevent from the test suite because we are at the point it can be done.