### PR TITLE
Tests: Stop leaking running greenlets from test cases

### DIFF
--- a/tests/api/test_folders.py
+++ b/tests/api/test_folders.py
@@ -76,3 +76,5 @@ def test_folder_name_translation(
         time.sleep(1)
     time.sleep(1)
     mock_imapclient.create_folder.assert_called_with("INBOX.Taxes.Accounting")
+
+    syncback.stop()

--- a/tests/imap/test_actions.py
+++ b/tests/imap/test_actions.py
@@ -237,3 +237,5 @@ def test_failed_event_creation(db, patched_syncback_task, default_account, event
 
     q = db.session.query(ActionLog).filter_by(record_id=event.id).all()
     assert all(a.status == "failed" for a in q)
+
+    service.stop()

--- a/tests/scheduling/test_syncback_logic.py
+++ b/tests/scheduling/test_syncback_logic.py
@@ -122,6 +122,8 @@ def test_actions_are_claimed(purge_accounts_and_actions, patched_task):
         assert q.count() == 1
         assert all(a.status != "pending" for a in q)
 
+    service.stop()
+
 
 @pytest.mark.skipif(True, reason="Need to investigate")
 def test_actions_claimed_by_a_single_service(purge_accounts_and_actions, patched_task):


### PR DESCRIPTION
I've identified some tests that start greenlets but forget to stop them afterwards. Those greenlets go away at the end of the test suite but this is just not clean, pollutes other test and makes debugging concurrency bugs harder.