### PR TITLE
Sync: Port --exit-after to threads

### DIFF
--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -64,12 +64,7 @@ class SyncService:
     """
 
     def __init__(
-        self,
-        process_identifier,
-        process_number,
-        poll_interval=SYNC_POLL_INTERVAL,
-        exit_after_min=None,
-        exit_after_max=None,
+        self, process_identifier, process_number, poll_interval=SYNC_POLL_INTERVAL
     ):
         self.keep_running = True
         self.host = platform.node()
@@ -118,11 +113,6 @@ class SyncService:
         self.stealing_enabled = config.get("SYNC_STEAL_ACCOUNTS", True)
         self._pending_avgs_provider = None
         self.last_unloaded_account = time.time()
-
-        if exit_after_min and exit_after_max:
-            exit_after = random.randint(exit_after_min * 60, exit_after_max * 60)
-            self.log.info("exit after", seconds=exit_after)
-            gevent.spawn_later(exit_after, self.stop)
 
     def run(self):
         while self.keep_running:


### PR DESCRIPTION
Ports off this functionality from `gevent.spawn_after` API.

Note that we are using this functionality in production to automatically cycle pods from time to time and avoid memory leaks (yes they are there in the first place and we just deal with them like that since forever LOL)

So the process can end on signals, or exit automatically somewhere between `--exit-after=min_minutes:max_minutes`. The values we are using in production are `--exit-after=240:360` which is somewhere between 4 and 6 hours.

This is done in thread-land with a daemon thread that sleeps and calls sync_service stop(). I moved the whole logic away from the class because this is very similar to how signals are handled.

Why daemon? Because the interpreter does not wait for daemon threads to exit before shutting down, otherwise if a signal came first we would get stuck on the sleep. From the [docs](https://docs.python.org/3/library/threading.html#thread-objects).

> A thread can be flagged as a “daemon thread”. The significance of this flag is that the entire Python program exits when only daemon threads are left. The initial value is inherited from the creating thread. The flag can be set through the [daemon](https://docs.python.org/3/library/threading.html#threading.Thread.daemon) property or the daemon constructor argument.