### PR TITLE
Scripts: Remove gevent

### DIFF
--- a/bin/inbox-api.py
+++ b/bin/inbox-api.py
@@ -3,6 +3,8 @@
 import os
 import sys
 
+import click
+import werkzeug.serving
 from setproctitle import setproctitle
 
 setproctitle("inbox-api")
@@ -20,15 +22,13 @@ except ImportError:
         "Try running sudo ./setup.sh"
     )
 
+inbox_config["USE_GEVENT"] = False
 
-import click
-from gevent.pywsgi import WSGIServer
 
-from inbox.api.wsgi import NylasWSGIHandler
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.logging import configure_logging, get_logger
 from inbox.mailsync.frontend import SyncbackHTTPFrontend
-from inbox.util.startup import load_overrides, preflight
+from inbox.util.startup import load_overrides
 
 syncback = None
 http_server = None
@@ -46,18 +46,13 @@ http_server = None
     help="Also start the syncback service",
 )
 @click.option(
-    "--enable-tracer/--disable-tracer",
-    default=True,
-    help="Disables the stuck greenlet tracer",
-)
-@click.option(
     "--enable-profiler/--disable-profiler",
     default=False,
     help="Enables the CPU profiler web API",
 )
 @click.option("-c", "--config", default=None, help="Path to JSON configuration file.")
 @click.option("-p", "--port", default=5555, help="Port to run flask app on.")
-def main(prod, start_syncback, enable_tracer, config, port, enable_profiler):
+def main(prod, start_syncback, config, port, enable_profiler):
     """Launch the Nylas API service."""
     level = os.environ.get("LOGLEVEL", inbox_config.get("LOGLEVEL"))
     configure_logging(log_level=level)
@@ -68,18 +63,23 @@ def main(prod, start_syncback, enable_tracer, config, port, enable_profiler):
         config_path = os.path.abspath(config)
         load_overrides(config_path)
 
-    if prod:
-        start(port, start_syncback, enable_tracer, enable_profiler)
-    else:
-        preflight()
-        from werkzeug.serving import run_with_reloader
-
-        run_with_reloader(
-            lambda: start(port, start_syncback, enable_tracer, enable_profiler)
-        )
+    start(
+        port=int(port),
+        start_syncback=start_syncback,
+        enable_tracer=False,
+        enable_profiler=enable_profiler,
+        use_reloader=not prod,
+    )
 
 
-def start(port, start_syncback, enable_tracer, enable_profiler):
+def start(
+    *,
+    port: int,
+    start_syncback: bool,
+    enable_tracer: bool,
+    enable_profiler: bool,
+    use_reloader: bool = False
+) -> None:
     # We need to import this down here, because this in turn imports
     # ignition.engine, which has to happen *after* we read any config overrides
     # for the database parameters. Boo for imports with side-effects.
@@ -95,18 +95,15 @@ def start(port, start_syncback, enable_tracer, enable_profiler):
 
         syncback = SyncbackService(0, 0, 1)
         profiling_frontend = SyncbackHTTPFrontend(
-            int(port) + 1, enable_tracer, enable_profiler_api
+            port + 1, enable_tracer, enable_profiler_api
         )
         profiling_frontend.start()
         syncback.start()
 
     nylas_logger = get_logger()
 
-    http_server = WSGIServer(
-        ("", int(port)), app, log=nylas_logger, handler_class=NylasWSGIHandler
-    )
     nylas_logger.info("Starting API server", port=port)
-    http_server.serve_forever()
+    werkzeug.serving.run_simple("", port, app, use_reloader=use_reloader)
 
     if start_syncback:
         syncback.join()

--- a/bin/inbox-auth.py
+++ b/bin/inbox-auth.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
 
-from gevent import monkey
-
-monkey.patch_all()
-
 import sys
 
 import click
@@ -14,6 +10,9 @@ setproctitle("inbox-auth")
 
 from inbox.auth.base import handler_from_provider
 from inbox.config import config
+
+config["USE_GEVENT"] = False
+
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.exceptions import NotSupportedError
 from inbox.logging import configure_logging
@@ -60,7 +59,7 @@ def main(email_address, reauth, target, provider):
 
             # Resolve unknown providers into either custom IMAP or EAS.
             if provider == "unknown":
-                is_imap = raw_input("IMAP account? [Y/n] ").strip().lower() != "n"
+                is_imap = input("IMAP account? [Y/n] ").strip().lower() != "n"
                 provider = "custom" if is_imap else "eas"
 
         auth_handler = handler_from_provider(provider)

--- a/bin/inbox-console.py
+++ b/bin/inbox-console.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
-from gevent import monkey
 
-monkey.patch_all()
 
 from setproctitle import setproctitle
 
 setproctitle("inbox-console")
 
 import click
+
+from inbox.config import config
+
+config["USE_GEVENT"] = False
 
 from inbox.logging import get_logger
 

--- a/bin/remove-message-attachments.py
+++ b/bin/remove-message-attachments.py
@@ -1,8 +1,4 @@
 #!/usr/bin/env python
-from gevent import monkey
-
-monkey.patch_all()
-
 import datetime
 import enum
 import logging
@@ -11,6 +7,10 @@ from collections.abc import Iterable
 import click
 from sqlalchemy.orm import Query, joinedload
 from sqlalchemy.sql import func
+
+from inbox.config import config
+
+config["USE_GEVENT"] = False
 
 from inbox.logging import configure_logging, get_logger
 from inbox.models.block import Block

--- a/bin/restart-forgotten-accounts.py
+++ b/bin/restart-forgotten-accounts.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-import gevent
-import gevent.monkey
+import time
 
-gevent.monkey.patch_all()
+from inbox.config import config
+
+config["USE_GEVENT"] = False
 
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.ignition import engine_manager
@@ -64,7 +65,7 @@ def check_accounts():
 
         accounts_without_sync_host = not_syncing_accounts
 
-    gevent.sleep(poll_interval)
+    time.sleep(poll_interval)
 
 
 def main():

--- a/bin/syncback-stats.py
+++ b/bin/syncback-stats.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
-
-from gevent import monkey
-
-monkey.patch_all()
-
 import click
 from sqlalchemy import func
+
+from inbox.config import config
+
+config["USE_GEVENT"] = False
 
 from inbox.error_handling import maybe_enable_rollbar
 from inbox.ignition import engine_manager


### PR DESCRIPTION
This ports all the scripts that we are not running in k8s pods.

While porting and testing I found out that some of them were already broken before and I fixed them.

Note that we have to pass `config["USE_GEVENT"] = False` since some of the code is still shared with sync and syncback pods that were not fully ported away from gevent.

- Port bin/check-attachments.py
- Port bin/inbox-auth.py
- Port bin/inbox-api.py
- Port bin/inbox-console.py
- Port bin/remove-message-attachments.py
- Port bin/restart-forgotten-accounts.py
- Port bin/syncback-stats.py
