### PR TITLE
Reduce memory pressure

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -832,7 +832,10 @@ class CrispinClient:
         criteria.
 
         """
-        return sorted(int(uid) for uid in self.conn.search(criteria))
+        return sorted(
+            int(uid) if not isinstance(uid, int) else uid
+            for uid in self.conn.search(criteria)
+        )
 
     def all_uids(self) -> List[int]:
         """Fetch all UIDs associated with the currently selected folder.
@@ -881,7 +884,9 @@ class CrispinClient:
         log.debug(
             "Requested all UIDs", search_time=elapsed, total_uids=len(fetch_result)
         )
-        return sorted(int(uid) for uid in fetch_result)
+        return sorted(
+            int(uid) if not isinstance(uid, int) else uid for uid in fetch_result
+        )
 
     def uids(self, uids: List[int]) -> List[RawMessage]:
         uid_set = set(uids)
@@ -1580,4 +1585,4 @@ class GmailCrispinClient(CrispinClient):
             raise
 
         response = imapclient.response_parser.parse_message_list(data)
-        return sorted(int(uid) for uid in response)
+        return sorted(int(uid) if not isinstance(uid, int) else uid for uid in response)

--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -45,7 +45,9 @@ def local_uids(
     if limit:
         q = q.order_by(desc(ImapUid.msg_uid))
         q = q.limit(bindparam("limit"))
-    q = q.params(account_id=account_id, folder_id=folder_id, limit=limit)
+    q = q.params(account_id=account_id, folder_id=folder_id, limit=limit).yield_per(
+        1000
+    )
     return {uid for uid, in q}
 
 

--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -32,7 +32,9 @@ from inbox.models.util import reconcile_message
 log = get_logger()
 
 
-def local_uids(account_id, session, folder_id, limit=None):
+def local_uids(
+    account_id: int, session, folder_id: int, limit: "int | None" = None
+) -> "set[int]":
     q = session.query(ImapUid.msg_uid).with_hint(
         ImapUid, "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)"
     )
@@ -43,8 +45,8 @@ def local_uids(account_id, session, folder_id, limit=None):
     if limit:
         q = q.order_by(desc(ImapUid.msg_uid))
         q = q.limit(bindparam("limit"))
-    results = q.params(account_id=account_id, folder_id=folder_id, limit=limit).all()
-    return {u for u, in results}
+    q = q.params(account_id=account_id, folder_id=folder_id, limit=limit)
+    return {uid for uid, in q}
 
 
 def lastseenuid(account_id, session, folder_id):

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -65,7 +65,7 @@ import contextlib
 import imaplib
 import time
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Dict, Optional
 
 from gevent import Greenlet
 from sqlalchemy import func
@@ -84,7 +84,13 @@ from inbox.util.threading import MAX_THREAD_LENGTH, fetch_corresponding_thread
 
 log = get_logger()
 from inbox.config import config
-from inbox.crispin import FolderMissingError, RawMessage, connection_pool, retry_crispin
+from inbox.crispin import (
+    CrispinClient,
+    FolderMissingError,
+    RawMessage,
+    connection_pool,
+    retry_crispin,
+)
 from inbox.events.ical import import_attached_events
 from inbox.heartbeat.store import HeartbeatStatusProxy
 from inbox.mailsync.backends.base import (
@@ -102,9 +108,6 @@ from inbox.models.backends.imap import (
     ImapUid,
 )
 from inbox.models.session import session_scope
-
-if TYPE_CHECKING:
-    from inbox.crispin import CrispinClient
 
 # Idle doesn't necessarily pick up flag changes, so we don't want to
 # idle for very long, or we won't detect things like messages being
@@ -428,7 +431,7 @@ class FolderSyncEngine(Greenlet):
         self.resync_uids_impl()
         return "initial"
 
-    def initial_sync_impl(self, crispin_client):
+    def initial_sync_impl(self, crispin_client: CrispinClient):
         # We wrap the block in a try/finally because the change_poller greenlet
         # needs to be killed when this greenlet is interrupted
         change_poller = None
@@ -441,18 +444,20 @@ class FolderSyncEngine(Greenlet):
                         self.account_id, db_session, self.folder_id
                     )
                 common.remove_deleted_uids(
-                    self.account_id,
-                    self.folder_id,
-                    set(local_uids).difference(remote_uids),
+                    self.account_id, self.folder_id, local_uids.difference(remote_uids)
                 )
 
-            new_uids = set(remote_uids).difference(local_uids)
+            new_uids = sorted(set(remote_uids).difference(local_uids), reverse=True)
+
+            len_remote_uids = len(remote_uids)
+            del remote_uids  # free up memory as soon as possible
+
             with session_scope(self.namespace_id) as db_session:
                 account = db_session.query(Account).get(self.account_id)
                 throttled = account.throttled
                 self.update_uid_counts(
                     db_session,
-                    remote_uid_count=len(remote_uids),
+                    remote_uid_count=len_remote_uids,
                     # This is the initial size of our download_queue
                     download_uid_count=len(new_uids),
                 )
@@ -460,8 +465,7 @@ class FolderSyncEngine(Greenlet):
             change_poller = ChangePoller(self)
             change_poller.start()
             bind_context(change_poller, "changepoller", self.account_id, self.folder_id)
-            uids = sorted(new_uids, reverse=True)
-            for count, uid in enumerate(uids, start=1):
+            for count, uid in enumerate(new_uids, start=1):
                 # The speedup from batching appears to be less clear for
                 # non-Gmail accounts, so for now just download one-at-a-time.
                 self.download_and_commit_uids(crispin_client, [uid])
@@ -473,6 +477,8 @@ class FolderSyncEngine(Greenlet):
                     # Note this is an approx. limit since we use the #(uids),
                     # not the #(messages).
                     time.sleep(THROTTLE_WAIT)
+
+            del new_uids  # free up memory as soon as possible
         finally:
             if change_poller is not None:
                 # schedule change_poller to die
@@ -775,7 +781,7 @@ class FolderSyncEngine(Greenlet):
                 self.download_and_commit_uids(crispin_client, [uid])
         self.uidnext = remote_uidnext
 
-    def condstore_refresh_flags(self, crispin_client: "CrispinClient") -> None:
+    def condstore_refresh_flags(self, crispin_client: CrispinClient) -> None:
         new_highestmodseq: int = crispin_client.conn.folder_status(
             self.folder_name, ["HIGHESTMODSEQ"]
         )[b"HIGHESTMODSEQ"]
@@ -879,9 +885,7 @@ class FolderSyncEngine(Greenlet):
             self.refresh_flags_impl(crispin_client, FAST_FLAGS_REFRESH_LIMIT)
             self.last_fast_refresh = datetime.utcnow()
 
-    def refresh_flags_impl(
-        self, crispin_client: "CrispinClient", max_uids: int
-    ) -> None:
+    def refresh_flags_impl(self, crispin_client: CrispinClient, max_uids: int) -> None:
         crispin_client.select_folder(self.folder_name, self.uidvalidity_cb)
 
         # Check for any deleted messages.


### PR DESCRIPTION
I'm currently hunting memory leaks in sync pods. While running [memray](https://github.com/bloomberg/memray) in production I noticed that we are holding a lot of references to collections of integers. This is not a surprise to me as a single folder can have tens of millions of messages these days. Nonetheless we were holding references for too long, and sometimes buffering/copying twice for no good reason. This PR fixes those problems.

![image](https://github.com/user-attachments/assets/bc01a21d-6a59-4221-9683-fd434e5998b3)


