### PR TITLE
Upgrade sqlalchemy

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -72,7 +72,7 @@ rollbar==0.16.2
 s3transfer==0.5.0
 setproctitle==1.2.2
 six==1.16.0
-sqlalchemy==1.4.26
+sqlalchemy==1.4.54
 statsd==3.3.0
 stack-data==0.6.2
 tldextract==3.1.2


### PR DESCRIPTION
I am in the process of hunting memory leaks with [memray](https://github.com/bloomberg/memray). While analyzing the parts of the program that allocate memory faster than they deallocate I've seen a lot of stack traces inside sqlalchemy. E.g.

![image](https://github.com/user-attachments/assets/8c0418c5-90de-424e-a1f2-c4c40bd92e88)

This lead me to suspect that the version of sqlalchemy sync-engine uses has memory leaks.
I started reading the changelog and quickly spotted that there are indeed changes that fix memory leaks/improve memory usage that we are missing i.e.:

https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-1.4.44

> Fixed critical memory issue identified in cache key generation, where for very large and complex ORM statements that make use of lots of ORM aliases with subqueries, cache key generation could produce excessively large keys that were orders of magnitude bigger than the statement itself.

https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-1.4.36

> Fixed a memory leak in the C extensions which could occur when calling upon named members of [Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row) when the member does not exist under Python 3; in particular this could occur during NumPy transformations when it attempts to call members such as .__array__, but the issue was surrounding any AttributeError thrown by the [Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row) object. This issue does not apply to version 2.0 which has already transitioned to Cython.

https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-1.4.33

> Improvements in memory usage by the ORM, removing a significant set of intermediary expression objects that are typically stored when a copy of an expression object is created. These clones have been greatly reduced, reducing the number of total expression objects stored in memory by ORM mappings by about 30%



[Full Changelog](https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-1.4.52)

```
1.4.54
Released: September 5, 2024
general

    [general] [change]

    The pin for setuptools<69.3 in pyproject.toml has been removed. This pin was to prevent a sudden change in setuptools to use [PEP 625](https://peps.python.org/pep-0625/) from taking place, which would change the file name of SQLAlchemy’s source distribution on pypi to be an all lower case name, which is likely to cause problems with various build environments that expected the previous naming style. However, the presence of this pin is holding back environments that otherwise want to use a newer setuptools, so we’ve decided to move forward with this change, with the assumption that build environments will have largely accommodated the setuptools change by now.

    This change was first released in version 2.0.33 however is being backported to 1.4.54 to support ongoing releases.

    References: [#11818](https://www.sqlalchemy.org/trac/ticket/11818)

    [general] [change]

    The setuptools “test” command is removed from the 1.4 series as modern versions of setuptools actively refuse to accommodate this extension being present. This change was already part of the 2.0 series. To run the test suite use the tox command.

orm

    [orm] [bug] [regression]

    Fixed regression from 1.3 where the column key used for a hybrid property might be populated with that of the underlying column that it returns, for a property that returns an ORM mapped column directly, rather than the key used by the hybrid property itself.

    References: [#11728](https://www.sqlalchemy.org/trac/ticket/11728)

postgresql

    [postgresql] [bug]

    Fixed critical issue in the asyncpg driver where a rollback or commit that fails specifically for the MissingGreenlet condition or any other error that is not raised by asyncpg itself would discard the asyncpg transaction in any case, even though the transaction were still idle, leaving to a server side condition with an idle transaction that then goes back into the connection pool. The flags for “transaction closed” are now not reset for errors that are raised outside of asyncpg itself. When asyncpg itself raises an error for .commit() or .rollback(), asyncpg does then discard of this transaction.

    References: [#11819](https://www.sqlalchemy.org/trac/ticket/11819)

1.4.53
Released: July 29, 2024
general

    [general] [bug]

    Set up full Python 3.13 support to the extent currently possible, repairing issues within internal language helpers as well as the serializer extension module.

    For version 1.4, this also modernizes the “extras” names in setup.cfg to use dashes and not underscores for two-word names. Underscore names are still present to accommodate potential compatibility issues.

    References: [#11417](https://www.sqlalchemy.org/trac/ticket/11417)

orm

    [orm] [bug] [regression]

    Fixed regression going back to 1.4 where accessing a collection using the “dynamic” strategy on a transient object and attempting to query would raise an internal error rather than the expected [NoResultFound](https://docs.sqlalchemy.org/en/20/core/exceptions.html#sqlalchemy.exc.NoResultFound) that occurred in 1.3.

    References: [#11562](https://www.sqlalchemy.org/trac/ticket/11562)

engine

    [engine] [usecase]

    Modified the internal representation used for adapting asyncio calls to greenlets to allow for duck-typed compatibility with third party libraries that implement SQLAlchemy’s “greenlet-to-asyncio” pattern directly. Running code within a greenlet that features the attribute __sqlalchemy_greenlet_provider__ = True will allow calls to sqlalchemy.util.await_only() directly.

    [engine] [bug]

    Adjustments to the C extensions, which are specific to the SQLAlchemy 1.x series, to work under Python 3.13. Pull request courtesy Ben Beasley.

    References: [#11499](https://www.sqlalchemy.org/trac/ticket/11499)

sql

    [sql] [bug]

    Fixed caching issue where using the [TextualSelect.add_cte()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TextualSelect.add_cte) method of the [TextualSelect](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TextualSelect) construct would not set a correct cache key which distinguished between different CTE expressions.

    References: [#11471](https://www.sqlalchemy.org/trac/ticket/11471)

    [sql] [bug]

    Fixed caching issue where the [Select.with_for_update.key_share](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.with_for_update.params.key_share) element of [Select.with_for_update()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.with_for_update) was not considered as part of the cache key, leading to incorrect caching if different variations of this parameter were used with an otherwise identical statement.

    References: [#11544](https://www.sqlalchemy.org/trac/ticket/11544)

mypy

    [mypy] [bug]

    The deprecated mypy plugin is no longer fully functional with the latest series of mypy 1.11.0, as changes in the mypy interpreter are no longer compatible with the approach used by the plugin. If code is dependent on the mypy plugin with sqlalchemy2-stubs, it’s recommended to pin mypy to be below the 1.11.0 series. Seek upgrading to the 2.0 series of SQLAlchemy and migrating to the modern type annotations.

    See also

    [Mypy / Pep-484 Support for ORM Mappings](https://docs.sqlalchemy.org/en/20/orm/extensions/mypy.html)

sqlite

    [sqlite] [bug] [reflection]

    Fixed reflection of computed column in SQLite to properly account for complex expressions.

    References: [#11582](https://www.sqlalchemy.org/trac/ticket/11582)

mssql

    [mssql] [bug]

    Fixed issue where SQL Server drivers don’t support bound parameters when rendering the “frame specification” for a window function, e.g. “ROWS BETWEEN”, etc.

    References: [#11514](https://www.sqlalchemy.org/trac/ticket/11514)

1.4.52
Released: March 4, 2024
orm

    [orm] [bug]

    Fixed bug where ORM [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) would not apply itself to a [Select.join()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.join) where the ON clause were given as a plain SQL comparison, rather than as a relationship target or similar.

    This is a backport of the same issue fixed in version 2.0 for 2.0.22.

    update - this was found to also fix an issue where single-inheritance criteria would not be correctly applied to a subclass entity that only appeared in the select_from() list, see [#11412](https://www.sqlalchemy.org/trac/ticket/11412)

    References: [#10365](https://www.sqlalchemy.org/trac/ticket/10365), [#11412](https://www.sqlalchemy.org/trac/ticket/11412)

1.4.51
Released: January 2, 2024
orm

    [orm] [bug]

    Improved a fix first implemented for [#3208](https://www.sqlalchemy.org/trac/ticket/3208) released in version 0.9.8, where the registry of classes used internally by declarative could be subject to a race condition in the case where individual mapped classes are being garbage collected at the same time while new mapped classes are being constructed, as can happen in some test suite configurations or dynamic class creation environments. In addition to the weakref check already added, the list of items being iterated is also copied first to avoid “list changed while iterating” errors. Pull request courtesy Yilei Yang.

    References: [#10782](https://www.sqlalchemy.org/trac/ticket/10782)

asyncio

    [asyncio] [bug]

    Fixed critical issue in asyncio version of the connection pool where calling [AsyncEngine.dispose()](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncEngine.dispose) would produce a new connection pool that did not fully re-establish the use of asyncio-compatible mutexes, leading to the use of a plain threading.Lock() which would then cause deadlocks in an asyncio context when using concurrency features like asyncio.gather().

    References: [#10813](https://www.sqlalchemy.org/trac/ticket/10813)

mysql

    [mysql] [bug]

    Fixed regression introduced by the fix in ticket [#10492](https://www.sqlalchemy.org/trac/ticket/10492) when using pool pre-ping with PyMySQL version older than 1.0.

    References: [#10650](https://www.sqlalchemy.org/trac/ticket/10650)

1.4.50
Released: October 29, 2023
orm

    [orm] [bug]

    Fixed fundamental issue which prevented some forms of ORM “annotations” from taking place for subqueries which made use of [Select.join()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.join) against a relationship target. These annotations are used whenever a subquery is used in special situations such as within [PropComparator.and_()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.and_) and other ORM-specific scenarios.

    References: [#10223](https://www.sqlalchemy.org/trac/ticket/10223)

sql

    [sql] [bug]

    Fixed issue where using the same bound parameter more than once with literal_execute=True in some combinations with other literal rendering parameters would cause the wrong values to render due to an iteration issue.

    References: [#10142](https://www.sqlalchemy.org/trac/ticket/10142)

    [sql] [bug]

    Fixed issue where unpickling of a [Column](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column) or other [ColumnElement](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnElement) would fail to restore the correct “comparator” object, which is used to generate SQL expressions specific to the type object.

    References: [#10213](https://www.sqlalchemy.org/trac/ticket/10213)

schema

    [schema] [bug]

    Modified the rendering of the Oracle only [Identity.order](https://docs.sqlalchemy.org/en/20/core/defaults.html#sqlalchemy.schema.Identity.params.order) parameter that’s part of both [Sequence](https://docs.sqlalchemy.org/en/20/core/defaults.html#sqlalchemy.schema.Sequence) and [Identity](https://docs.sqlalchemy.org/en/20/core/defaults.html#sqlalchemy.schema.Identity) to only take place for the Oracle backend, and not other backends such as that of PostgreSQL. A future release will rename the [Identity.order](https://docs.sqlalchemy.org/en/20/core/defaults.html#sqlalchemy.schema.Identity.params.order), [Sequence.order](https://docs.sqlalchemy.org/en/20/core/defaults.html#sqlalchemy.schema.Sequence.params.order) and [Identity.on_null](https://docs.sqlalchemy.org/en/20/core/defaults.html#sqlalchemy.schema.Identity.params.on_null) parameters to Oracle-specific names, deprecating the old names, these parameters only apply to Oracle.

    References: [#10207](https://www.sqlalchemy.org/trac/ticket/10207)

mysql

    [mysql] [usecase]

    Updated aiomysql dialect since the dialect appears to be maintained again. Re-added to the ci testing using version 0.2.0.

    [mysql] [bug]

    Repaired a new incompatibility in the MySQL “pre-ping” routine where the False argument passed to connection.ping(), which is intended to disable an unwanted “automatic reconnect” feature, is being deprecated in MySQL drivers and backends, and is producing warnings for some versions of MySQL’s native client drivers. It’s removed for mysqlclient, whereas for PyMySQL and drivers based on PyMySQL, the parameter will be deprecated and removed at some point, so API introspection is used to future proof against these various stages of removal.

    References: [#10492](https://www.sqlalchemy.org/trac/ticket/10492)

mssql

    [mssql] [bug] [reflection]

    Fixed issue where identity column reflection would fail for a bigint column with a large identity start value (more than 18 digits).

    References: [#10504](https://www.sqlalchemy.org/trac/ticket/10504)

1.4.49
Released: July 5, 2023
platform

    [platform] [usecase]

    Compatibility improvements to work fully with Python 3.12

sql

    [sql] [bug]

    Fixed issue where the [ColumnOperators.regexp_match()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.regexp_match) when using “flags” would not produce a “stable” cache key, that is, the cache key would keep changing each time causing cache pollution. The same issue existed for [ColumnOperators.regexp_replace()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.regexp_replace) with both the flags and the actual replacement expression. The flags are now represented as fixed modifier strings rendered as safestrings rather than bound parameters, and the replacement expression is established within the primary portion of the “binary” element so that it generates an appropriate cache key.

    Note that as part of this change, the [ColumnOperators.regexp_match.flags](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.regexp_match.params.flags) and [ColumnOperators.regexp_replace.flags](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.regexp_replace.params.flags) have been modified to render as literal strings only, whereas previously they were rendered as full SQL expressions, typically bound parameters. These parameters should always be passed as plain Python strings and not as SQL expression constructs; it’s not expected that SQL expression constructs were used in practice for this parameter, so this is a backwards-incompatible change.

    The change also modifies the internal structure of the expression generated, for [ColumnOperators.regexp_replace()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.regexp_replace) with or without flags, and for [ColumnOperators.regexp_match()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.regexp_match) with flags. Third party dialects which may have implemented regexp implementations of their own (no such dialects could be located in a search, so impact is expected to be low) would need to adjust the traversal of the structure to accommodate.

    References: [#10042](https://www.sqlalchemy.org/trac/ticket/10042)

    [sql] [bug]

    Fixed issue in mostly-internal [CacheKey](https://docs.sqlalchemy.org/en/20/core/foundation.html#sqlalchemy.sql.expression.CacheKey) construct where the __ne__() operator were not properly implemented, leading to nonsensical results when comparing [CacheKey](https://docs.sqlalchemy.org/en/20/core/foundation.html#sqlalchemy.sql.expression.CacheKey) instances to each other.

extensions

    [extensions] [bug]

    Fixed issue in mypy plugin for use with mypy 1.4.

1.4.48
Released: April 30, 2023
orm

    [orm] [bug]

    Fixed critical caching issue where the combination of [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) and [hybrid_property()](https://docs.sqlalchemy.org/en/20/orm/extensions/hybrid.html#sqlalchemy.ext.hybrid.hybrid_property) expression compositions would cause a cache key mismatch, leading to cache keys that held onto the actual [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) object while also not matching that of equivalent constructs, filling up the cache.

    References: [#9728](https://www.sqlalchemy.org/trac/ticket/9728)

    [orm] [bug]

    Fixed bug where various ORM-specific getters such as [ORMExecuteState.is_column_load](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.ORMExecuteState.is_column_load), [ORMExecuteState.is_relationship_load](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.ORMExecuteState.is_relationship_load), [ORMExecuteState.loader_strategy_path](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.ORMExecuteState.loader_strategy_path) etc. would throw an AttributeError if the SQL statement itself were a “compound select” such as a UNION.

    References: [#9634](https://www.sqlalchemy.org/trac/ticket/9634)

    [orm] [bug]

    Fixed endless loop which could occur when using “relationship to aliased class” feature and also indicating a recursive eager loader such as lazy="selectinload" in the loader, in combination with another eager loader on the opposite side. The check for cycles has been fixed to include aliased class relationships.

    References: [#9590](https://www.sqlalchemy.org/trac/ticket/9590)

1.4.47
Released: March 18, 2023
sql

    [sql] [bug]

    Fixed bug / regression where using [bindparam()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.bindparam) with the same name as a column in the [Update.values()](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Update.values) method of [Update](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Update), as well as the [Insert.values()](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Insert.values) method of [Insert](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Insert) in 2.0 only, would in some cases silently fail to honor the SQL expression in which the parameter were presented, replacing the expression with a new parameter of the same name and discarding any other elements of the SQL expression, such as SQL functions, etc. The specific case would be statements that were constructed against ORM entities rather than plain [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table) instances, but would occur if the statement were invoked with a [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session) or a [Connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection).

    [Update](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Update) part of the issue was present in both 2.0 and 1.4 and is backported to 1.4.

    References: [#9075](https://www.sqlalchemy.org/trac/ticket/9075)

    [sql] [bug]

    Fixed stringify for a the [CreateSchema](https://docs.sqlalchemy.org/en/20/core/ddl.html#sqlalchemy.schema.CreateSchema) and [DropSchema](https://docs.sqlalchemy.org/en/20/core/ddl.html#sqlalchemy.schema.DropSchema) DDL constructs, which would fail with an AttributeError when stringified without a dialect.

    References: [#7664](https://www.sqlalchemy.org/trac/ticket/7664)

    [sql] [bug]

    Fixed critical SQL caching issue where use of the [Operators.op()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.Operators.op) custom operator function would not produce an appropriate cache key, leading to reduce the effectiveness of the SQL cache.

    References: [#9506](https://www.sqlalchemy.org/trac/ticket/9506)

mypy

    [mypy] [bug]

    Adjustments made to the mypy plugin to accommodate for some potential changes being made for issue #236 sqlalchemy2-stubs when using SQLAlchemy 1.4. These changes are being kept in sync within SQLAlchemy 2.0. The changes are also backwards compatible with older versions of sqlalchemy2-stubs.

    [mypy] [bug]

    Fixed crash in mypy plugin which could occur on both 1.4 and 2.0 versions if a decorator for the [mapped()](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.registry.mapped) decorator were used that was referenced in an expression with more than two components (e.g. @Backend.mapper_registry.mapped). This scenario is now ignored; when using the plugin, the decorator expression needs to be two components (i.e. @reg.mapped).

    References: [#9102](https://www.sqlalchemy.org/trac/ticket/9102)

postgresql

    [postgresql] [bug]

    Added support to the asyncpg dialect to return the cursor.rowcount value for SELECT statements when available. While this is not a typical use for cursor.rowcount, the other PostgreSQL dialects generally provide this value. Pull request courtesy Michael Gorven.

    References: [#9048](https://www.sqlalchemy.org/trac/ticket/9048)

mysql

    [mysql] [usecase]

    Added support to MySQL index reflection to correctly reflect the mysql_length dictionary, which previously was being ignored.

    References: [#9047](https://www.sqlalchemy.org/trac/ticket/9047)

mssql

    [mssql] [bug]

    Fixed bug where a schema name given with brackets, but no dots inside the name, for parameters such as [Table.schema](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.params.schema) would not be interpreted within the context of the SQL Server dialect’s documented behavior of interpreting explicit brackets as token delimiters, first added in 1.2 for #2626, when referring to the schema name in reflection operations. The original assumption for #2626’s behavior was that the special interpretation of brackets was only significant if dots were present, however in practice, the brackets are not included as part of the identifier name for all SQL rendering operations since these are not valid characters within regular or delimited identifiers. Pull request courtesy Shan.

    References: [#9133](https://www.sqlalchemy.org/trac/ticket/9133)

oracle

    [oracle] [bug]

    Added [ROWID](https://docs.sqlalchemy.org/en/20/dialects/oracle.html#sqlalchemy.dialects.oracle.ROWID) to reflected types as this type may be used in a “CREATE TABLE” statement.

    References: [#5047](https://www.sqlalchemy.org/trac/ticket/5047)

1.4.46
Released: January 3, 2023
general

    [general] [change]

    A new deprecation “uber warning” is now emitted at runtime the first time any SQLAlchemy 2.0 deprecation warning would normally be emitted, but the SQLALCHEMY_WARN_20 environment variable is not set. The warning emits only once at most, before setting a boolean to prevent it from emitting a second time.

    This deprecation warning intends to notify users who may not have set an appropriate constraint in their requirements files to block against a surprise SQLAlchemy 2.0 upgrade and also alert that the SQLAlchemy 2.0 upgrade process is available, as the first full 2.0 release is expected very soon. The deprecation warning can be silenced by setting the environment variable SQLALCHEMY_SILENCE_UBER_WARNING to "1".

    See also

    [SQLAlchemy 2.0 - Major Migration Guide](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html)

    References: [#8983](https://www.sqlalchemy.org/trac/ticket/8983)

    [general] [bug]

    Fixed regression where the base compat module was calling upon platform.architecture() in order to detect some system properties, which results in an over-broad system call against the system-level file call that is unavailable under some circumstances, including within some secure environment configurations.

    References: [#8995](https://www.sqlalchemy.org/trac/ticket/8995)

orm

    [orm] [bug]

    Fixed issue in the internal SQL traversal for DML statements like [Update](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Update) and [Delete](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Delete) which would cause among other potential issues, a specific issue using lambda statements with the ORM update/delete feature.

    References: [#9033](https://www.sqlalchemy.org/trac/ticket/9033)

engine

    [engine] [bug]

    Fixed a long-standing race condition in the connection pool which could occur under eventlet/gevent monkeypatching schemes in conjunction with the use of eventlet/gevent Timeout conditions, where a connection pool checkout that’s interrupted due to the timeout would fail to clean up the failed state, causing the underlying connection record and sometimes the database connection itself to “leak”, leaving the pool in an invalid state with unreachable entries. This issue was first identified and fixed in SQLAlchemy 1.2 for [#4225](https://www.sqlalchemy.org/trac/ticket/4225), however the failure modes detected in that fix failed to accommodate for BaseException, rather than Exception, which prevented eventlet/gevent Timeout from being caught. In addition, a block within initial pool connect has also been identified and hardened with a BaseException -> “clean failed connect” block to accommodate for the same condition in this location. Big thanks to Github user @niklaus for their tenacious efforts in identifying and describing this intricate issue.

    References: [#8974](https://www.sqlalchemy.org/trac/ticket/8974)

sql

    [sql] [bug]

    Added parameter [FunctionElement.column_valued.joins_implicitly](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.column_valued.params.joins_implicitly), which is useful in preventing the “cartesian product” warning when making use of table-valued or column-valued functions. This parameter was already introduced for [FunctionElement.table_valued()](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.table_valued) in [#7845](https://www.sqlalchemy.org/trac/ticket/7845), however it failed to be added for [FunctionElement.column_valued()](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.column_valued) as well.

    References: [#9009](https://www.sqlalchemy.org/trac/ticket/9009)

    [sql] [bug]

    Fixed bug where SQL compilation would fail (assertion fail in 2.0, NoneType error in 1.4) when using an expression whose type included [TypeEngine.bind_expression()](https://docs.sqlalchemy.org/en/20/core/type_api.html#sqlalchemy.types.TypeEngine.bind_expression), in the context of an “expanding” (i.e. “IN”) parameter in conjunction with the literal_binds compiler parameter.

    References: [#8989](https://www.sqlalchemy.org/trac/ticket/8989)

    [sql] [bug]

    Fixed issue in lambda SQL feature where the calculated type of a literal value would not take into account the type coercion rules of the “compared to type”, leading to a lack of typing information for SQL expressions, such as comparisons to [JSON](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.JSON) elements and similar.

    References: [#9029](https://www.sqlalchemy.org/trac/ticket/9029)

postgresql

    [postgresql] [usecase]

    Added the PostgreSQL type MACADDR8. Pull request courtesy of Asim Farooq.

    References: [#8393](https://www.sqlalchemy.org/trac/ticket/8393)

    [postgresql] [bug]

    Fixed bug where the PostgreSQL [Insert.on_conflict_do_update.constraint](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.Insert.on_conflict_do_update.params.constraint) parameter would accept an [Index](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.Index) object, however would not expand this index out into its individual index expressions, instead rendering its name in an ON CONFLICT ON CONSTRAINT clause, which is not accepted by PostgreSQL; the “constraint name” form only accepts unique or exclude constraint names. The parameter continues to accept the index but now expands it out into its component expressions for the render.

    References: [#9023](https://www.sqlalchemy.org/trac/ticket/9023)

sqlite

    [sqlite] [bug]

    Fixed regression caused by new support for reflection of partial indexes on SQLite added in 1.4.45 for [#8804](https://www.sqlalchemy.org/trac/ticket/8804), where the index_list pragma command in very old versions of SQLite (possibly prior to 3.8.9) does not return the current expected number of columns, leading to exceptions raised when reflecting tables and indexes.

    References: [#8969](https://www.sqlalchemy.org/trac/ticket/8969)

tests

    [tests] [bug]

    Fixed issue in tox.ini file where changes in the tox 4.0 series to the format of “passenv” caused tox to not function correctly, in particular raising an error as of tox 4.0.6.

    [tests] [bug]

    Added new exclusion rule for third party dialects called unusual_column_name_characters, which can be “closed” for third party dialects that don’t support column names with unusual characters such as dots, slashes, or percent signs in them, even if the name is properly quoted.

    References: [#9002](https://www.sqlalchemy.org/trac/ticket/9002)

1.4.45
Released: December 10, 2022
orm

    [orm] [bug]

    Fixed bug where [Session.merge()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge) would fail to preserve the current loaded contents of relationship attributes that were indicated with the [relationship.viewonly](https://docs.sqlalchemy.org/en/20/orm/relationship_api.html#sqlalchemy.orm.relationship.params.viewonly) parameter, thus defeating strategies that use [Session.merge()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge) to pull fully loaded objects from caches and other similar techniques. In a related change, fixed issue where an object that contains a loaded relationship that was nonetheless configured as lazy='raise' on the mapping would fail when passed to [Session.merge()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge); checks for “raise” are now suspended within the merge process assuming the [Session.merge.load](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge.params.load) parameter remains at its default of True.

    Overall, this is a behavioral adjustment to a change introduced in the 1.4 series as of [#4994](https://www.sqlalchemy.org/trac/ticket/4994), which took “merge” out of the set of cascades applied by default to “viewonly” relationships. As “viewonly” relationships aren’t persisted under any circumstances, allowing their contents to transfer during “merge” does not impact the persistence behavior of the target object. This allows [Session.merge()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge) to correctly suit one of its use cases, that of adding objects to a [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session) that were loaded elsewhere, often for the purposes of restoring from a cache.

    References: [#8862](https://www.sqlalchemy.org/trac/ticket/8862)

    [orm] [bug]

    Fixed issues in [with_expression()](https://docs.sqlalchemy.org/en/20/orm/queryguide/columns.html#sqlalchemy.orm.with_expression) where expressions that were composed of columns that were referenced from the enclosing SELECT would not render correct SQL in some contexts, in the case where the expression had a label name that matched the attribute which used [query_expression()](https://docs.sqlalchemy.org/en/20/orm/queryguide/columns.html#sqlalchemy.orm.query_expression), even when [query_expression()](https://docs.sqlalchemy.org/en/20/orm/queryguide/columns.html#sqlalchemy.orm.query_expression) had no default expression. For the moment, if the [query_expression()](https://docs.sqlalchemy.org/en/20/orm/queryguide/columns.html#sqlalchemy.orm.query_expression) does have a default expression, that label name is still used for that default, and an additional label with the same name will continue to be ignored. Overall, this case is pretty thorny so further adjustments might be warranted.

    References: [#8881](https://www.sqlalchemy.org/trac/ticket/8881)

engine

    [engine] [bug]

    Fixed issue where [Result.freeze()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.freeze) method would not work for textual SQL using either [text()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.text) or [Connection.exec_driver_sql()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.exec_driver_sql).

    References: [#8963](https://www.sqlalchemy.org/trac/ticket/8963)

sql

    [sql] [usecase]

    An informative re-raise is now thrown in the case where any “literal bindparam” render operation fails, indicating the value itself and the datatype in use, to assist in debugging when literal params are being rendered in a statement.

    References: [#8800](https://www.sqlalchemy.org/trac/ticket/8800)

    [sql] [bug]

    Fixed a series of issues regarding the position and sometimes the identity of rendered bound parameters, such as those used for SQLite, asyncpg, MySQL, Oracle and others. Some compiled forms would not maintain the order of parameters correctly, such as the PostgreSQL regexp_replace() function, the “nesting” feature of the [CTE](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.CTE) construct first introduced in [#4123](https://www.sqlalchemy.org/trac/ticket/4123), and selectable tables formed by using the [FunctionElement.column_valued()](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.column_valued) method with Oracle.

    References: [#8827](https://www.sqlalchemy.org/trac/ticket/8827)

asyncio

    [asyncio] [bug]

    Removed non-functional merge() method from [AsyncResult](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncResult). This method has never worked and was included with [AsyncResult](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncResult) in error.

    References: [#8952](https://www.sqlalchemy.org/trac/ticket/8952)

postgresql

    [postgresql] [bug]

    Made an adjustment to how the PostgreSQL dialect considers column types when it reflects columns from a table, to accommodate for alternative backends which may return NULL from the PG format_type() function.

    References: [#8748](https://www.sqlalchemy.org/trac/ticket/8748)

sqlite

    [sqlite] [usecase]

    Added support for the SQLite backend to reflect the “DEFERRABLE” and “INITIALLY” keywords which may be present on a foreign key construct. Pull request courtesy Michael Gorven.

    References: [#8903](https://www.sqlalchemy.org/trac/ticket/8903)

    [sqlite] [usecase]

    Added support for reflection of expression-oriented WHERE criteria included in indexes on the SQLite dialect, in a manner similar to that of the PostgreSQL dialect. Pull request courtesy Tobias Pfeiffer.

    References: [#8804](https://www.sqlalchemy.org/trac/ticket/8804)

    [sqlite] [bug]

    Backported a fix for SQLite reflection of unique constraints in attached schemas, released in 2.0 as a small part of [#4379](https://www.sqlalchemy.org/trac/ticket/4379). Previously, unique constraints in attached schemas would be ignored by SQLite reflection. Pull request courtesy Michael Gorven.

    References: [#8866](https://www.sqlalchemy.org/trac/ticket/8866)

oracle

    [oracle] [bug]

    Continued fixes for Oracle fix [#8708](https://www.sqlalchemy.org/trac/ticket/8708) released in 1.4.43 where bound parameter names that start with underscores, which are disallowed by Oracle, were still not being properly escaped in all circumstances.

    References: [#8708](https://www.sqlalchemy.org/trac/ticket/8708)

    [oracle] [bug]

    Fixed issue in Oracle compiler where the syntax for [FunctionElement.column_valued()](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.column_valued) was incorrect, rendering the name COLUMN_VALUE without qualifying the source table correctly.

    References: [#8945](https://www.sqlalchemy.org/trac/ticket/8945)

1.4.44
Released: November 12, 2022
sql

    [sql] [bug]

    Fixed critical memory issue identified in cache key generation, where for very large and complex ORM statements that make use of lots of ORM aliases with subqueries, cache key generation could produce excessively large keys that were orders of magnitude bigger than the statement itself. Much thanks to Rollo Konig Brock for their very patient, long term help in finally identifying this issue.

    References: [#8790](https://www.sqlalchemy.org/trac/ticket/8790)

postgresql

    [postgresql] [bug] [mssql]

    For the PostgreSQL and SQL Server dialects only, adjusted the compiler so that when rendering column expressions in the RETURNING clause, the “non anon” label that’s used in SELECT statements is suggested for SQL expression elements that generate a label; the primary example is a SQL function that may be emitting as part of the column’s type, where the label name should match the column’s name by default. This restores a not-well defined behavior that had changed in version 1.4.21 due to [#6718](https://www.sqlalchemy.org/trac/ticket/6718), [#6710](https://www.sqlalchemy.org/trac/ticket/6710). The Oracle dialect has a different RETURNING implementation and was not affected by this issue. Version 2.0 features an across the board change for its widely expanded support of RETURNING on other backends.

    References: [#8770](https://www.sqlalchemy.org/trac/ticket/8770)

oracle

    [oracle] [bug]

    Fixed issue in the Oracle dialect where an INSERT statement that used insert(some_table).values(...).returning(some_table) against a full [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table) object at once would fail to execute, raising an exception.

tests

    [tests] [bug]

    Fixed issue where the --disable-asyncio parameter to the test suite would fail to not actually run greenlet tests and would also not prevent the suite from using a “wrapping” greenlet for the whole suite. This parameter now ensures that no greenlet or asyncio use will occur within the entire run when set.

    References: [#8793](https://www.sqlalchemy.org/trac/ticket/8793)

    [tests] [bug]

    Adjusted the test suite which tests the Mypy plugin to accommodate for changes in Mypy 0.990 regarding how it handles message output, which affect how sys.path is interpreted when determining if notes and errors should be printed for particular files. The change broke the test suite as the files within the test directory itself no longer produced messaging when run under the mypy API.

1.4.43
Released: November 4, 2022
orm

    [orm] [bug]

    Fixed issue in joined eager loading where an assertion fail would occur with a particular combination of outer/inner joined eager loads, when eager loading across three mappers where the middle mapper was an inherited subclass mapper.

    References: [#8738](https://www.sqlalchemy.org/trac/ticket/8738)

    [orm] [bug]

    Fixed bug involving [Select](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select) constructs, where combinations of [Select.select_from()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.select_from) with [Select.join()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.join), as well as when using [Select.join_from()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.join_from), would cause the [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) feature as well as the IN criteria needed for single-table inheritance queries to not render, in cases where the columns clause of the query did not explicitly include the left-hand side entity of the JOIN. The correct entity is now transferred to the [Join](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Join) object that’s generated internally, so that the criteria against the left side entity is correctly added.

    References: [#8721](https://www.sqlalchemy.org/trac/ticket/8721)

    [orm] [bug]

    An informative exception is now raised when the [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) option is used as a loader option added to a specific “loader path”, such as when using it within [Load.options()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.Load.options). This use is not supported as [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) is only intended to be used as a top level loader option. Previously, an internal error would be generated.

    References: [#8711](https://www.sqlalchemy.org/trac/ticket/8711)

    [orm] [bug]

    Improved “dictionary mode” for [Session.get()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.get) so that synonym names which refer to primary key attribute names may be indicated in the named dictionary.

    References: [#8753](https://www.sqlalchemy.org/trac/ticket/8753)

    [orm] [bug]

    Fixed issue where “selectin_polymorphic” loading for inheritance mappers would not function correctly if the [Mapper.polymorphic_on](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.Mapper.params.polymorphic_on) parameter referred to a SQL expression that was not directly mapped on the class.

    References: [#8704](https://www.sqlalchemy.org/trac/ticket/8704)

    [orm] [bug]

    Fixed issue where the underlying DBAPI cursor would not be closed when using the [Query](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query) object as an iterator, if a user-defined exception case were raised within the iteration process, thereby causing the iterator to be closed by the Python interpreter. When using [Query.yield_per()](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.yield_per) to create server-side cursors, this would lead to the usual MySQL-related issues with server side cursors out of sync, and without direct access to the [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) object, end-user code could not access the cursor in order to close it.

    To resolve, a catch for GeneratorExit is applied within the iterator method, which will close the result object in those cases when the iterator were interrupted, and by definition will be closed by the Python interpreter.

    As part of this change as implemented for the 1.4 series, ensured that .close() methods are available on all [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) implementations including [ScalarResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.ScalarResult), [MappingResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.MappingResult). The 2.0 version of this change also includes new context manager patterns for use with [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) classes.

    References: [#8710](https://www.sqlalchemy.org/trac/ticket/8710)

engine

    [engine] [bug] [regression]

    Fixed issue where the [PoolEvents.reset()](https://docs.sqlalchemy.org/en/20/core/events.html#sqlalchemy.events.PoolEvents.reset) event hook would not be be called in all cases when a [Connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) were closed and was in the process of returning its DBAPI connection to the connection pool.

    The scenario was when the [Connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) had already emitted .rollback() on its DBAPI connection within the process of returning the connection to the pool, where it would then instruct the connection pool to forego doing its own “reset” to save on the additional method call. However, this prevented custom pool reset schemes from being used within this hook, as such hooks by definition are doing more than just calling .rollback(), and need to be invoked under all circumstances. This was a regression that appeared in version 1.4.

    For version 1.4, the [PoolEvents.checkin()](https://docs.sqlalchemy.org/en/20/core/events.html#sqlalchemy.events.PoolEvents.checkin) remains viable as an alternate event hook to use for custom “reset” implementations. Version 2.0 will feature an improved version of [PoolEvents.reset()](https://docs.sqlalchemy.org/en/20/core/events.html#sqlalchemy.events.PoolEvents.reset) which is called for additional scenarios such as termination of asyncio connections, and is also passed contextual information about the reset, to allow for “custom connection reset” schemes which can respond to different reset scenarios in different ways.

    References: [#8717](https://www.sqlalchemy.org/trac/ticket/8717)

    [engine] [bug]

    Ensured all [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) objects include a [Result.close()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.close) method as well as a [Result.closed](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.closed) attribute, including on [ScalarResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.ScalarResult) and [MappingResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.MappingResult).

    References: [#8710](https://www.sqlalchemy.org/trac/ticket/8710)

sql

    [sql] [bug]

    Fixed issue which prevented the [literal_column()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.literal_column) construct from working properly within the context of a [Select](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select) construct as well as other potential places where “anonymized labels” might be generated, if the literal expression contained characters which could interfere with format strings, such as open parenthesis, due to an implementation detail of the “anonymous label” structure.

    References: [#8724](https://www.sqlalchemy.org/trac/ticket/8724)

mssql

    [mssql] [bug]

    Fixed issue with [Inspector.has_table()](https://docs.sqlalchemy.org/en/20/core/reflection.html#sqlalchemy.engine.reflection.Inspector.has_table), which when used against a temporary table with the SQL Server dialect would fail on some Azure variants, due to an unnecessary information schema query that is not supported on those server versions. Pull request courtesy Mike Barry.

    References: [#8714](https://www.sqlalchemy.org/trac/ticket/8714)

    [mssql] [bug] [reflection]

    Fixed issue with [Inspector.has_table()](https://docs.sqlalchemy.org/en/20/core/reflection.html#sqlalchemy.engine.reflection.Inspector.has_table), which when used against a view with the SQL Server dialect would erroneously return False, due to a regression in the 1.4 series which removed support for this on SQL Server. The issue is not present in the 2.0 series which uses a different reflection architecture. Test support is added to ensure has_table() remains working per spec re: views.

    References: [#8700](https://www.sqlalchemy.org/trac/ticket/8700)

oracle

    [oracle] [bug]

    Fixed issue where bound parameter names, including those automatically derived from similarly-named database columns, which contained characters that normally require quoting with Oracle would not be escaped when using “expanding parameters” with the Oracle dialect, causing execution errors. The usual “quoting” for bound parameters used by the Oracle dialect is not used with the “expanding parameters” architecture, so escaping for a large range of characters is used instead, now using a list of characters/escapes that are specific to Oracle.

    References: [#8708](https://www.sqlalchemy.org/trac/ticket/8708)

    [oracle] [bug]

    Fixed issue where the nls_session_parameters view queried on first connect in order to get the default decimal point character may not be available depending on Oracle connection modes, and would therefore raise an error. The approach to detecting decimal char has been simplified to test a decimal value directly, instead of reading system views, which works on any backend / driver.

    References: [#8744](https://www.sqlalchemy.org/trac/ticket/8744)

1.4.42
Released: October 16, 2022
orm

    [orm] [bug]

    The [Session.execute.bind_arguments](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.execute.params.bind_arguments) dictionary is no longer mutated when passed to [Session.execute()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.execute) and similar; instead, it’s copied to an internal dictionary for state changes. Among other things, this fixes and issue where the “clause” passed to the [Session.get_bind()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.get_bind) method would be incorrectly referring to the [Select](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select) construct used for the “fetch” synchronization strategy, when the actual query being emitted was a [Delete](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Delete) or [Update](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Update). This would interfere with recipes for “routing sessions”.

    References: [#8614](https://www.sqlalchemy.org/trac/ticket/8614)

    [orm] [bug]

    A warning is emitted in ORM configurations when an explicit [remote()](https://docs.sqlalchemy.org/en/20/orm/relationship_api.html#sqlalchemy.orm.remote) annotation is applied to columns that are local to the immediate mapped class, when the referenced class does not include any of the same table columns. Ideally this would raise an error at some point as it’s not correct from a mapping point of view.

    References: [#7094](https://www.sqlalchemy.org/trac/ticket/7094)

    [orm] [bug]

    A warning is emitted when attempting to configure a mapped class within an inheritance hierarchy where the mapper is not given any polymorphic identity, however there is a polymorphic discriminator column assigned. Such classes should be abstract if they never intend to load directly.

    References: [#7545](https://www.sqlalchemy.org/trac/ticket/7545)

    [orm] [bug] [regression]

    Fixed regression for 1.4 in [contains_eager()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.contains_eager) where the “wrap in subquery” logic of [joinedload()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.joinedload) would be inadvertently triggered for use of the [contains_eager()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.contains_eager) function with similar statements (e.g. those that use distinct(), limit() or offset()), which would then lead to secondary issues with queries that used some combinations of SQL label names and aliasing. This “wrapping” is not appropriate for [contains_eager()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.contains_eager) which has always had the contract that the user-defined SQL statement is unmodified with the exception of adding the appropriate columns to be fetched.

    References: [#8569](https://www.sqlalchemy.org/trac/ticket/8569)

    [orm] [bug] [regression]

    Fixed regression where using ORM update() with synchronize_session=’fetch’ would fail due to the use of evaluators that are now used to determine the in-Python value for expressions in the SET clause when refreshing objects; if the evaluators make use of math operators against non-numeric values such as PostgreSQL JSONB, the non-evaluable condition would fail to be detected correctly. The evaluator now limits the use of math mutation operators to numeric types only, with the exception of “+” that continues to work for strings as well. SQLAlchemy 2.0 may alter this further by fetching the SET values completely rather than using evaluation.

    References: [#8507](https://www.sqlalchemy.org/trac/ticket/8507)

engine

    [engine] [bug]

    Fixed issue where mixing “*” with additional explicitly-named column expressions within the columns clause of a [select()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.select) construct would cause result-column targeting to sometimes consider the label name or other non-repeated names to be an ambiguous target.

    References: [#8536](https://www.sqlalchemy.org/trac/ticket/8536)

asyncio

    [asyncio] [bug]

    Improved implementation of asyncio.shield() used in context managers as added in [#8145](https://www.sqlalchemy.org/trac/ticket/8145), such that the “close” operation is enclosed within an asyncio.Task which is then strongly referenced as the operation proceeds. This is per Python documentation indicating that the task is otherwise not strongly referenced.

    References: [#8516](https://www.sqlalchemy.org/trac/ticket/8516)

postgresql

    [postgresql] [usecase]

    [aggregate_order_by](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.aggregate_order_by) now supports cache generation.

    References: [#8574](https://www.sqlalchemy.org/trac/ticket/8574)

mysql

    [mysql] [bug]

    Adjusted the regular expression used to match “CREATE VIEW” when testing for views to work more flexibly, no longer requiring the special keyword “ALGORITHM” in the middle, which was intended to be optional but was not working correctly. The change allows view reflection to work more completely on MySQL-compatible variants such as StarRocks. Pull request courtesy John Bodley.

    References: [#8588](https://www.sqlalchemy.org/trac/ticket/8588)

mssql

    [mssql] [bug] [regression]

    Fixed yet another regression in SQL Server isolation level fetch (see [#8231](https://www.sqlalchemy.org/trac/ticket/8231), [#8475](https://www.sqlalchemy.org/trac/ticket/8475)), this time with “Microsoft Dynamics CRM Database via Azure Active Directory”, which apparently lacks the system_views view entirely. Error catching has been extended that under no circumstances will this method ever fail, provided database connectivity is present.

    References: [#8525](https://www.sqlalchemy.org/trac/ticket/8525)

1.4.41
Released: September 6, 2022
orm

    [orm] [bug] [events]

    Fixed event listening issue where event listeners added to a superclass would be lost if a subclass were created which then had its own listeners associated. The practical example is that of the [sessionmaker](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.sessionmaker) class created after events have been associated with the [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session) class.

    References: [#8467](https://www.sqlalchemy.org/trac/ticket/8467)

    [orm] [bug]

    Hardened the cache key strategy for the [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) and [with_polymorphic()](https://docs.sqlalchemy.org/en/20/orm/queryguide/inheritance.html#sqlalchemy.orm.with_polymorphic) constructs. While no issue involving actual statements being cached can easily be demonstrated (if at all), these two constructs were not including enough of what makes them unique in their cache keys for caching on the aliased construct alone to be accurate.

    References: [#8401](https://www.sqlalchemy.org/trac/ticket/8401)

    [orm] [bug] [regression]

    Fixed regression appearing in the 1.4 series where a joined-inheritance query placed as a subquery within an enclosing query for that same entity would fail to render the JOIN correctly for the inner query. The issue manifested in two different ways prior and subsequent to version 1.4.18 (related issue [#6595](https://www.sqlalchemy.org/trac/ticket/6595)), in one case rendering JOIN twice, in the other losing the JOIN entirely. To resolve, the conditions under which “polymorphic loading” are applied have been scaled back to not be invoked for simple joined inheritance queries.

    References: [#8456](https://www.sqlalchemy.org/trac/ticket/8456)

    [orm] [bug]

    Fixed issue in [sqlalchemy.ext.mutable](https://docs.sqlalchemy.org/en/20/orm/extensions/mutable.html#module-sqlalchemy.ext.mutable) extension where collection links to the parent object would be lost if the object were merged with [Session.merge()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge) while also passing [Session.merge.load](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.merge.params.load) as False.

    References: [#8446](https://www.sqlalchemy.org/trac/ticket/8446)

    [orm] [bug]

    Fixed issue involving [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) where a closure variable used as bound parameter value within the lambda would not carry forward correctly into additional relationship loaders such as [selectinload()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.selectinload) and [lazyload()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.lazyload) after the statement were cached, using the stale originally-cached value instead.

    References: [#8399](https://www.sqlalchemy.org/trac/ticket/8399)

sql

    [sql] [bug]

    Fixed issue where use of the [table()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.table) construct, passing a string for the [table.schema](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.table.params.schema) parameter, would fail to take the “schema” string into account when producing a cache key, thus leading to caching collisions if multiple, same-named [table()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.table) constructs with different schemas were used.

    References: [#8441](https://www.sqlalchemy.org/trac/ticket/8441)

asyncio

    [asyncio] [bug]

    Integrated support for asyncpg’s terminate() method call for cases where the connection pool is recycling a possibly timed-out connection, where a connection is being garbage collected that wasn’t gracefully closed, as well as when the connection has been invalidated. This allows asyncpg to abandon the connection without waiting for a response that may incur long timeouts.

    References: [#8419](https://www.sqlalchemy.org/trac/ticket/8419)

mssql

    [mssql] [bug] [regression]

    Fixed regression caused by the fix for [#8231](https://www.sqlalchemy.org/trac/ticket/8231) released in 1.4.40 where connection would fail if the user did not have permission to query the dm_exec_sessions or dm_pdw_nodes_exec_sessions system views when trying to determine the current transaction isolation level.

    References: [#8475](https://www.sqlalchemy.org/trac/ticket/8475)

1.4.40
Released: August 8, 2022
orm

    [orm] [bug]

    Fixed issue where referencing a CTE multiple times in conjunction with a polymorphic SELECT could result in multiple “clones” of the same CTE being constructed, which would then trigger these two CTEs as duplicates. To resolve, the two CTEs are deep-compared when this occurs to ensure that they are equivalent, then are treated as equivalent.

    References: [#8357](https://www.sqlalchemy.org/trac/ticket/8357)

    [orm] [bug]

    A [select()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.select) construct that is passed a sole ‘*’ argument for SELECT *, either via string, [text()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.text), or [literal_column()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.literal_column), will be interpreted as a Core-level SQL statement rather than as an ORM level statement. This is so that the *, when expanded to match any number of columns, will result in all columns returned in the result. the ORM- level interpretation of [select()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.select) needs to know the names and types of all ORM columns up front which can’t be achieved when '*' is used.

    If '* is used amongst other expressions simultaneously with an ORM statement, an error is raised as this can’t be interpreted correctly by the ORM.

    References: [#8235](https://www.sqlalchemy.org/trac/ticket/8235)

orm declarative

    [orm] [declarative] [bug]

    Fixed issue where a hierarchy of classes set up as an abstract or mixin declarative classes could not declare standalone columns on a superclass that would then be copied correctly to a [declared_attr](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.declared_attr) callable that wanted to make use of them on a descendant class.

    References: [#8190](https://www.sqlalchemy.org/trac/ticket/8190)

engine

    [engine] [usecase]

    Implemented new [Connection.execution_options.yield_per](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.yield_per) execution option for [Connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) in Core, to mirror that of the same [yield_per](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#orm-queryguide-yield-per) option available in the ORM. The option sets both the [Connection.execution_options.stream_results](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.stream_results) option at the same time as invoking [Result.yield_per()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.yield_per), to provide the most common streaming result configuration which also mirrors that of the ORM use case in its usage pattern.

    See also

    [Using Server Side Cursors (a.k.a. stream results)](https://docs.sqlalchemy.org/en/20/core/connections.html#engine-stream-results) - revised documentation

    [engine] [bug]

    Fixed bug in [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) where the usage of a buffered result strategy would not be used if the dialect in use did not support an explicit “server side cursor” setting, when using [Connection.execution_options.stream_results](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.stream_results). This is in error as DBAPIs such as that of SQLite and Oracle already use a non-buffered result fetching scheme, which still benefits from usage of partial result fetching. The “buffered” strategy is now used in all cases where [Connection.execution_options.stream_results](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.stream_results) is set.

    [engine] [bug]

    Added [FilterResult.yield_per()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.FilterResult.yield_per) so that result implementations such as [MappingResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.MappingResult), [ScalarResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.ScalarResult) and [AsyncResult](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncResult) have access to this method.

    References: [#8199](https://www.sqlalchemy.org/trac/ticket/8199)

sql

    [sql] [bug]

    Adjusted the SQL compilation for string containment functions .contains(), .startswith(), .endswith() to force the use of the string concatenation operator, rather than relying upon the overload of the addition operator, so that non-standard use of these operators with for example bytestrings still produces string concatenation operators.

    References: [#8253](https://www.sqlalchemy.org/trac/ticket/8253)

mypy

    [mypy] [bug]

    Fixed a crash of the mypy plugin when using a lambda as a Column default. Pull request courtesy of tchapi.

    References: [#8196](https://www.sqlalchemy.org/trac/ticket/8196)

asyncio

    [asyncio] [bug]

    Added asyncio.shield() to the connection and session release process specifically within the __aexit__() context manager exit, when using [AsyncConnection](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncConnection) or [AsyncSession](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncSession) as a context manager that releases the object when the context manager is complete. This appears to help with task cancellation when using alternate concurrency libraries such as anyio, uvloop that otherwise don’t provide an async context for the connection pool to release the connection properly during task cancellation.

    References: [#8145](https://www.sqlalchemy.org/trac/ticket/8145)

postgresql

    [postgresql] [bug]

    Fixed issue in psycopg2 dialect where the “multiple hosts” feature implemented for [#4392](https://www.sqlalchemy.org/trac/ticket/4392), where multiple host:port pairs could be passed in the query string as ?host=host1:port1&host=host2:port2&host=host3:port3 was not implemented correctly, as it did not propagate the “port” parameter appropriately. Connections that didn’t use a different “port” likely worked without issue, and connections that had “port” for some of the entries may have incorrectly passed on that hostname. The format is now corrected to pass hosts/ports appropriately.

    As part of this change, maintained support for another multihost style that worked unintentionally, which is comma-separated ?host=h1,h2,h3&port=p1,p2,p3. This format is more consistent with libpq’s query-string format, whereas the previous format is inspired by a different aspect of libpq’s URI format but is not quite the same thing.

    If the two styles are mixed together, an error is raised as this is ambiguous.

    References: [#4392](https://www.sqlalchemy.org/trac/ticket/4392)

mssql

    [mssql] [bug]

    Fixed issues that prevented the new usage patterns for using DML with ORM objects presented at [Using INSERT, UPDATE and ON CONFLICT (i.e. upsert) to return ORM Objects](https://docs.sqlalchemy.org/en/20/orm/persistence_techniques.html#orm-dml-returning-objects) from working correctly with the SQL Server pyodbc dialect.

    References: [#8210](https://www.sqlalchemy.org/trac/ticket/8210)

    [mssql] [bug]

    Fixed issue where the SQL Server dialect’s query for the current isolation level would fail on Azure Synapse Analytics, due to the way in which this database handles transaction rollbacks after an error has occurred. The initial query has been modified to no longer rely upon catching an error when attempting to detect the appropriate system view. Additionally, to better support this database’s very specific “rollback” behavior, implemented new parameter ignore_no_transaction_on_rollback indicating that a rollback should ignore Azure Synapse error ‘No corresponding transaction found. (111214)’, which is raised if no transaction is present in conflict with the Python DBAPI.

    Initial patch and valuable debugging assistance courtesy of @ww2406.

    See also

    [Avoiding transaction-related exceptions on Azure Synapse Analytics](https://docs.sqlalchemy.org/en/20/dialects/mssql.html#azure-synapse-ignore-no-transaction-on-rollback)

    References: [#8231](https://www.sqlalchemy.org/trac/ticket/8231)

misc

    [bug] [types]

    Fixed issue where [TypeDecorator](https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.TypeDecorator) would not correctly proxy the __getitem__() operator when decorating the [ARRAY](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY) datatype, without explicit workarounds.

    References: [#7249](https://www.sqlalchemy.org/trac/ticket/7249)

1.4.39
Released: June 24, 2022
orm

    [orm] [bug] [regression]

    Fixed regression caused by [#8133](https://www.sqlalchemy.org/trac/ticket/8133) where the pickle format for mutable attributes was changed, without a fallback to recognize the old format, causing in-place upgrades of SQLAlchemy to no longer be able to read pickled data from previous versions. A check plus a fallback for the old format is now in place.

    References: [#8133](https://www.sqlalchemy.org/trac/ticket/8133)

1.4.38
Released: June 23, 2022
orm

    [orm] [bug] [regression]

    Fixed regression caused by [#8064](https://www.sqlalchemy.org/trac/ticket/8064) where a particular check for column correspondence was made too liberal, resulting in incorrect rendering for some ORM subqueries such as those using [PropComparator.has()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.has) or [PropComparator.any()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.any) in conjunction with joined-inheritance queries that also use legacy aliasing features.

    References: [#8162](https://www.sqlalchemy.org/trac/ticket/8162)

    [orm] [bug] [sql]

    Fixed an issue where [GenerativeSelect.fetch()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.GenerativeSelect.fetch) would not be applied when executing a statement using the ORM.

    References: [#8091](https://www.sqlalchemy.org/trac/ticket/8091)

    [orm] [bug]

    Fixed issue where a [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) option could not be pickled, as is necessary when it is carried along for propagation to lazy loaders in conjunction with a caching scheme. Currently, the only form that is supported as picklable is to pass the “where criteria” as a fixed module-level callable function that produces a SQL expression. An ad-hoc “lambda” can’t be pickled, and a SQL expression object is usually not fully picklable directly.

    References: [#8109](https://www.sqlalchemy.org/trac/ticket/8109)

engine

    [engine] [bug]

    Repaired a deprecation warning class decorator that was preventing key objects such as [Connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) from having a proper __weakref__ attribute, causing operations like Python standard library inspect.getmembers() to fail.

    References: [#8115](https://www.sqlalchemy.org/trac/ticket/8115)

sql

    [sql] [bug]

    Fixed multiple observed race conditions related to [lambda_stmt()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.lambda_stmt), including an initial “dogpile” issue when a new Python code object is initially analyzed among multiple simultaneous threads which created both a performance issue as well as some internal corruption of state. Additionally repaired observed race condition which could occur when “cloning” an expression construct that is also in the process of being compiled or otherwise accessed in a different thread due to memoized attributes altering the __dict__ while iterated, for Python versions prior to 3.10; in particular the lambda SQL construct is sensitive to this as it holds onto a single statement object persistently. The iteration has been refined to use dict.copy() with or without an additional iteration instead.

    References: [#8098](https://www.sqlalchemy.org/trac/ticket/8098)

    [sql] [bug]

    Enhanced the mechanism of [Cast](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.Cast) and other “wrapping” column constructs to more fully preserve a wrapped [Label](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.Label) construct, including that the label name will be preserved in the .c collection of a [Subquery](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Subquery). The label was already able to render in the SQL correctly on the outside of the construct which it was wrapped inside.

    References: [#8084](https://www.sqlalchemy.org/trac/ticket/8084)

    [sql] [bug]

    Adjusted the fix made for [#8056](https://www.sqlalchemy.org/trac/ticket/8056) which adjusted the escaping of bound parameter names with special characters such that the escaped names were translated after the SQL compilation step, which broke a published recipe on the FAQ illustrating how to merge parameter names into the string output of a compiled SQL string. The change restores the escaped names that come from compiled.params and adds a conditional parameter to [SQLCompiler.construct_params()](https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.sql.compiler.SQLCompiler.construct_params) named escape_names that defaults to True, restoring the old behavior by default.

    References: [#8113](https://www.sqlalchemy.org/trac/ticket/8113)

schema

    [schema] [bug]

    Fixed bugs involving the [Table.include_columns](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.params.include_columns) and the [Table.resolve_fks](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.params.resolve_fks) parameters on [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table); these little-used parameters were apparently not working for columns that refer to foreign key constraints.

    In the first case, not-included columns that refer to foreign keys would still attempt to create a [ForeignKey](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey) object, producing errors when attempting to resolve the columns for the foreign key constraint within reflection; foreign key constraints that refer to skipped columns are now omitted from the table reflection process in the same way as occurs for [Index](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.Index) and [UniqueConstraint](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.UniqueConstraint) objects with the same conditions. No warning is produced however, as we likely want to remove the include_columns warnings for all constraints in 2.0.

    In the latter case, the production of table aliases or subqueries would fail on an FK related table not found despite the presence of resolve_fks=False; the logic has been repaired so that if a related table is not found, the [ForeignKey](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey) object is still proxied to the aliased table or subquery (these [ForeignKey](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey) objects are normally used in the production of join conditions), but it is sent with a flag that it’s not resolvable. The aliased table / subquery will then work normally, with the exception that it cannot be used to generate a join condition automatically, as the foreign key information is missing. This was already the behavior for such foreign key constraints produced using non-reflection methods, such as joining [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table) objects from different [MetaData](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.MetaData) collections.

    References: [#8100](https://www.sqlalchemy.org/trac/ticket/8100), [#8101](https://www.sqlalchemy.org/trac/ticket/8101)

    [schema] [bug] [mssql]

    Fixed issue where [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table) objects that made use of IDENTITY columns with a [Numeric](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Numeric) datatype would produce errors when attempting to reconcile the “autoincrement” column, preventing construction of the [Column](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column) from using the [Column.autoincrement](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column.params.autoincrement) parameter as well as emitting errors when attempting to invoke an [Insert](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Insert) construct.

    References: [#8111](https://www.sqlalchemy.org/trac/ticket/8111)

extensions

    [extensions] [bug]

    Fixed bug in [Mutable](https://docs.sqlalchemy.org/en/20/orm/extensions/mutable.html#sqlalchemy.ext.mutable.Mutable) where pickling and unpickling of an ORM mapped instance would not correctly restore state for mappings that contained multiple [Mutable](https://docs.sqlalchemy.org/en/20/orm/extensions/mutable.html#sqlalchemy.ext.mutable.Mutable)-enabled attributes.

    References: [#8133](https://www.sqlalchemy.org/trac/ticket/8133)

1.4.37
Released: May 31, 2022
orm

    [orm] [bug]

    Fixed issue where using a [column_property()](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.column_property) construct containing a subquery against an already-mapped column attribute would not correctly apply ORM-compilation behaviors to the subquery, including that the “IN” expression added for a single-table inherits expression would fail to be included.

    References: [#8064](https://www.sqlalchemy.org/trac/ticket/8064)

    [orm] [bug]

    Fixed issue where ORM results would apply incorrect key names to the returned [Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row) objects in the case where the set of columns to be selected were changed, such as when using [Select.with_only_columns()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.with_only_columns).

    References: [#8001](https://www.sqlalchemy.org/trac/ticket/8001)

    [orm] [bug] [oracle] [postgresql]

    Fixed bug, likely a regression from 1.3, where usage of column names that require bound parameter escaping, more concretely when using Oracle with column names that require quoting such as those that start with an underscore, or in less common cases with some PostgreSQL drivers when using column names that contain percent signs, would cause the ORM versioning feature to not work correctly if the versioning column itself had such a name, as the ORM assumes certain bound parameter naming conventions that were being interfered with via the quotes. This issue is related to [#8053](https://www.sqlalchemy.org/trac/ticket/8053) and essentially revises the approach towards fixing this, revising the original issue [#5653](https://www.sqlalchemy.org/trac/ticket/5653) that created the initial implementation for generalized bound-parameter name quoting.

    References: [#8056](https://www.sqlalchemy.org/trac/ticket/8056)

engine

    [engine] [bug] [tests]

    Fixed issue where support for logging “stacklevel” implemented in [#7612](https://www.sqlalchemy.org/trac/ticket/7612) required adjustment to work with recently released Python 3.11.0b1, also repairs the unit tests which tested this feature.

    References: [#8019](https://www.sqlalchemy.org/trac/ticket/8019)

sql

    [sql] [bug] [postgresql] [sqlite]

    Fixed bug where the PostgreSQL [Insert.on_conflict_do_update()](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.Insert.on_conflict_do_update) method and the SQLite [Insert.on_conflict_do_update()](https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#sqlalchemy.dialects.sqlite.Insert.on_conflict_do_update) method would both fail to correctly accommodate a column with a separate “.key” when specifying the column using its key name in the dictionary passed to [Insert.on_conflict_do_update.set_](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.Insert.on_conflict_do_update.params.set_), as well as if the [Insert.excluded](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.Insert.excluded) collection were used as the dictionary directly.

    References: [#8014](https://www.sqlalchemy.org/trac/ticket/8014)

    [sql] [bug]

    An informative error is raised for the use case where [Insert.from_select()](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Insert.from_select) is being passed a “compound select” object such as a UNION, yet the INSERT statement needs to append additional columns to support Python-side or explicit SQL defaults from the table metadata. In this case a subquery of the compound object should be passed.

    References: [#8073](https://www.sqlalchemy.org/trac/ticket/8073)

    [sql] [bug]

    Fixed an issue where using [bindparam()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.bindparam) with no explicit data or type given could be coerced into the incorrect type when used in expressions such as when using [Comparator.any()](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY.Comparator.any) and [Comparator.all()](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY.Comparator.all).

    References: [#7979](https://www.sqlalchemy.org/trac/ticket/7979)

    [sql] [bug]

    An informative error is raised if two individual [BindParameter](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.BindParameter) objects share the same name, yet one is used within an “expanding” context (typically an IN expression) and the other is not; mixing the same name in these two different styles of usage is not supported and typically the expanding=True parameter should be set on the parameters that are to receive list values outside of IN expressions (where expanding is set by default).

    References: [#8018](https://www.sqlalchemy.org/trac/ticket/8018)

mysql

    [mysql] [bug]

    Further adjustments to the MySQL PyODBC dialect to allow for complete connectivity, which was previously still not working despite fixes in [#7871](https://www.sqlalchemy.org/trac/ticket/7871).

    References: [#7966](https://www.sqlalchemy.org/trac/ticket/7966)

    [mysql] [bug]

    Added disconnect code for MySQL error 4031, introduced in MySQL >= 8.0.24, indicating connection idle timeout exceeded. In particular this repairs an issue where pre-ping could not reconnect on a timed-out connection. Pull request courtesy valievkarim.

    References: [#8036](https://www.sqlalchemy.org/trac/ticket/8036)

mssql

    [mssql] [bug]

    Fix issue where a password with a leading “{” would result in login failure.

    References: [#8062](https://www.sqlalchemy.org/trac/ticket/8062)

    [mssql] [bug] [reflection]

    Explicitly specify the collation when reflecting table columns using MSSQL to prevent “collation conflict” errors.

    References: [#8035](https://www.sqlalchemy.org/trac/ticket/8035)

oracle

    [oracle] [usecase]

    Added two new error codes for Oracle disconnect handling to support early testing of the new “python-oracledb” driver released by Oracle.

    References: [#8066](https://www.sqlalchemy.org/trac/ticket/8066)

    [oracle] [bug]

    Fixed SQL compiler issue where the “bind processing” function for a bound parameter would not be correctly applied to a bound value if the bound parameter’s name were “escaped”. Concretely, this applies, among other cases, to Oracle when a [Column](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Column) has a name that itself requires quoting, such that the quoting-required name is then used for the bound parameters generated within DML statements, and the datatype in use requires bind processing, such as the [Enum](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum) datatype.

    References: [#8053](https://www.sqlalchemy.org/trac/ticket/8053)

1.4.36
Released: April 26, 2022
orm

    [orm] [bug] [regression]

    Fixed regression where the change made for [#7861](https://www.sqlalchemy.org/trac/ticket/7861), released in version 1.4.33, that brought the [Insert](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Insert) construct to be partially recognized as an ORM-enabled statement did not properly transfer the correct mapper / mapped table state to the [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session), causing the [Session.get_bind()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.get_bind) method to fail for a [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session) that was bound to engines and/or connections using the [Session.binds](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.params.binds) parameter.

    References: [#7936](https://www.sqlalchemy.org/trac/ticket/7936)

orm declarative

    [orm] [declarative] [bug]

    Modified the DeclarativeMeta metaclass to pass cls.__dict__ into the declarative scanning process to look for attributes, rather than the separate dictionary passed to the type’s __init__() method. This allows user-defined base classes that add attributes within an __init_subclass__() to work as expected, as __init_subclass__() can only affect the cls.__dict__ itself and not the other dictionary. This is technically a regression from 1.3 where __dict__ was being used.

    References: [#7900](https://www.sqlalchemy.org/trac/ticket/7900)

engine

    [engine] [bug]

    Fixed a memory leak in the C extensions which could occur when calling upon named members of [Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row) when the member does not exist under Python 3; in particular this could occur during NumPy transformations when it attempts to call members such as .__array__, but the issue was surrounding any AttributeError thrown by the [Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row) object. This issue does not apply to version 2.0 which has already transitioned to Cython. Thanks much to Sebastian Berg for identifying the problem.

    References: [#7875](https://www.sqlalchemy.org/trac/ticket/7875)

    [engine] [bug]

    Added a warning regarding a bug which exists in the [Result.columns()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.columns) method when passing 0 for the index in conjunction with a [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) that will return a single ORM entity, which indicates that the current behavior of [Result.columns()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.columns) is broken in this case as the [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) object will yield scalar values and not [Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row) objects. The issue will be fixed in 2.0, which would be a backwards-incompatible change for code that relies on the current broken behavior. Code which wants to receive a collection of scalar values should use the [Result.scalars()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.scalars) method, which will return a new [ScalarResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.ScalarResult) object that yields non-row scalar objects.

    References: [#7953](https://www.sqlalchemy.org/trac/ticket/7953)

schema

    [schema] [bug]

    Fixed bug where [ForeignKeyConstraint](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKeyConstraint) naming conventions using the referred_column_0 naming convention key would not work if the foreign key constraint were set up as a [ForeignKey](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey) object rather than an explicit [ForeignKeyConstraint](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKeyConstraint) object. As this change makes use of a backport of some fixes from version 2.0, an additional little-known feature that has likely been broken for many years is also fixed which is that a [ForeignKey](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey) object may refer to a referred table by name of the table alone without using a column name, if the name of the referent column is the same as that of the referred column.

    The referred_column_0 naming convention key was previously not tested with the [ForeignKey](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey) object, only [ForeignKeyConstraint](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKeyConstraint), and this bug reveals that the feature has never worked correctly unless [ForeignKeyConstraint](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKeyConstraint) is used for all FK constraints. This bug traces back to the original introduction of the feature introduced for [#3989](https://www.sqlalchemy.org/trac/ticket/3989).

    References: [#7958](https://www.sqlalchemy.org/trac/ticket/7958)

asyncio

    [asyncio] [bug]

    Repaired handling of contextvar.ContextVar objects inside of async adapted event handlers. Previously, values applied to a ContextVar would not be propagated in the specific case of calling upon awaitables inside of non-awaitable code.

    References: [#7937](https://www.sqlalchemy.org/trac/ticket/7937)

postgresql

    [postgresql] [bug]

    Fixed bug in [ARRAY](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.ARRAY) datatype in combination with [Enum](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum) on PostgreSQL where using the .any() or .all() methods to render SQL ANY() or ALL(), given members of the Python enumeration as arguments, would produce a type adaptation failure on all drivers.

    References: [#6515](https://www.sqlalchemy.org/trac/ticket/6515)

    [postgresql] [bug]

    Implemented UUID.python_type attribute for the PostgreSQL UUID type object. The attribute will return either str or uuid.UUID based on the UUID.as_uuid parameter setting. Previously, this attribute was unimplemented. Pull request courtesy Alex Grönholm.

    References: [#7943](https://www.sqlalchemy.org/trac/ticket/7943)

    [postgresql] [bug]

    Fixed an issue in the psycopg2 dialect when using the [create_engine.pool_pre_ping](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.pool_pre_ping) parameter which would cause user-configured AUTOCOMMIT isolation level to be inadvertently reset by the “ping” handler.

    References: [#7930](https://www.sqlalchemy.org/trac/ticket/7930)

mysql

    [mysql] [bug] [regression]

    Fixed a regression in the untested MySQL PyODBC dialect caused by the fix for [#7518](https://www.sqlalchemy.org/trac/ticket/7518) in version 1.4.32 where an argument was being propagated incorrectly upon first connect, leading to a TypeError.

    References: [#7871](https://www.sqlalchemy.org/trac/ticket/7871)

tests

    [tests] [bug]

    For third party dialects, repaired a missing requirement for the SimpleUpdateDeleteTest suite test which was not checking for a working “rowcount” function on the target dialect.

    References: [#7919](https://www.sqlalchemy.org/trac/ticket/7919)

1.4.35
Released: April 6, 2022
sql

    [sql] [bug]

    Fixed bug in newly implemented [FunctionElement.table_valued.joins_implicitly](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.table_valued.params.joins_implicitly) feature where the parameter would not automatically propagate from the original [TableValuedAlias](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TableValuedAlias) object to the secondary object produced when calling upon [TableValuedAlias.render_derived()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TableValuedAlias.render_derived) or [TableValuedAlias.alias()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TableValuedAlias.alias).

    Additionally repaired these issues in [TableValuedAlias](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TableValuedAlias):

        repaired a potential memory issue which could occur when repeatedly calling [TableValuedAlias.render_derived()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TableValuedAlias.render_derived) against successive copies of the same object (for .alias(), we currently have to still continue chaining from the previous element. not sure if this can be improved but this is standard behavior for .alias() elsewhere)

        repaired issue where the individual element types would be lost when calling upon [TableValuedAlias.render_derived()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TableValuedAlias.render_derived) or [TableValuedAlias.alias()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TableValuedAlias.alias).

    References: [#7890](https://www.sqlalchemy.org/trac/ticket/7890)

    [sql] [bug] [regression]

    Fixed regression caused by [#7823](https://www.sqlalchemy.org/trac/ticket/7823) which impacted the caching system, such that bound parameters that had been “cloned” within ORM operations, such as polymorphic loading, would in some cases not acquire their correct execution-time value leading to incorrect bind values being rendered.

    References: [#7903](https://www.sqlalchemy.org/trac/ticket/7903)

1.4.34
Released: March 31, 2022
orm

    [orm] [bug] [regression]

    Fixed regression caused by [#7861](https://www.sqlalchemy.org/trac/ticket/7861) where invoking an [Insert](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Insert) construct which contained ORM entities directly via [Session.execute()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.execute) would fail.

    References: [#7878](https://www.sqlalchemy.org/trac/ticket/7878)

postgresql

    [postgresql] [bug]

    Scaled back a fix made for [#6581](https://www.sqlalchemy.org/trac/ticket/6581) where “executemany values” mode for psycopg2 were disabled for all “ON CONFLICT” styles of INSERT, to not apply to the “ON CONFLICT DO NOTHING” clause, which does not include any parameters and is safe for “executemany values” mode. “ON CONFLICT DO UPDATE” is still blocked from “executemany values” as there may be additional parameters in the DO UPDATE clause that cannot be batched (which is the original issue fixed by [#6581](https://www.sqlalchemy.org/trac/ticket/6581)).

    References: [#7880](https://www.sqlalchemy.org/trac/ticket/7880)

1.4.33
Released: March 31, 2022
orm

    [orm] [usecase]

    Added [with_polymorphic.adapt_on_names](https://docs.sqlalchemy.org/en/20/orm/queryguide/inheritance.html#sqlalchemy.orm.with_polymorphic.params.adapt_on_names) to the [with_polymorphic()](https://docs.sqlalchemy.org/en/20/orm/queryguide/inheritance.html#sqlalchemy.orm.with_polymorphic) function, which allows a polymorphic load (typically with concrete mapping) to be stated against an alternative selectable that will adapt to the original mapped selectable on column names alone.

    References: [#7805](https://www.sqlalchemy.org/trac/ticket/7805)

    [orm] [usecase]

    Added new attributes [UpdateBase.returning_column_descriptions](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.UpdateBase.returning_column_descriptions) and [UpdateBase.entity_description](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.UpdateBase.entity_description) to allow for inspection of ORM attributes and entities that are installed as part of an [Insert](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Insert), [Update](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Update), or [Delete](https://docs.sqlalchemy.org/en/20/core/dml.html#sqlalchemy.sql.expression.Delete) construct. The [Select.column_descriptions](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.column_descriptions) accessor is also now implemented for Core-only selectables.

    References: [#7861](https://www.sqlalchemy.org/trac/ticket/7861)

    [orm] [bug] [regression]

    Fixed regression in “dynamic” loader strategy where the [Query.filter_by()](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.filter_by) method would not be given an appropriate entity to filter from, in the case where a “secondary” table were present in the relationship being queried and the mapping were against something complex such as a “with polymorphic”.

    References: [#7868](https://www.sqlalchemy.org/trac/ticket/7868)

    [orm] [bug]

    Fixed bug where [composite()](https://docs.sqlalchemy.org/en/20/orm/composites.html#sqlalchemy.orm.composite) attributes would not work in conjunction with the [selectin_polymorphic()](https://docs.sqlalchemy.org/en/20/orm/queryguide/inheritance.html#sqlalchemy.orm.selectin_polymorphic) loader strategy for joined table inheritance.

    References: [#7801](https://www.sqlalchemy.org/trac/ticket/7801)

    [orm] [bug] [performance]

    Improvements in memory usage by the ORM, removing a significant set of intermediary expression objects that are typically stored when a copy of an expression object is created. These clones have been greatly reduced, reducing the number of total expression objects stored in memory by ORM mappings by about 30%.

    References: [#7823](https://www.sqlalchemy.org/trac/ticket/7823)

    [orm] [bug]

    Fixed issue where the [selectin_polymorphic()](https://docs.sqlalchemy.org/en/20/orm/queryguide/inheritance.html#sqlalchemy.orm.selectin_polymorphic) loader option would not work with joined inheritance mappers that don’t have a fixed “polymorphic_on” column. Additionally added test support for a wider variety of usage patterns with this construct.

    References: [#7799](https://www.sqlalchemy.org/trac/ticket/7799)

    [orm] [bug]

    Fixed bug in [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) function where loader criteria would not be applied to a joined eager load that were invoked within the scope of a refresh operation for the parent object.

    References: [#7862](https://www.sqlalchemy.org/trac/ticket/7862)

    [orm] [bug]

    Fixed issue where the [Mapper](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.Mapper) would reduce a user-defined [Mapper.primary_key](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.Mapper.params.primary_key) argument too aggressively, in the case of mapping to a UNION where for some of the SELECT entries, two columns are essentially equivalent, but in another, they are not, such as in a recursive CTE. The logic here has been changed to accept a given user-defined PK as given, where columns will be related to the mapped selectable but no longer “reduced” as this heuristic can’t accommodate for all situations.

    References: [#7842](https://www.sqlalchemy.org/trac/ticket/7842)

engine

    [engine] [usecase]

    Added new parameter [Engine.dispose.close](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine.dispose.params.close), defaulting to True. When False, the engine disposal does not touch the connections in the old pool at all, simply dropping the pool and replacing it. This use case is so that when the original pool is transferred from a parent process, the parent process may continue to use those connections.

    See also

    [Using Connection Pools with Multiprocessing or os.fork()](https://docs.sqlalchemy.org/en/20/core/pooling.html#pooling-multiprocessing) - revised documentation

    References: [#7815](https://www.sqlalchemy.org/trac/ticket/7815), [#7877](https://www.sqlalchemy.org/trac/ticket/7877)

    [engine] [bug]

    Further clarified connection-level logging to indicate the BEGIN, ROLLBACK and COMMIT log messages do not actually indicate a real transaction when the AUTOCOMMIT isolation level is in use; messaging has been extended to include the BEGIN message itself, and the messaging has also been fixed to accommodate when the [Engine](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine) level [create_engine.isolation_level](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.isolation_level) parameter was used directly.

    References: [#7853](https://www.sqlalchemy.org/trac/ticket/7853)

sql

    [sql] [usecase]

    Added new parameter [FunctionElement.table_valued.joins_implicitly](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.table_valued.params.joins_implicitly), for the [FunctionElement.table_valued()](https://docs.sqlalchemy.org/en/20/core/functions.html#sqlalchemy.sql.functions.FunctionElement.table_valued) construct. This parameter indicates that the table-valued function provided will automatically perform an implicit join with the referenced table. This effectively disables the ‘from linting’ feature, such as the ‘cartesian product’ warning, from triggering due to the presence of this parameter. May be used for functions such as func.json_each().

    References: [#7845](https://www.sqlalchemy.org/trac/ticket/7845)

    [sql] [bug]

    The [bindparam.literal_execute](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.bindparam.params.literal_execute) parameter now takes part of the cache generation of a [bindparam()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.bindparam), since it changes the sql string generated by the compiler. Previously the correct bind values were used, but the literal_execute would be ignored on subsequent executions of the same query.

    References: [#7876](https://www.sqlalchemy.org/trac/ticket/7876)

    [sql] [bug] [regression]

    Fixed regression caused by [#7760](https://www.sqlalchemy.org/trac/ticket/7760) where the new capabilities of [TextualSelect](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TextualSelect) were not fully implemented within the compiler properly, leading to issues with composed INSERT constructs such as “INSERT FROM SELECT” and “INSERT…ON CONFLICT” when combined with CTE and textual statements.

    References: [#7798](https://www.sqlalchemy.org/trac/ticket/7798)

schema

    [schema] [usecase]

    Added support so that the [Table.to_metadata.referred_schema_fn](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.to_metadata.params.referred_schema_fn) callable passed to [Table.to_metadata()](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.to_metadata) may return the value [BLANK_SCHEMA](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.SchemaConst.BLANK_SCHEMA) to indicate that the referenced foreign key should be reset to None. The [RETAIN_SCHEMA](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.SchemaConst.RETAIN_SCHEMA) symbol may also be returned from this function to indicate “no change”, which will behave the same as None currently does which also indicates no change.

    References: [#7860](https://www.sqlalchemy.org/trac/ticket/7860)

sqlite

    [sqlite] [bug] [reflection]

    Fixed bug where the name of CHECK constraints under SQLite would not be reflected if the name were created using quotes, as is the case when the name uses mixed case or special characters.

    References: [#5463](https://www.sqlalchemy.org/trac/ticket/5463)

mssql

    [mssql] [bug] [regression]

    Fixed regression caused by [#7160](https://www.sqlalchemy.org/trac/ticket/7160) where FK reflection in conjunction with a low compatibility level setting (compatibility level 80: SQL Server 2000) causes an “Ambiguous column name” error. Patch courtesy @Lin-Your.

    References: [#7812](https://www.sqlalchemy.org/trac/ticket/7812)

misc

    [bug] [ext]

    Improved the error message that’s raised for the case where the [association_proxy()](https://docs.sqlalchemy.org/en/20/orm/extensions/associationproxy.html#sqlalchemy.ext.associationproxy.association_proxy) construct attempts to access a target attribute at the class level, and this access fails. The particular use case here is when proxying to a hybrid attribute that does not include a working class-level implementation.

    References: [#7827](https://www.sqlalchemy.org/trac/ticket/7827)

1.4.32
Released: March 6, 2022
orm

    [orm] [bug] [regression]

    Fixed regression where the ORM exception that is to be raised when an INSERT silently fails to actually insert a row (such as from a trigger) would not be reached, due to a runtime exception raised ahead of time due to the missing primary key value, thus raising an uninformative exception rather than the correct one. For 1.4 and above, a new [FlushError](https://docs.sqlalchemy.org/en/20/orm/exceptions.html#sqlalchemy.orm.exc.FlushError) is added for this case that’s raised earlier than the previous “null identity” exception was for 1.3, as a situation where the number of rows actually INSERTed does not match what was expected is a more critical situation in 1.4 as it prevents batching of multiple objects from working correctly. This is separate from the case where a newly fetched primary key is fetched as NULL, which continues to raise the existing “null identity” exception.

    References: [#7594](https://www.sqlalchemy.org/trac/ticket/7594)

    [orm] [bug]

    Fixed issue where using a fully qualified path for the classname in [relationship()](https://docs.sqlalchemy.org/en/20/orm/relationship_api.html#sqlalchemy.orm.relationship) that nonetheless contained an incorrect name for path tokens that were not the first token, would fail to raise an informative error and would instead fail randomly at a later step.

    References: [#7697](https://www.sqlalchemy.org/trac/ticket/7697)

engine

    [engine] [bug]

    Adjusted the logging for key SQLAlchemy components including [Engine](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine), [Connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) to establish an appropriate stack level parameter, so that the Python logging tokens funcName and lineno when used in custom logging formatters will report the correct information, which can be useful when filtering log output; supported on Python 3.8 and above. Pull request courtesy Markus Gerstel.

    References: [#7612](https://www.sqlalchemy.org/trac/ticket/7612)

sql

    [sql] [bug]

    Fixed type-related error messages that would fail for values that were tuples, due to string formatting syntax, including compile of unsupported literal values and invalid boolean values.

    References: [#7721](https://www.sqlalchemy.org/trac/ticket/7721)

    [sql] [bug] [mysql]

    Fixed issues in MySQL [SET](https://docs.sqlalchemy.org/en/20/dialects/mysql.html#sqlalchemy.dialects.mysql.SET) datatype as well as the generic [Enum](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum) datatype where the __repr__() method would not render all optional parameters in the string output, impacting the use of these types in Alembic autogenerate. Pull request for MySQL courtesy Yuki Nishimine.

    References: [#7598](https://www.sqlalchemy.org/trac/ticket/7598), [#7720](https://www.sqlalchemy.org/trac/ticket/7720), [#7789](https://www.sqlalchemy.org/trac/ticket/7789)

    [sql] [bug]

    The [Enum](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum) datatype now emits a warning if the [Enum.length](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum.params.length) argument is specified without also specifying [Enum.native_enum](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum.params.native_enum) as False, as the parameter is otherwise silently ignored in this case, despite the fact that the [Enum](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Enum) datatype will still render VARCHAR DDL on backends that don’t have a native ENUM datatype such as SQLite. This behavior may change in a future release so that “length” is honored for all non-native “enum” types regardless of the “native_enum” setting.

    [sql] [bug]

    Fixed issue where the [HasCTE.add_cte()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.HasCTE.add_cte) method as called upon a [TextualSelect](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TextualSelect) instance was not being accommodated by the SQL compiler. The fix additionally adds more “SELECT”-like compiler behavior to [TextualSelect](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.TextualSelect) including that DML CTEs such as UPDATE and INSERT may be accommodated.

    References: [#7760](https://www.sqlalchemy.org/trac/ticket/7760)

asyncio

    [asyncio] [bug]

    Fixed issues where a descriptive error message was not raised for some classes of event listening with an async engine, which should instead be a sync engine instance.

    [asyncio] [bug]

    Fixed issue where the [AsyncSession.execute()](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncSession.execute) method failed to raise an informative exception if the [Connection.execution_options.stream_results](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.stream_results) execution option were used, which is incompatible with a sync-style [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) object when using an asyncio calling style, as the operation to fetch more rows would need to be awaited. An exception is now raised in this scenario in the same way one was already raised when the [Connection.execution_options.stream_results](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.stream_results) option would be used with the [AsyncConnection.execute()](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncConnection.execute) method.

    Additionally, for improved stability with state-sensitive database drivers such as asyncmy, the cursor is now closed when this error condition is raised; previously with the asyncmy dialect, the connection would go into an invalid state with unconsumed server side results remaining.

    References: [#7667](https://www.sqlalchemy.org/trac/ticket/7667)

postgresql

    [postgresql] [usecase]

    Added compiler support for the PostgreSQL NOT VALID phrase when rendering DDL for the [CheckConstraint](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.CheckConstraint), [ForeignKeyConstraint](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKeyConstraint) and [ForeignKey](https://docs.sqlalchemy.org/en/20/core/constraints.html#sqlalchemy.schema.ForeignKey) schema constructs. Pull request courtesy Gilbert Gilb’s.

    See also

    [PostgreSQL Constraint Options](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#postgresql-constraint-options)

    References: [#7600](https://www.sqlalchemy.org/trac/ticket/7600)

mysql

    [mysql] [bug] [regression]

    Fixed regression caused by [#7518](https://www.sqlalchemy.org/trac/ticket/7518) where changing the syntax “SHOW VARIABLES” to “SELECT @@” broke compatibility with MySQL versions older than 5.6, including early 5.0 releases. While these are very old MySQL versions, a change in compatibility was not planned, so version-specific logic has been restored to fall back to “SHOW VARIABLES” for MySQL server versions < 5.6.

    References: [#7518](https://www.sqlalchemy.org/trac/ticket/7518)

mariadb

    [mariadb] [bug] [regression]

    Fixed regression in mariadbconnector dialect as of mariadb connector 1.0.10 where the DBAPI no longer pre-buffers cursor.lastrowid, leading to errors when inserting objects with the ORM as well as causing non-availability of the [CursorResult.inserted_primary_key](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.CursorResult.inserted_primary_key) attribute. The dialect now fetches this value proactively for situations where it applies.

    References: [#7738](https://www.sqlalchemy.org/trac/ticket/7738)

sqlite

    [sqlite] [usecase]

    Added support for reflecting SQLite inline unique constraints where the column names are formatted with SQLite “escape quotes” [] or `, which are discarded by the database when producing the column name.

    References: [#7736](https://www.sqlalchemy.org/trac/ticket/7736)

    [sqlite] [bug]

    Fixed issue where SQLite unique constraint reflection would fail to detect a column-inline UNIQUE constraint where the column name had an underscore in its name.

    References: [#7736](https://www.sqlalchemy.org/trac/ticket/7736)

oracle

    [oracle] [bug]

    Fixed issue in Oracle dialect where using a column name that requires quoting when written as a bound parameter, such as "_id", would not correctly track a Python generated default value due to the bound-parameter rewriting missing this value, causing an Oracle error to be raised.

    References: [#7676](https://www.sqlalchemy.org/trac/ticket/7676)

    [oracle] [bug] [regression]

    Added support to parse “DPI” error codes from cx_Oracle exception objects such as DPI-1080 and DPI-1010, both of which now indicate a disconnect scenario as of cx_Oracle 8.3.

    References: [#7748](https://www.sqlalchemy.org/trac/ticket/7748)

tests

    [tests] [bug]

    Improvements to the test suite’s integration with pytest such that the “warnings” plugin, if manually enabled, will not interfere with the test suite, such that third parties can enable the warnings plugin or make use of the -W parameter and SQLAlchemy’s test suite will continue to pass. Additionally, modernized the detection of the “pytest-xdist” plugin so that plugins can be globally disabled using PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 without breaking the test suite if xdist were still installed. Warning filters that promote deprecation warnings to errors are now localized to SQLAlchemy-specific warnings, or within SQLAlchemy-specific sources for general Python deprecation warnings, so that non-SQLAlchemy deprecation warnings emitted from pytest plugins should also not impact the test suite.

    References: [#7599](https://www.sqlalchemy.org/trac/ticket/7599)

    [tests] [bug]

    Made corrections to the default pytest configuration regarding how test discovery is configured, to fix issue where the test suite would not configure warnings correctly and also attempt to load example suites as tests, in the specific case where the SQLAlchemy checkout were located in an absolute path that had a super-directory named “test”.

    References: [#7045](https://www.sqlalchemy.org/trac/ticket/7045)

1.4.31
Released: January 20, 2022
orm

    [orm] [bug]

    Fixed issue in [Session.bulk_save_objects()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.bulk_save_objects) where the sorting that takes place when the preserve_order parameter is set to False would sort partially on Mapper objects, which is rejected in Python 3.11.

    References: [#7591](https://www.sqlalchemy.org/trac/ticket/7591)

postgresql

    [postgresql] [bug] [regression]

    Fixed regression where the change in [#7148](https://www.sqlalchemy.org/trac/ticket/7148) to repair ENUM handling in PostgreSQL broke the use case of an empty ARRAY of ENUM, preventing rows that contained an empty array from being handled correctly when fetching results.

    References: [#7590](https://www.sqlalchemy.org/trac/ticket/7590)

mysql

    [mysql] [bug] [regression]

    Fixed regression in asyncmy dialect caused by [#7567](https://www.sqlalchemy.org/trac/ticket/7567) where removal of the PyMySQL dependency broke binary columns, due to the asyncmy dialect not being properly included within CI tests.

    References: [#7593](https://www.sqlalchemy.org/trac/ticket/7593)

mssql

    [mssql]

    Added support for FILESTREAM when using VARBINARY(max) in MSSQL.

    See also

    VARBINARY.filestream

    References: [#7243](https://www.sqlalchemy.org/trac/ticket/7243)

1.4.30
Released: January 19, 2022
orm

    [orm] [bug]

    Fixed issue in joined-inheritance load of additional attributes functionality in deep multi-level inheritance where an intermediary table that contained no columns would not be included in the tables joined, instead linking those tables to their primary key identifiers. While this works fine, it nonetheless in 1.4 began producing the cartesian product compiler warning. The logic has been changed so that these intermediary tables are included regardless. While this does include additional tables in the query that are not technically necessary, this only occurs for the highly unusual case of deep 3+ level inheritance with intermediary tables that have no non primary key columns, potential performance impact is therefore expected to be negligible.

    References: [#7507](https://www.sqlalchemy.org/trac/ticket/7507)

    [orm] [bug]

    Fixed issue where calling upon [registry.map_imperatively()](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.registry.map_imperatively) more than once for the same class would produce an unexpected error, rather than an informative error that the target class is already mapped. This behavior differed from that of the mapper() function which does report an informative message already.

    References: [#7579](https://www.sqlalchemy.org/trac/ticket/7579)

    [orm] [bug] [asyncio]

    Added missing method [AsyncSession.invalidate()](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncSession.invalidate) to the [AsyncSession](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncSession) class.

    References: [#7524](https://www.sqlalchemy.org/trac/ticket/7524)

    [orm] [bug] [regression]

    Fixed regression which appeared in 1.4.23 which could cause loader options to be mis-handled in some cases, in particular when using joined table inheritance in combination with the polymorphic_load="selectin" option as well as relationship lazy loading, leading to a TypeError.

    References: [#7557](https://www.sqlalchemy.org/trac/ticket/7557)

    [orm] [bug] [regression]

    Fixed ORM regression where calling the [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) function against an existing [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) construct would fail to produce correct SQL if the existing construct were against a fixed table. The fix allows that the original [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) construct is disregarded if it were only against a table that’s now being replaced. It also allows for correct behavior when constructing a [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) without a selectable argument against a [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) that’s against a subquery, to create an alias of that subquery (i.e. to change its name).

    The nesting behavior of [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) remains in place for the case where the outer [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) object is against a subquery which in turn refers to the inner [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) object. This is a relatively new 1.4 feature that helps to suit use cases that were previously served by the deprecated Query.from_self() method.

    References: [#7576](https://www.sqlalchemy.org/trac/ticket/7576)

    [orm] [bug]

    Fixed issue where [Select.correlate_except()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.correlate_except) method, when passed either the None value or no arguments, would not correlate any elements when used in an ORM context (that is, passing ORM entities as FROM clauses), rather than causing all FROM elements to be considered as “correlated” in the same way which occurs when using Core-only constructs.

    References: [#7514](https://www.sqlalchemy.org/trac/ticket/7514)

    [orm] [bug] [regression]

    Fixed regression from 1.3 where the “subqueryload” loader strategy would fail with a stack trace if used against a query that made use of [Query.from_statement()](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.from_statement) or [Select.from_statement()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.from_statement). As subqueryload requires modifying the original statement, it’s not compatible with the “from_statement” use case, especially for statements made against the [text()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.text) construct. The behavior now is equivalent to that of 1.3 and previously, which is that the loader strategy silently degrades to not be used for such statements, typically falling back to using the lazyload strategy.

    References: [#7505](https://www.sqlalchemy.org/trac/ticket/7505)

sql

    [sql] [bug] [postgresql]

    Added additional rule to the system that determines TypeEngine implementations from Python literals to apply a second level of adjustment to the type, so that a Python datetime with or without tzinfo can set the timezone=True parameter on the returned [DateTime](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.DateTime) object, as well as [Time](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Time). This helps with some round-trip scenarios on type-sensitive PostgreSQL dialects such as asyncpg, psycopg3 (2.0 only).

    References: [#7537](https://www.sqlalchemy.org/trac/ticket/7537)

    [sql] [bug]

    Added an informative error message when a method object is passed to a SQL construct. Previously, when such a callable were passed, as is a common typographical error when dealing with method-chained SQL constructs, they were interpreted as “lambda SQL” targets to be invoked at compilation time, which would lead to silent failures. As this feature was not intended to be used with methods, method objects are now rejected.

    References: [#7032](https://www.sqlalchemy.org/trac/ticket/7032)

mypy

    [mypy] [bug]

    Fixed Mypy crash when running id daemon mode caused by a missing attribute on an internal mypy Var instance.

    References: [#7321](https://www.sqlalchemy.org/trac/ticket/7321)

asyncio

    [asyncio] [usecase]

    Added new method [AdaptedConnection.run_async()](https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.engine.AdaptedConnection.run_async) to the DBAPI connection interface used by asyncio drivers, which allows methods to be called against the underlying “driver” connection directly within a sync-style function where the await keyword can’t be used, such as within SQLAlchemy event handler functions. The method is analogous to the [AsyncConnection.run_sync()](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#sqlalchemy.ext.asyncio.AsyncConnection.run_sync) method which translates async-style calls to sync-style. The method is useful for things like connection-pool on-connect handlers that need to invoke awaitable methods on the driver connection when it’s first created.

    See also

    [Using awaitable-only driver methods in connection pool and other events](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#asyncio-events-run-async)

    References: [#7580](https://www.sqlalchemy.org/trac/ticket/7580)

postgresql

    [postgresql] [usecase]

    Added string rendering to the UUID datatype, so that stringifying a statement with “literal_binds” that uses this type will render an appropriate string value for the PostgreSQL backend. Pull request courtesy José Duarte.

    References: [#7561](https://www.sqlalchemy.org/trac/ticket/7561)

    [postgresql] [bug] [asyncpg]

    Improved support for asyncpg handling of TIME WITH TIMEZONE, which was not fully implemented.

    References: [#7537](https://www.sqlalchemy.org/trac/ticket/7537)

    [postgresql] [bug] [mssql] [reflection]

    Fixed reflection of covering indexes to report include_columns as part of the dialect_options entry in the reflected index dictionary, thereby enabling round trips from reflection->create to be complete. Included columns continue to also be present under the include_columns key for backwards compatibility.

    References: [#7382](https://www.sqlalchemy.org/trac/ticket/7382)

    [postgresql] [bug]

    Fixed handling of array of enum values which require escape characters.

    References: [#7418](https://www.sqlalchemy.org/trac/ticket/7418)

mysql

    [mysql] [change]

    Replace SHOW VARIABLES LIKE statement with equivalent SELECT @@variable in MySQL and MariaDB dialect initialization. This should avoid mutex contention caused by SHOW VARIABLES, improving initialization performance.

    References: [#7518](https://www.sqlalchemy.org/trac/ticket/7518)

    [mysql] [bug]

    Removed unnecessary dependency on PyMySQL from the asyncmy dialect. Pull request courtesy long2ice.

    References: [#7567](https://www.sqlalchemy.org/trac/ticket/7567)

1.4.29
Released: December 22, 2021
orm

    [orm] [usecase]

    Added [Session.get.execution_options](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.get.params.execution_options) parameter which was previously missing from the [Session.get()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.get) method.

    References: [#7410](https://www.sqlalchemy.org/trac/ticket/7410)

    [orm] [bug]

    Fixed issue in new “loader criteria” method [PropComparator.and_()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.and_) where usage with a loader strategy like [selectinload()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.selectinload) against a column that was a member of the .c. collection of a subquery object, where the subquery would be dynamically added to the FROM clause of the statement, would be subject to stale parameter values within the subquery in the SQL statement cache, as the process used by the loader strategy to replace the parameters at execution time would fail to accommodate the subquery when received in this form.

    References: [#7489](https://www.sqlalchemy.org/trac/ticket/7489)

    [orm] [bug]

    Fixed recursion overflow which could occur within ORM statement compilation when using either the [with_loader_criteria()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.with_loader_criteria) feature or the the [PropComparator.and_()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.and_) method within a loader strategy in conjunction with a subquery which referred to the same entity being altered by the criteria option, or loaded by the loader strategy. A check for coming across the same loader criteria option in a recursive fashion has been added to accommodate for this scenario.

    References: [#7491](https://www.sqlalchemy.org/trac/ticket/7491)

    [orm] [bug] [mypy]

    Fixed issue where the __class_getitem__() method of the generated declarative base class by [as_declarative()](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.as_declarative) would lead to inaccessible class attributes such as __table__, for cases where a Generic[T] style typing declaration were used in the class hierarchy. This is in continuation from the basic addition of __class_getitem__() in [#7368](https://www.sqlalchemy.org/trac/ticket/7368). Pull request courtesy Kai Mueller.

    References: [#7368](https://www.sqlalchemy.org/trac/ticket/7368), [#7462](https://www.sqlalchemy.org/trac/ticket/7462)

    [orm] [bug] [regression]

    Fixed caching-related issue where the use of a loader option of the form lazyload(aliased(A).bs).joinedload(B.cs) would fail to result in the joinedload being invoked for runs subsequent to the query being cached, due to a mismatch for the options / object path applied to the objects loaded for a query with a lead entity that used aliased().

    References: [#7447](https://www.sqlalchemy.org/trac/ticket/7447)

engine

    [engine] [bug]

    Corrected the error message for the AttributeError that’s raised when attempting to write to an attribute on the [Row](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Row) class, which is immutable. The previous message claimed the column didn’t exist which is misleading.

    References: [#7432](https://www.sqlalchemy.org/trac/ticket/7432)

    [engine] [bug] [regression]

    Fixed regression in the [make_url()](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.make_url) function used to parse URL strings where the query string parsing would go into a recursion overflow if a Python 2 u'' string were used.

    References: [#7446](https://www.sqlalchemy.org/trac/ticket/7446)

mypy

    [mypy] [bug]

    Fixed mypy regression where the release of mypy 0.930 added additional internal checks to the format of “named types”, requiring that they be fully qualified and locatable. This broke the mypy plugin for SQLAlchemy, raising an assertion error, as there was use of symbols such as __builtins__ and other un-locatable or unqualified names that previously had not raised any assertions.

    References: [#7496](https://www.sqlalchemy.org/trac/ticket/7496)

asyncio

    [asyncio] [usecase]

    Added async_engine_config() function to create an async engine from a configuration dict. This otherwise behaves the same as [engine_from_config()](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine_from_config).

    References: [#7301](https://www.sqlalchemy.org/trac/ticket/7301)

mariadb

    [mariadb] [bug]

    Corrected the error classes inspected for the “is_disconnect” check for the mariadbconnector dialect, which was failing for disconnects that occurred due to common MySQL/MariaDB error codes such as 2006; the DBAPI appears to currently use the mariadb.InterfaceError exception class for disconnect errors such as error code 2006, which has been added to the list of classes checked.

    References: [#7457](https://www.sqlalchemy.org/trac/ticket/7457)

tests

    [tests] [bug] [regression]

    Fixed a regression in the test suite where the test called CompareAndCopyTest::test_all_present would fail on some platforms due to additional testing artifacts being detected. Pull request courtesy Nils Philippsen.

    References: [#7450](https://www.sqlalchemy.org/trac/ticket/7450)

1.4.28
Released: December 9, 2021
platform

    [platform] [bug]

    Python 3.10 has deprecated “distutils” in favor of explicit use of “setuptools” in [PEP 632](https://peps.python.org/pep-0632/); SQLAlchemy’s setup.py has replaced imports accordingly. However, since setuptools itself only recently added the replacement symbols mentioned in pep-632 as of November of 2021 in version 59.0.1, setup.py still has fallback imports to distutils, as SQLAlchemy 1.4 does not have a hard setuptools versioning requirement at this time. SQLAlchemy 2.0 is expected to use a full [PEP 517](https://peps.python.org/pep-0517/) installation layout which will indicate appropriate setuptools versioning up front.

    References: [#7311](https://www.sqlalchemy.org/trac/ticket/7311)

orm

    [orm] [bug] [ext]

    Fixed issue where the internal cloning used by the [PropComparator.any()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.any) method on a [relationship()](https://docs.sqlalchemy.org/en/20/orm/relationship_api.html#sqlalchemy.orm.relationship) in the case where the related class also makes use of ORM polymorphic loading, would fail if a hybrid property on the related, polymorphic class were used within the criteria for the any() operation.

    References: [#7425](https://www.sqlalchemy.org/trac/ticket/7425)

    [orm] [bug] [mypy]

    Fixed issue where the [as_declarative()](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.as_declarative) decorator and similar functions used to generate the declarative base class would not copy the __class_getitem__() method from a given superclass, which prevented the use of pep-484 generics in conjunction with the Base class. Pull request courtesy Kai Mueller.

    References: [#7368](https://www.sqlalchemy.org/trac/ticket/7368)

    [orm] [bug] [regression]

    Fixed ORM regression where the new behavior of “eager loaders run on unexpire” added in [#1763](https://www.sqlalchemy.org/trac/ticket/1763) would lead to loader option errors being raised inappropriately for the case where a single [Query](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query) or [Select](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select) were used to load multiple kinds of entities, along with loader options that apply to just one of those kinds of entity like a [joinedload()](https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html#sqlalchemy.orm.joinedload), and later the objects would be refreshed from expiration, where the loader options would attempt to be applied to the mismatched object type and then raise an exception. The check for this mismatch now bypasses raising an error for this case.

    References: [#7318](https://www.sqlalchemy.org/trac/ticket/7318)

    [orm] [bug]

    User defined ORM options, such as those illustrated in the dogpile.caching example which subclass UserDefinedOption, by definition are handled on every statement execution and do not need to be considered as part of the cache key for the statement. Caching of the base ExecutableOption class has been modified so that it is no longer a [HasCacheKey](https://docs.sqlalchemy.org/en/20/core/foundation.html#sqlalchemy.sql.traversals.HasCacheKey) subclass directly, so that the presence of user defined option objects will not have the unwanted side effect of disabling statement caching. Only ORM specific loader and criteria options, which are all internal to SQLAlchemy, now participate within the caching system.

    References: [#7394](https://www.sqlalchemy.org/trac/ticket/7394)

    [orm] [bug]

    Fixed issue where mappings that made use of [synonym()](https://docs.sqlalchemy.org/en/20/orm/mapped_attributes.html#sqlalchemy.orm.synonym) and potentially other kinds of “proxy” attributes would not in all cases successfully generate a cache key for their SQL statements, leading to degraded performance for those statements.

    References: [#7394](https://www.sqlalchemy.org/trac/ticket/7394)

    [orm] [bug]

    Fixed issue where a list mapped with [relationship()](https://docs.sqlalchemy.org/en/20/orm/relationship_api.html#sqlalchemy.orm.relationship) would go into an endless loop if in-place added to itself, i.e. the += operator were used, as well as if .extend() were given the same list.

    References: [#7389](https://www.sqlalchemy.org/trac/ticket/7389)

    [orm] [bug]

    Fixed issue where if an exception occurred when the [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session) were to close the connection within the [Session.commit()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.commit) method, when using a context manager for [Session.begin()](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.begin) , it would attempt a rollback which would not be possible as the [Session](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session) was in between where the transaction is committed and the connection is then to be returned to the pool, raising the exception “this sessiontransaction is in the committed state”. This exception can occur mostly in an asyncio context where CancelledError can be raised.

    References: [#7388](https://www.sqlalchemy.org/trac/ticket/7388)

    [orm] [deprecated]

    Deprecated an undocumented loader option syntax ".*", which appears to be no different than passing a single asterisk, and will emit a deprecation warning if used. This syntax may have been intended for something but there is currently no need for it.

    References: [#4390](https://www.sqlalchemy.org/trac/ticket/4390)

engine

    [engine] [usecase]

    Added support for copy() and deepcopy() to the [URL](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.engine.URL) class. Pull request courtesy Tom Ritchford.

    References: [#7400](https://www.sqlalchemy.org/trac/ticket/7400)

sql

    [sql] [usecase]

    ”Compound select” methods like [Select.union()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.union), [Select.intersect_all()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select.intersect_all) etc. now accept *other as an argument rather than other to allow for multiple additional SELECTs to be compounded with the parent statement at once. In particular, the change as applied to [CTE.union()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.CTE.union) and [CTE.union_all()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.CTE.union_all) now allow for a so-called “non-linear CTE” to be created with the [CTE](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.CTE) construct, whereas previously there was no way to have more than two CTE sub-elements in a UNION together while still correctly calling upon the CTE in recursive fashion. Pull request courtesy Eric Masseran.

    References: [#7259](https://www.sqlalchemy.org/trac/ticket/7259)

    [sql] [usecase]

    Support multiple clause elements in the [Exists.where()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Exists.where) method, unifying the api with the one presented by a normal [select()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.select) construct.

    References: [#7386](https://www.sqlalchemy.org/trac/ticket/7386)

    [sql] [bug] [regression]

    Extended the [TypeDecorator.cache_ok](https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.TypeDecorator.cache_ok) attribute and corresponding warning message if this flag is not defined, a behavior first established for [TypeDecorator](https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.TypeDecorator) as part of [#6436](https://www.sqlalchemy.org/trac/ticket/6436), to also take place for [UserDefinedType](https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.UserDefinedType), by generalizing the flag and associated caching logic to a new common base for these two types, [ExternalType](https://docs.sqlalchemy.org/en/20/core/type_api.html#sqlalchemy.types.ExternalType) to create [UserDefinedType.cache_ok](https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.UserDefinedType.cache_ok).

    The change means any current [UserDefinedType](https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.UserDefinedType) will now cause SQL statement caching to no longer take place for statements which make use of the datatype, along with a warning being emitted, unless the class defines the [UserDefinedType.cache_ok](https://docs.sqlalchemy.org/en/20/core/custom_types.html#sqlalchemy.types.UserDefinedType.cache_ok) flag as True. If the datatype cannot form a deterministic, hashable cache key derived from its arguments, the attribute may be set to False which will continue to keep caching disabled but will suppress the warning. In particular, custom datatypes currently used in packages such as SQLAlchemy-utils will need to implement this flag. The issue was observed as a result of a SQLAlchemy-utils datatype that is not currently cacheable.

    See also

    [ExternalType.cache_ok](https://docs.sqlalchemy.org/en/20/core/type_api.html#sqlalchemy.types.ExternalType.cache_ok)

    References: [#7319](https://www.sqlalchemy.org/trac/ticket/7319)

    [sql] [bug]

    Custom SQL elements, third party dialects, custom or third party datatypes will all generate consistent warnings when they do not clearly opt in or out of SQL statement caching, which is achieved by setting the appropriate attributes on each type of class. The warning links to documentation sections which indicate the appropriate approach for each type of object in order for caching to be enabled.

    References: [#7394](https://www.sqlalchemy.org/trac/ticket/7394)

    [sql] [bug]

    Fixed missing caching directives for a few lesser used classes in SQL Core which would cause [no key] to be logged for elements which made use of these.

    References: [#7394](https://www.sqlalchemy.org/trac/ticket/7394)

mypy

    [mypy] [bug]

    Fixed Mypy crash which would occur when using Mypy plugin against code which made use of [declared_attr](https://docs.sqlalchemy.org/en/20/orm/mapping_api.html#sqlalchemy.orm.declared_attr) methods for non-mapped names like __mapper_args__, __table_args__, or other dunder names, as the plugin would try to interpret these as mapped attributes which would then be later mis-handled. As part of this change, the decorated function is still converted by the plugin into a generic assignment statement (e.g. __mapper_args__: Any) so that the argument signature can continue to be annotated in the same way one would for any other @classmethod without Mypy complaining about the wrong argument type for a method that isn’t explicitly @classmethod.

    References: [#7321](https://www.sqlalchemy.org/trac/ticket/7321)

postgresql

    [postgresql] [bug]

    Fixed missing caching directives for [hstore](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.hstore) and [array](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.array) constructs which would cause [no key] to be logged for these elements.

    References: [#7394](https://www.sqlalchemy.org/trac/ticket/7394)

tests

    [tests] [bug]

    Implemented support for the test suite to run correctly under Pytest 7. Previously, only Pytest 6.x was supported for Python 3, however the version was not pinned on the upper bound in tox.ini. Pytest is not pinned in tox.ini to be lower than version 8 so that SQLAlchemy versions released with the current codebase will be able to be tested under tox without changes to the environment. Much thanks to the Pytest developers for their help with this issue.

1.4.27
Released: November 11, 2021
orm

    [orm] [bug]

    Fixed bug in “relationship to aliased class” feature introduced at [Relationship to Aliased Class](https://docs.sqlalchemy.org/en/20/orm/join_conditions.html#relationship-aliased-class) where it was not possible to create a loader strategy option targeting an attribute on the target using the [aliased()](https://docs.sqlalchemy.org/en/20/orm/queryguide/api.html#sqlalchemy.orm.aliased) construct directly in a second loader option, such as selectinload(A.aliased_bs).joinedload(aliased_b.cs), without explicitly qualifying using [PropComparator.of_type()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.of_type) on the preceding element of the path. Additionally, targeting the non-aliased class directly would be accepted (inappropriately), but would silently fail, such as selectinload(A.aliased_bs).joinedload(B.cs); this now raises an error referring to the typing mismatch.

    References: [#7224](https://www.sqlalchemy.org/trac/ticket/7224)

    [orm] [bug]

    All [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) objects will now consistently raise [ResourceClosedError](https://docs.sqlalchemy.org/en/20/core/exceptions.html#sqlalchemy.exc.ResourceClosedError) if they are used after a hard close, which includes the “hard close” that occurs after calling “single row or value” methods like [Result.first()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.first) and [Result.scalar()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.scalar). This was already the behavior of the most common class of result objects returned for Core statement executions, i.e. those based on [CursorResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.CursorResult), so this behavior is not new. However, the change has been extended to properly accommodate for the ORM “filtering” result objects returned when using 2.0 style ORM queries, which would previously behave in “soft closed” style of returning empty results, or wouldn’t actually “soft close” at all and would continue yielding from the underlying cursor.

    As part of this change, also added [Result.close()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result.close) to the base [Result](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Result) class and implemented it for the filtered result implementations that are used by the ORM, so that it is possible to call the [CursorResult.close()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.CursorResult.close) method on the underlying [CursorResult](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.CursorResult) when the yield_per execution option is in use to close a server side cursor before remaining ORM results have been fetched. This was again already available for Core result sets but the change makes it available for 2.0 style ORM results as well.

    References: [#7274](https://www.sqlalchemy.org/trac/ticket/7274)

    [orm] [bug] [regression]

    Fixed 1.4 regression where [Query.filter_by()](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.filter_by) would not function correctly on a [Query](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query) that was produced from [Query.union()](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.union), Query.from_self() or similar.

    References: [#7239](https://www.sqlalchemy.org/trac/ticket/7239)

    [orm] [bug]

    Fixed issue where deferred polymorphic loading of attributes from a joined-table inheritance subclass would fail to populate the attribute correctly if the [load_only()](https://docs.sqlalchemy.org/en/20/orm/queryguide/columns.html#sqlalchemy.orm.load_only) option were used to originally exclude that attribute, in the case where the load_only were descending from a relationship loader option. The fix allows that other valid options such as defer(..., raiseload=True) etc. still function as expected.

    References: [#7304](https://www.sqlalchemy.org/trac/ticket/7304)

    [orm] [bug] [regression]

    Fixed 1.4 regression where [Query.filter_by()](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.filter_by) would not function correctly when [Query.join()](https://docs.sqlalchemy.org/en/20/orm/queryguide/query.html#sqlalchemy.orm.Query.join) were joined to an entity which made use of [PropComparator.of_type()](https://docs.sqlalchemy.org/en/20/orm/internals.html#sqlalchemy.orm.PropComparator.of_type) to specify an aliased version of the target entity. The issue also applies to future style ORM queries constructed with [select()](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.select).

    References: [#7244](https://www.sqlalchemy.org/trac/ticket/7244)

engine

    [engine] [bug]

    Fixed issue in future [Connection](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection) object where the [Connection.execute()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execute) method would not accept a non-dict mapping object, such as SQLAlchemy’s own [RowMapping](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.RowMapping) or other abc.collections.Mapping object as a parameter dictionary.

    References: [#7291](https://www.sqlalchemy.org/trac/ticket/7291)

    [engine] [bug] [regression]

    Fixed regression where the [CursorResult.fetchmany()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.CursorResult.fetchmany) method would fail to autoclose a server-side cursor (i.e. when stream_results or yield_per is in use, either Core or ORM oriented results) when the results were fully exhausted.

    References: [#7274](https://www.sqlalchemy.org/trac/ticket/7274)

    [engine] [bug]

    Fixed issue in future [Engine](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine) where calling upon [Engine.begin()](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Engine.begin) and entering the context manager would not close the connection if the actual BEGIN operation failed for some reason, such as an event handler raising an exception; this use case failed to be tested for the future version of the engine. Note that the “future” context managers which handle begin() blocks in Core and ORM don’t actually run the “BEGIN” operation until the context managers are actually entered. This is different from the legacy version which runs the “BEGIN” operation up front.

    References: [#7272](https://www.sqlalchemy.org/trac/ticket/7272)

sql

    [sql] [usecase]

    Added TupleType to the top level sqlalchemy import namespace.

    [sql] [bug] [regression]

    Fixed regression where the row objects returned for ORM queries, which are now the normal Row objects, would not be interpreted by the [ColumnOperators.in_()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.ColumnOperators.in_) operator as tuple values to be broken out into individual bound parameters, and would instead pass them as single values to the driver leading to failures. The change to the “expanding IN” system now accommodates for the expression already being of type TupleType and treats values accordingly if so. In the uncommon case of using “tuple-in” with an untyped statement such as a textual statement with no typing information, a tuple value is detected for values that implement collections.abc.Sequence, but that are not str or bytes, as always when testing for Sequence.

    References: [#7292](https://www.sqlalchemy.org/trac/ticket/7292)

    [sql] [bug]

    Fixed issue where using the feature of using a string label for ordering or grouping described at [Ordering or Grouping by a Label](https://docs.sqlalchemy.org/en/20/tutorial/data_select.html#tutorial-order-by-label) would fail to function correctly if used on a [CTE](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.CTE) construct, when the CTE were embedded inside of an enclosing [Select](https://docs.sqlalchemy.org/en/20/core/selectable.html#sqlalchemy.sql.expression.Select) statement that itself was set up as a scalar subquery.

    References: [#7269](https://www.sqlalchemy.org/trac/ticket/7269)

    [sql] [bug] [regression]

    Fixed regression where the [text()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.text) construct would no longer be accepted as a target case in the “whens” list within a [case()](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.case) construct. The regression appears related to an attempt to guard against some forms of literal values that were considered to be ambiguous when passed here; however, there’s no reason the target cases shouldn’t be interpreted as open-ended SQL expressions just like anywhere else, and a literal string or tuple will be converted to a bound parameter as would be the case elsewhere.

    References: [#7287](https://www.sqlalchemy.org/trac/ticket/7287)

schema

    [schema] [bug]

    Fixed issue in [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table) where the [Table.implicit_returning](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.params.implicit_returning) parameter would not be accommodated correctly when passed along with [Table.extend_existing](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table.params.extend_existing) to augment an existing [Table](https://docs.sqlalchemy.org/en/20/core/metadata.html#sqlalchemy.schema.Table).

    References: [#7295](https://www.sqlalchemy.org/trac/ticket/7295)

postgresql

    [postgresql] [usecase] [asyncpg]

    Added overridable methods PGDialect_asyncpg.setup_asyncpg_json_codec and PGDialect_asyncpg.setup_asyncpg_jsonb_codec codec, which handle the required task of registering JSON/JSONB codecs for these datatypes when using asyncpg. The change is that methods are broken out as individual, overridable methods to support third party dialects that need to alter or disable how these particular codecs are set up.

    References: [#7284](https://www.sqlalchemy.org/trac/ticket/7284)

    [postgresql] [bug] [asyncpg]

    Changed the asyncpg dialect to bind the [Float](https://docs.sqlalchemy.org/en/20/core/type_basics.html#sqlalchemy.types.Float) type to the “float” PostgreSQL type instead of “numeric” so that the value float(inf) can be accommodated. Added test suite support for persistence of the “inf” value.

    References: [#7283](https://www.sqlalchemy.org/trac/ticket/7283)

    [postgresql] [pg8000]

    Improve array handling when using PostgreSQL with the pg8000 dialect.

    References: [#7167](https://www.sqlalchemy.org/trac/ticket/7167)

mysql

    [mysql] [bug] [mariadb] [¶](https://docs.sqlalchemy.org/en/20/changelog/changelog_14.html#change-bc546dd34176e5361c7a2e9e20ee5703)

    Reorganized the list of reserved words into two separate lists, one for MySQL and one for MariaDB, so that these diverging sets of words can be managed more accurately; adjusted the MySQL/MariaDB dialect to switch among these lists based on either explicitly configured or server-version-detected “MySQL” or “MariaDB” backend. Added all current reserved words through MySQL 8 and current MariaDB versions including recently added keywords like “lead” . Pull request courtesy Kevin Kirsche.

    References: [#7167](https://www.sqlalchemy.org/trac/ticket/7167)

    [mysql] [bug]

    Fixed issue in MySQL [Insert.on_duplicate_key_update()](https://docs.sqlalchemy.org/en/20/dialects/mysql.html#sqlalchemy.dialects.mysql.Insert.on_duplicate_key_update) which would render the wrong column name when an expression were used in a VALUES expression. Pull request courtesy Cristian Sabaila.

    References: [#7281](https://www.sqlalchemy.org/trac/ticket/7281)

mssql

    [mssql] [bug]

    Adjusted the compiler’s generation of “post compile” symbols including those used for “expanding IN” as well as for the “schema translate map” to not be based directly on plain bracketed strings with underscores, as this conflicts directly with SQL Server’s quoting format of also using brackets, which produces false matches when the compiler replaces “post compile” and “schema translate” symbols. The issue created easy to reproduce examples both with the [Inspector.get_schema_names()](https://docs.sqlalchemy.org/en/20/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_schema_names) method when used in conjunction with the [Connection.execution_options.schema_translate_map](https://docs.sqlalchemy.org/en/20/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.schema_translate_map) feature, as well in the unlikely case that a symbol overlapping with the internal name “POSTCOMPILE” would be used with a feature like “expanding in”.

    References: [#7300](https://www.sqlalchemy.org/trac/ticket/7300)
```
