### PR TITLE
Sync: Fix stopping

### DIFF
--- a/bin/inbox-start.py
+++ b/bin/inbox-start.py
@@ -1,23 +1,21 @@
 #!/usr/bin/env python
 
-
-import random
-import threading
-import time
-
-import structlog
 from gevent import monkey
 
 monkey.patch_all()
 
 import os
 import platform
+import random
 import signal
 import socket
 import sys
+import threading
+import time
 
 import click
 import setproctitle
+import structlog
 
 # Check that the inbox package is installed. It seems Vagrant may sometimes
 # fail to provision the box appropriately; this check is a reasonable

--- a/inbox/mailsync/backends/base.py
+++ b/inbox/mailsync/backends/base.py
@@ -75,12 +75,15 @@ class BaseMailSyncMonitor(Greenlet):
         self.sync_greenlet.join()
 
         if self.sync_greenlet.successful():
-            return self._cleanup()
+            self._cleanup()
+            self.log.info(
+                "mail sync finished successfully", provider=self.provider_name
+            )
+            return
 
         self.log.error(
-            "mail sync should run forever",
+            "mail sync raised an exception",
             provider=self.provider_name,
-            account_id=self.account_id,
             exc=self.sync_greenlet.exception,
         )
         raise self.sync_greenlet.exception

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -118,6 +118,22 @@ class SyncService:
         while self.keep_running:
             retry_with_logging(self._run_impl, self.log)
 
+        for email_sync_monitor in self.email_sync_monitors.values():
+            email_sync_monitor.sync_greenlet.kill()
+        self.log.info(
+            "stopped email sync monitors", count=len(self.email_sync_monitors)
+        )
+        for contact_sync_monitor in self.contact_sync_monitors.values():
+            contact_sync_monitor.kill()
+        self.log.info(
+            "stopped contact sync monitors", count=len(self.contact_sync_monitors)
+        )
+        for event_sync_monitor in self.event_sync_monitors.values():
+            event_sync_monitor.kill()
+        self.log.info(
+            "stopped event sync monitors", count=len(self.event_sync_monitors)
+        )
+
     def _run_impl(self):
         """
         Waits for notifications about Account migrations and checks for start/stop commands.
@@ -349,14 +365,8 @@ class SyncService:
                 return False
         return True
 
-    def stop(self, *args):
-        self.log.info("stopping mail sync process")
-        for _, v in self.email_sync_monitors.items():
-            gevent.kill(v)
-        for _, v in self.contact_sync_monitors.items():
-            gevent.kill(v)
-        for _, v in self.event_sync_monitors.items():
-            gevent.kill(v)
+    def stop(self) -> None:
+        self.log.info("stopping sync process")
         self.keep_running = False
 
     def stop_sync(self, account_id):
@@ -368,7 +378,7 @@ class SyncService:
         with self.semaphore:
             self.log.info("Stopping monitors", account_id=account_id)
             if account_id in self.email_sync_monitors:
-                self.email_sync_monitors[account_id].kill()
+                self.email_sync_monitors[account_id].sync_greenlet.kill()
                 del self.email_sync_monitors[account_id]
 
             # Stop contacts sync if necessary


### PR DESCRIPTION
This fixes some of the perils of concurrent programming...

First of all we were killing greenlets inside a signal handler which you should never do as those operations are not safe to run there ending up in `gevent.exceptions.BlockingSwitchOutError: Impossible to call blocking function in the event loop callback`. I moved them outside the signal handler and now they run after the main loop of the program ends after signal handler is received. 

On this branch sync-engine exists without exceptions

```
{"greenlet_id": 281473418792448, "env": "prod", "event": "stopping sync process", "timestamp": "2024-10-02T12:10:27.258759Z", "level": "info", "module": "inbox.mailsync.service:379"}
{"provider": "imap", "account_id": 4, "greenlet_id": 281473279804256, "env": "prod", "event": "mail sync finished successfully", "timestamp": "2024-10-02T12:10:31.783778Z", "level": "info", "module": "inbox.mailsync.backends.base:79"}
{"component": "mail sync", "count": 1, "greenlet_id": 281473430750144, "env": "prod", "event": "stopped email sync monitors", "timestamp": "2024-10-02T12:10:31.781238Z", "level": "info", "module": "inbox.mailsync.service:133"}
{"component": "mail sync", "count": 0, "greenlet_id": 281473430750144, "env": "prod", "event": "stopped contact sync monitors", "timestamp": "2024-10-02T12:10:31.781742Z", "level": "info", "module": "inbox.mailsync.service:138"}
{"component": "mail sync", "count": 0, "greenlet_id": 281473430750144, "env": "prod", "event": "stopped event sync monitors", "timestamp": "2024-10-02T12:10:31.782038Z", "level": "info", "module": "inbox.mailsync.service:143"}
Nylas Sync Engine exiting...
```

Before on master we had a very ungraceful explosion when stopping sync-engine...

```
[INFO] {"greenlet_id": 281473293991504, "env": "prod", "event": "stopping mail sync process", "timestamp": "2024-10-03T10:36:30.171478Z", "level": "info", "module": "inbox.mailsync.service:372"}
Traceback (most recent call last):
  File "/opt/app/bin/inbox-start.py", line 156, in <lambda>
    signal.signal(signal.SIGINT, lambda *_: sync_service.stop())
  File "/opt/app/inbox/mailsync/service.py", line 374, in stop
    v.kill()
  File "/usr/lib/python3.9/threading.py", line 1033, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.9/threading.py", line 1049, in _wait_for_tstate_lock
    elif lock.acquire(block, timeout):
  File "/opt/venv/lib/python3.9/site-packages/gevent/thread.py", line 112, in acquire
    acquired = BoundedSemaphore.acquire(self, blocking, timeout)
  File "src/gevent/_semaphore.py", line 184, in gevent._gevent_c_semaphore.Semaphore.acquire
  File "src/gevent/_semaphore.py", line 253, in gevent._gevent_c_semaphore.Semaphore.acquire
  File "src/gevent/_abstract_linkable.py", line 521, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait
  File "src/gevent/_abstract_linkable.py", line 487, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 490, in gevent._gevent_c_abstract_linkable.AbstractLinkable._wait_core
  File "src/gevent/_abstract_linkable.py", line 442, in gevent._gevent_c_abstract_linkable.AbstractLinkable._AbstractLinkable__wait_to_be_notified
  File "src/gevent/_abstract_linkable.py", line 451, in gevent._gevent_c_abstract_linkable.AbstractLinkable._switch_to_hub
  File "src/gevent/_greenlet_primitives.py", line 61, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 64, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch
  File "src/gevent/_greenlet_primitives.py", line 67, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch_out
  File "src/gevent/_greenlet_primitives.py", line 68, in gevent._gevent_c_greenlet_primitives.SwitchOutGreenletWithLoop.switch_out
gevent.exceptions.BlockingSwitchOutError: Impossible to call blocking function in the event loop callback
```

The process would SEGFAULT after this exception

Second, we were killing the main email sync greenlet without killing their children greenlets. Those would become runaway, and in turn their cleanup would not run as they would be still running at the time the main program thread exists.

