### PR TITLE
Sync: Drop gevent

### DIFF
--- a/bin/inbox-start.py
+++ b/bin/inbox-start.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-from gevent import monkey
-
-monkey.patch_all()
 
 import os
 import platform
@@ -134,7 +131,8 @@ def main(prod, enable_tracer, enable_profiler, config, process_num):
     http_frontend = SyncHTTPFrontend(
         sync_service, port, enable_tracer, enable_profiler_api
     )
-    sync_service.register_pending_avgs_provider(http_frontend)
+    if enable_tracer:
+        sync_service.register_pending_avgs_provider(http_frontend)
     http_frontend.start()
 
     sync_service.run()

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -27,6 +27,7 @@ import imapclient.imap_utf7
 import imapclient.imapclient
 import imapclient.response_parser
 
+from inbox import interruptible_threading
 from inbox.constants import MAX_MESSAGE_BODY_LENGTH
 
 # Prevent "got more than 1000000 bytes" errors for servers that send more data.
@@ -275,9 +276,10 @@ class CrispinConnectionPool:
         if not succeeded:
             raise ConnectionPoolTimeoutError()
 
-        client = self._queue.get()
+        client = interruptible_threading.queue_get(self._queue)
         try:
             if client is None:
+                interruptible_threading.check_interrupted()
                 client = self._new_connection()
             yield client
 
@@ -484,6 +486,7 @@ class CrispinClient:
         """
         # As discovered in the wild list_folders() can return None as name,
         # we cannot handle those folders anyway so just filter them out.
+        interruptible_threading.check_interrupted()
         return [
             (flags, delimiter, name)
             for flags, delimiter, name in self.conn.list_folders()
@@ -535,6 +538,7 @@ class CrispinClient:
         cached/out-of-date values for HIGHESTMODSEQ from the IMAP server.
         """
         try:
+            interruptible_threading.check_interrupted()
             select_info: Dict[bytes, Any] = self.conn.select_folder(
                 folder_name, readonly=self.readonly
             )
@@ -815,6 +819,7 @@ class CrispinClient:
         return RawFolder(display_name=display_name, role=role)
 
     def create_folder(self, name):
+        interruptible_threading.check_interrupted()
         self.conn.create_folder(name)
 
     def condstore_supported(self) -> bool:
@@ -824,6 +829,8 @@ class CrispinClient:
         return b"CONDSTORE" in capabilities or b"QRESYNC" in capabilities
 
     def idle_supported(self) -> bool:
+        interruptible_threading.check_interrupted()
+
         return b"IDLE" in self.conn.capabilities()
 
     def search_uids(self, criteria: List[str]) -> Iterable[int]:
@@ -833,6 +840,7 @@ class CrispinClient:
         criteria.
 
         """
+        interruptible_threading.check_interrupted()
         return (
             int(uid) if not isinstance(uid, int) else uid
             for uid in self.conn.search(criteria)
@@ -855,6 +863,8 @@ class CrispinClient:
 
         try:
             t = time.time()
+
+            interruptible_threading.check_interrupted()
             fetch_result: List[int] = self.conn.search(["ALL"])
         except imaplib.IMAP4.error as e:
             message = e.args[0] if e.args else ""
@@ -867,6 +877,8 @@ class CrispinClient:
                     exception=e,
                 )
                 t = time.time()
+
+                interruptible_threading.check_interrupted()
                 fetch_result = self.conn._search(["ALL"], None)
             elif message.find("UID SEARCH failed: Internal error") >= 0:
                 # Oracle Beehive fails for some folders
@@ -877,6 +889,8 @@ class CrispinClient:
                     exception=e,
                 )
                 t = time.time()
+
+                interruptible_threading.check_interrupted()
                 fetch_result = self.conn.search(["1:*"])
             else:
                 raise
@@ -899,6 +913,7 @@ class CrispinClient:
                     # We already reject parsing messages bigger than MAX_MESSAGE_BODY_PARSE_LENGTH.
                     # We might as well not download them at all, save bandwidth, processing time
                     # and prevent OOMs due to fetching oversized emails.
+                    interruptible_threading.check_interrupted()
                     fetched_size: Dict[int, Dict[bytes, Any]] = self.conn.fetch(
                         uid, ["RFC822.SIZE"]
                     )
@@ -907,6 +922,7 @@ class CrispinClient:
                         log.warning("Skipping fetching of oversized message", uid=uid)
                         continue
 
+                    interruptible_threading.check_interrupted()
                     result: Dict[int, Dict[bytes, Any]] = self.conn.fetch(
                         uid, ["BODY.PEEK[]", "INTERNALDATE", "FLAGS"]
                     )
@@ -975,6 +991,8 @@ class CrispinClient:
             seqset = f"{min(uids)}:*"
         else:
             seqset = uids
+
+        interruptible_threading.check_interrupted()
         data: Dict[int, Dict[bytes, Any]] = self.conn.fetch(seqset, ["FLAGS"])
         uid_set = set(uids)
         return {
@@ -985,10 +1003,15 @@ class CrispinClient:
 
     def delete_uids(self, uids):
         uids = [str(u) for u in uids]
+
+        interruptible_threading.check_interrupted()
         self.conn.delete_messages(uids, silent=True)
+
+        interruptible_threading.check_interrupted()
         self.conn.expunge()
 
     def set_starred(self, uids, starred):
+        interruptible_threading.check_interrupted()
         if starred:
             self.conn.add_flags(uids, ["\\Flagged"], silent=True)
         else:
@@ -996,6 +1019,8 @@ class CrispinClient:
 
     def set_unread(self, uids, unread):
         uids = [str(u) for u in uids]
+
+        interruptible_threading.check_interrupted()
         if unread:
             self.conn.remove_flags(uids, ["\\Seen"], silent=True)
         else:
@@ -1006,6 +1031,7 @@ class CrispinClient:
             self.selected_folder_name in self.folder_names()["drafts"]
         ), f"Must select a drafts folder first ({self.selected_folder_name})"
 
+        interruptible_threading.check_interrupted()
         self.conn.append(
             self.selected_folder_name, message, ["\\Draft", "\\Seen"], date
         )
@@ -1020,6 +1046,7 @@ class CrispinClient:
             self.selected_folder_name in self.folder_names()["sent"]
         ), f"Must select sent folder first ({self.selected_folder_name})"
 
+        interruptible_threading.check_interrupted()
         return self.conn.append(self.selected_folder_name, message, ["\\Seen"], date)
 
     def fetch_headers(self, uids: Iterable[int]) -> Dict[int, Dict[bytes, Any]]:
@@ -1031,6 +1058,7 @@ class CrispinClient:
         """
         headers: Dict[int, Dict[bytes, Any]] = {}
         for uid_chunk in chunk(uids, 100):
+            interruptible_threading.check_interrupted()
             headers.update(self.conn.fetch(uid_chunk, ["BODY.PEEK[HEADER]"]))
         return headers
 
@@ -1065,10 +1093,14 @@ class CrispinClient:
         """
         log.info("Trying to delete sent message", message_id_header=message_id_header)
         sent_folder_name = self.folder_names()["sent"][0]
+
+        interruptible_threading.check_interrupted()
         self.conn.select_folder(sent_folder_name)
         msg_deleted = self._delete_message(message_id_header, delete_multiple)
         if msg_deleted:
             trash_folder_name = self.folder_names()["trash"][0]
+
+            interruptible_threading.check_interrupted()
             self.conn.select_folder(trash_folder_name)
             self._delete_message(message_id_header, delete_multiple)
         return msg_deleted
@@ -1088,10 +1120,14 @@ class CrispinClient:
             message_id_header=message_id_header,
             folder=drafts_folder_name,
         )
+
+        interruptible_threading.check_interrupted()
         self.conn.select_folder(drafts_folder_name)
         draft_deleted = self._delete_message(message_id_header)
         if draft_deleted:
             trash_folder_name = self.folder_names()["trash"][0]
+
+            interruptible_threading.check_interrupted()
             self.conn.select_folder(trash_folder_name)
             self._delete_message(message_id_header)
         return draft_deleted
@@ -1117,11 +1153,16 @@ class CrispinClient:
                 uids=matching_uids,
             )
             return False
+
+        interruptible_threading.check_interrupted()
         self.conn.delete_messages(matching_uids, silent=True)
+
+        interruptible_threading.check_interrupted()
         self.conn.expunge()
         return True
 
     def logout(self):
+        interruptible_threading.check_interrupted()
         self.conn.logout()
 
     def idle(self, timeout):
@@ -1158,6 +1199,8 @@ class CrispinClient:
             if self.conn.welcome.endswith(b" SmarterMail")
             else ["FLAGS"]
         )
+
+        interruptible_threading.check_interrupted()
         data: Dict[int, Dict[bytes, Any]] = self.conn.fetch(
             "1:*", items, modifiers=[f"CHANGEDSINCE {modseq}"]
         )
@@ -1212,6 +1255,8 @@ class GmailCrispinClient(CrispinClient):
             Mapping of `uid` : GmailFlags.
 
         """
+
+        interruptible_threading.check_interrupted()
         data: Dict[int, Dict[bytes, Any]] = self.conn.fetch(
             uids, ["FLAGS", "X-GM-LABELS"]
         )
@@ -1229,6 +1274,7 @@ class GmailCrispinClient(CrispinClient):
     def condstore_changed_flags(
         self, modseq: int
     ) -> Dict[int, Union[GmailFlags, Flags]]:
+        interruptible_threading.check_interrupted()
         data: Dict[int, Dict[bytes, Any]] = self.conn.fetch(
             "1:*", ["FLAGS", "X-GM-LABELS"], modifiers=[f"CHANGEDSINCE {modseq}"]
         )
@@ -1241,6 +1287,8 @@ class GmailCrispinClient(CrispinClient):
                 log.info(
                     "Got incomplete response in flags fetch", uid=uid, ret=str(ret)
                 )
+
+                interruptible_threading.check_interrupted()
                 data_for_uid: Dict[int, Dict[bytes, Any]] = self.conn.fetch(
                     uid, ["FLAGS", "X-GM-LABELS"]
                 )
@@ -1264,6 +1312,7 @@ class GmailCrispinClient(CrispinClient):
             Mapping of `uid` (int) : `g_msgid` (int)
 
         """
+        interruptible_threading.check_interrupted()
         data: Dict[int, Dict[bytes, Any]] = self.conn.fetch(uids, ["X-GM-MSGID"])
         uid_set = set(uids)
         return {uid: ret[b"X-GM-MSGID"] for uid, ret in data.items() if uid in uid_set}
@@ -1277,6 +1326,7 @@ class GmailCrispinClient(CrispinClient):
         -------
         list
         """
+        interruptible_threading.check_interrupted()
         uids = [int(uid) for uid in self.conn.search(["X-GM-MSGID", g_msgid])]
         # UIDs ascend over time; return in order most-recent first
         return sorted(uids, reverse=True)
@@ -1349,6 +1399,7 @@ class GmailCrispinClient(CrispinClient):
         return RawFolder(display_name=display_name, role=role)
 
     def uids(self, uids: List[int]) -> List[RawMessage]:
+        interruptible_threading.check_interrupted()
         imap_messages: Dict[int, Dict[bytes, Any]] = self.conn.fetch(
             uids,
             [
@@ -1398,6 +1449,8 @@ class GmailCrispinClient(CrispinClient):
         # Super long sets of uids may fail with BAD ['Could not parse command']
         # In that case, just fetch metadata for /all/ uids.
         seqset = uids if len(uids) < 1e6 else "1:*"
+
+        interruptible_threading.check_interrupted()
         data = self.conn.fetch(seqset, ["X-GM-MSGID", "X-GM-THRID", "RFC822.SIZE"])
         uid_set = set(uids)
         return {
@@ -1415,11 +1468,13 @@ class GmailCrispinClient(CrispinClient):
         -------
         list
         """
+        interruptible_threading.check_interrupted()
         uids = [int(uid) for uid in self.conn.search(["X-GM-THRID", g_thrid])]
         # UIDs ascend over time; return in order most-recent first
         return sorted(uids, reverse=True)
 
     def find_by_header(self, header_name, header_value):
+        interruptible_threading.check_interrupted()
         return self.conn.search(["HEADER", header_name, header_value])
 
     def _decode_labels(self, labels):
@@ -1450,6 +1505,7 @@ class GmailCrispinClient(CrispinClient):
         # values.
 
         # First find the message in the sent folder
+        interruptible_threading.check_interrupted()
         self.conn.select_folder(sent_folder_name)
         matching_uids = self.find_by_header("Message-Id", message_id_header)
 
@@ -1461,6 +1517,7 @@ class GmailCrispinClient(CrispinClient):
             raise DraftDeletionException("Only one message should have this msgid")
 
         # Then find the draft in the draft folder
+        interruptible_threading.check_interrupted()
         self.conn.select_folder(drafts_folder_name)
         matching_uids = self.find_by_header("Message-Id", message_id_header)
         if not matching_uids:
@@ -1479,13 +1536,19 @@ class GmailCrispinClient(CrispinClient):
                     "different messages."
                 )
 
+        interruptible_threading.check_interrupted()
         self.conn.copy(matching_uids, trash_folder_name)
+
+        interruptible_threading.check_interrupted()
         self.conn.select_folder(trash_folder_name)
 
         for msgid in gm_msgids.values():
             uids = self.g_msgid_to_uids(msgid)
+
+            interruptible_threading.check_interrupted()
             self.conn.delete_messages(uids, silent=True)
 
+        interruptible_threading.check_interrupted()
         self.conn.expunge()
         return True
 
@@ -1506,6 +1569,8 @@ class GmailCrispinClient(CrispinClient):
         sent_folder_name = self.folder_names()["sent"][0]
         trash_folder_name = self.folder_names()["trash"][0]
         # First find the message in Sent
+        interruptible_threading.check_interrupted()
+
         self.conn.select_folder(sent_folder_name)
         matching_uids = self.find_by_header("Message-Id", message_id_header)
         if not matching_uids:
@@ -1513,10 +1578,14 @@ class GmailCrispinClient(CrispinClient):
 
         # To delete, first copy the message to trash (sufficient to move from
         # gmail's All Mail folder to Trash folder)
+        interruptible_threading.check_interrupted()
+
         self.conn.copy(matching_uids, trash_folder_name)
 
         # Next, select delete the message from trash (in the normal way) to
         # permanently delete it.
+        interruptible_threading.check_interrupted()
+
         self.conn.select_folder(trash_folder_name)
         self._delete_message(message_id_header, delete_multiple)
         return True
@@ -1556,6 +1625,8 @@ class GmailCrispinClient(CrispinClient):
         # Now actually perform the search skipping imapclient's public API which does quoting differently
         # based off: https://github.com/mjs/imapclient/blob/master/imapclient/imapclient.py#L1123-L1145
         try:
+            interruptible_threading.check_interrupted()
+
             data = self.conn._raw_command_untagged(
                 b"SEARCH", [b"X-GM-LABELS", encoded_label_name]
             )

--- a/inbox/events/google.py
+++ b/inbox/events/google.py
@@ -27,7 +27,7 @@ from inbox.exceptions import AccessNotEnabledError, OAuthError
 from inbox.models import Account, Calendar
 from inbox.models.backends.oauth import token_manager
 from inbox.models.event import EVENT_STATUSES, Event
-from inbox.util.concurrency import iterate_and_periodically_switch_to_gevent
+from inbox.util.concurrency import iterate_and_periodically_check_interrupted
 
 CALENDARS_URL = "https://www.googleapis.com/calendar/v3/users/me/calendarList"
 STATUS_MAP = {
@@ -93,7 +93,7 @@ class GoogleEventsProvider(AbstractEventsProvider):
         updates = []
         raw_events = self._get_raw_events(calendar_uid, sync_from_time)
         read_only_calendar = self.calendars_table.get(calendar_uid, True)
-        for raw_event in iterate_and_periodically_switch_to_gevent(raw_events):
+        for raw_event in iterate_and_periodically_check_interrupted(raw_events):
             try:
                 parsed = parse_event_response(raw_event, read_only_calendar)
                 updates.append(parsed)

--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -27,7 +27,7 @@ from inbox.models.backends.outlook import MICROSOFT_CALENDAR_SCOPES
 from inbox.models.calendar import Calendar
 from inbox.models.event import Event, RecurringEvent
 from inbox.models.session import session_scope
-from inbox.util.concurrency import iterate_and_periodically_switch_to_gevent
+from inbox.util.concurrency import iterate_and_periodically_check_interrupted
 
 URL_PREFIX = config.get("API_URL", "")
 
@@ -136,7 +136,7 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
             ),
         )
         read_only = self.calendars_table.get(calendar_uid, True)
-        for raw_event in iterate_and_periodically_switch_to_gevent(raw_events):
+        for raw_event in iterate_and_periodically_check_interrupted(raw_events):
             if not validate_event(raw_event):
                 self.log.warning("Invalid event", raw_event=raw_event)
                 continue

--- a/inbox/interruptible_threading.py
+++ b/inbox/interruptible_threading.py
@@ -70,7 +70,7 @@ class InterruptibleThread(threading.Thread):
         thread is started. Otherwise, the subclass must implement the `_run`
         method.
         """
-        self.__should_be_killed = threading.Event()
+        self.__should_be_killed = False
         self.__ready = False
         self.__run_target = (
             _InterruptibleThreadTarget(target, args, kwargs) if target else None
@@ -130,7 +130,7 @@ class InterruptibleThread(threading.Thread):
 
         If block is True, wait until the thread is ready.
         """
-        self.__should_be_killed.set()
+        self.__should_be_killed = True
         if block:
             self.join()
 
@@ -141,7 +141,7 @@ class InterruptibleThread(threading.Thread):
         Don't use this directly instead use the public
         `check_interrupted` function below.
         """
-        if self.__should_be_killed.wait(0.01):
+        if self.__should_be_killed:
             raise InterruptibleThreadExit()
 
         if (

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -20,7 +20,6 @@ user always gets the full thread when they look at mail.
 
 """
 
-import time
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from threading import Semaphore
@@ -28,6 +27,7 @@ from typing import TYPE_CHECKING, Dict, List
 
 from sqlalchemy.orm import joinedload, load_only
 
+from inbox import interruptible_threading
 from inbox.logging import get_logger
 from inbox.mailsync.backends.base import THROTTLE_COUNT, THROTTLE_WAIT
 from inbox.mailsync.backends.imap import common
@@ -553,7 +553,7 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 # messages for this batch are synced.
                 # Note this is an approx. limit since we use the #(uids),
                 # not the #(messages).
-                time.sleep(THROTTLE_WAIT)
+                interruptible_threading.sleep(THROTTLE_WAIT)
 
     @property
     def throttled(self):

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -510,12 +510,6 @@ class FolderSyncEngine(InterruptibleThread):
             )
         return self._should_idle
 
-    def idle(self, crispin_client):
-        start = time.monotonic()
-        while time.monotonic() - start < IDLE_WAIT:
-            interruptible_threading.check_interrupted()
-            crispin_client.idle(1)
-
     def poll_impl(self):
         with self.conn_pool.get() as crispin_client:
             self.check_uid_changes(crispin_client)
@@ -523,7 +517,7 @@ class FolderSyncEngine(InterruptibleThread):
                 crispin_client.select_folder(self.folder_name, self.uidvalidity_cb)
                 idling = True
                 try:
-                    self.idle(crispin_client)
+                    crispin_client.idle(IDLE_WAIT)
                 except Exception as exc:
                     # With some servers we get e.g.
                     # 'Unexpected IDLE response: * FLAGS  (...)'

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -65,15 +65,16 @@ import contextlib
 import imaplib
 import time
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Dict, NoReturn, Optional
 
-from gevent import Greenlet
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 
+from inbox import interruptible_threading
 from inbox.exceptions import ValidationError
+from inbox.interruptible_threading import InterruptibleThread
 from inbox.logging import get_logger
 from inbox.util.concurrency import retry_with_logging
 from inbox.util.debug import bind_context
@@ -127,7 +128,7 @@ MAX_UIDINVALID_RESYNCS = 5
 CONDSTORE_FLAGS_REFRESH_BATCH_SIZE = 200
 
 
-class ChangePoller(Greenlet):
+class ChangePoller(InterruptibleThread):
     def __init__(self, engine: "FolderSyncEngine") -> None:
         self.engine = engine
 
@@ -139,9 +140,10 @@ class ChangePoller(Greenlet):
         )
 
     @retry_crispin
-    def _run(self) -> None:
+    def _run(self) -> NoReturn:
         log.new(account_id=self.engine.account_id, folder=self.engine.folder_name)
         while True:
+            interruptible_threading.check_interrupted()
             log.debug("polling for changes")
             self.engine.poll_impl()
 
@@ -149,7 +151,7 @@ class ChangePoller(Greenlet):
         return f"<{self.name}>"
 
 
-class FolderSyncEngine(Greenlet):
+class FolderSyncEngine(InterruptibleThread):
     """Base class for a per-folder IMAP sync engine."""
 
     def __init__(
@@ -277,6 +279,7 @@ class FolderSyncEngine(Greenlet):
         # time if it receives a shutdown command. The shutdown command is
         # equivalent to ctrl-c.
         while self.state != "finish":
+            interruptible_threading.check_interrupted()
             retry_with_logging(
                 self._run_impl,
                 account_id=self.account_id,
@@ -491,7 +494,7 @@ class FolderSyncEngine(Greenlet):
                     # messages per folder are synced.
                     # Note this is an approx. limit since we use the #(uids),
                     # not the #(messages).
-                    time.sleep(THROTTLE_WAIT)
+                    interruptible_threading.sleep(THROTTLE_WAIT)
 
             del new_uids  # free up memory as soon as possible
         finally:
@@ -507,6 +510,12 @@ class FolderSyncEngine(Greenlet):
             )
         return self._should_idle
 
+    def idle(self, crispin_client):
+        start = time.monotonic()
+        while time.monotonic() - start < IDLE_WAIT:
+            interruptible_threading.check_interrupted()
+            crispin_client.idle(1)
+
     def poll_impl(self):
         with self.conn_pool.get() as crispin_client:
             self.check_uid_changes(crispin_client)
@@ -514,7 +523,7 @@ class FolderSyncEngine(Greenlet):
                 crispin_client.select_folder(self.folder_name, self.uidvalidity_cb)
                 idling = True
                 try:
-                    crispin_client.idle(IDLE_WAIT)
+                    self.idle(crispin_client)
                 except Exception as exc:
                     # With some servers we get e.g.
                     # 'Unexpected IDLE response: * FLAGS  (...)'
@@ -535,7 +544,7 @@ class FolderSyncEngine(Greenlet):
                 idling = False
         # Close IMAP connection before sleeping
         if not idling:
-            time.sleep(self.poll_frequency)
+            interruptible_threading.sleep(self.poll_frequency)
 
     def resync_uids_impl(self):
         # First, let's check if the UIVDALIDITY change was spurious, if

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -119,9 +119,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
 
     def start_new_folder_sync_engines(self):
         running_monitors = {
-            monitor.folder_name: monitor
-            for monitor in self.folder_monitors
-            if monitor.is_alive()
+            monitor.folder_name: monitor for monitor in self.folder_monitors
         }
 
         for folder_name in self.prepare_sync():

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -1,7 +1,7 @@
-import time
 from threading import BoundedSemaphore
 from typing import List
 
+from inbox import interruptible_threading
 from inbox.crispin import connection_pool, retry_crispin
 from inbox.exceptions import ValidationError
 from inbox.logging import get_logger
@@ -119,7 +119,9 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
 
     def start_new_folder_sync_engines(self):
         running_monitors = {
-            monitor.folder_name: monitor for monitor in self.folder_monitors
+            monitor.folder_name: monitor
+            for monitor in self.folder_monitors
+            if monitor.is_alive()
         }
 
         for folder_name in self.prepare_sync():
@@ -143,7 +145,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
                 thread.start()
 
             while thread.state != "poll" and not thread.ready():
-                time.sleep(self.heartbeat)
+                interruptible_threading.sleep(self.heartbeat)
 
             if thread.ready():
                 log.info(
@@ -173,7 +175,7 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
             self.start_delete_handler()
             self.start_new_folder_sync_engines()
             while True:
-                time.sleep(self.refresh_frequency)
+                interruptible_threading.sleep(self.refresh_frequency)
                 self.start_new_folder_sync_engines()
         except ValidationError as exc:
             log.error(

--- a/inbox/mailsync/frontend.py
+++ b/inbox/mailsync/frontend.py
@@ -58,7 +58,7 @@ class ProfilingHTTPFrontend:
         @app.route("/load")
         def load():
             if self.tracer is None:
-                return "Load tracing disabled\n", 404
+                return "Load tracing disabled\n"
             resp = jsonify(self.tracer.stats())
             if request.args.get("reset ") in (1, "true"):
                 self.tracer.reset()


### PR DESCRIPTION
Sync: Remove gevent

Stacked on https://github.com/closeio/sync-engine/pull/911

This again takes advantage of `IterruptibleThread` polyfill. The changes are
* changing base classes from `Greenlet` to `InterruptibleThread`.
* Added `check_interrupted` calls around I/O and other places it makes sense
* blocking calls like sleep become iterruptible etc.