### PR TITLE
Add thread names

### DIFF
--- a/inbox/mailsync/backends/base.py
+++ b/inbox/mailsync/backends/base.py
@@ -51,6 +51,8 @@ class BaseMailSyncMonitor(Greenlet):
 
         super().__init__()
 
+        self.name = f"{self.__class__.__name__}(account_id={account.id!r})"
+
     def _run(self):
         try:
             return retry_with_logging(
@@ -97,4 +99,4 @@ class BaseMailSyncMonitor(Greenlet):
             monitor.kill()
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}(account_id={self.account_id!r})>"
+        return f"<{self.name}>"

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -124,7 +124,13 @@ CONDSTORE_FLAGS_REFRESH_BATCH_SIZE = 200
 class ChangePoller(Greenlet):
     def __init__(self, engine: "FolderSyncEngine") -> None:
         self.engine = engine
+
         super().__init__()
+
+        self.name = (
+            f"{self.__class__.__name__}(account_id={engine.account_id!r}, "
+            f"folder_id={engine.folder_id!r}, folder_name={engine.folder_name!r})"
+        )
 
     @retry_crispin
     def _run(self) -> None:
@@ -132,6 +138,9 @@ class ChangePoller(Greenlet):
         while True:
             log.debug("polling for changes")
             self.engine.poll_impl()
+
+    def __repr__(self) -> str:
+        return f"<{self.name}>"
 
 
 class FolderSyncEngine(Greenlet):
@@ -200,6 +209,11 @@ class FolderSyncEngine(Greenlet):
         # times we got such an error and bail out if it's higher than
         # MAX_UIDINVALID_RESYNCS.
         self.uidinvalid_count = 0
+
+        self.name = (
+            f"{self.__class__.__name__}(account_id={account_id!r}, "
+            f"folder_id={self.folder_id!r}, folder_name={folder_name!r})"
+        )
 
     def setup_heartbeats(self):
         self.heartbeat_status = HeartbeatStatusProxy(
@@ -1010,10 +1024,7 @@ class FolderSyncEngine(Greenlet):
         return select_info
 
     def __repr__(self) -> str:
-        return (
-            f"<{self.__class__.__name__}(account_id={self.account_id!r}, "
-            f"folder_id={self.folder_id!r}, folder_name={self.folder_name!r})>"
-        )
+        return f"<{self.name}>"
 
 
 class UidInvalid(Exception):

--- a/inbox/mailsync/gc.py
+++ b/inbox/mailsync/gc.py
@@ -70,7 +70,10 @@ class DeleteHandler(gevent.Greenlet):
         self.log = log.new(account_id=account_id)
         self.message_ttl = datetime.timedelta(seconds=message_ttl)
         self.thread_ttl = datetime.timedelta(seconds=thread_ttl)
+
         super().__init__()
+
+        self.name = f"{self.__class__.__name__}(account_id={account_id!r})"
 
     def _run(self):
         while True:
@@ -201,7 +204,7 @@ class DeleteHandler(gevent.Greenlet):
                 db_session.commit()
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}(account_id={self.account_id!r})>"
+        return f"<{self.name}>"
 
 
 class LabelRenameHandler(gevent.Greenlet):
@@ -224,7 +227,10 @@ class LabelRenameHandler(gevent.Greenlet):
         self.label_name = label_name
         self.log = log.new(account_id=account_id)
         self.semaphore = semaphore
+
         super().__init__()
+
+        self.name = f"{self.__class__.__name__}(account_id={account_id!r}, label_name={label_name!r})"
 
     def _run(self):
         return retry_with_logging(self._run_impl, account_id=self.account_id)
@@ -282,4 +288,4 @@ class LabelRenameHandler(gevent.Greenlet):
             self.semaphore.release()
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}(account_id={self.account_id!r}, label_name={self.label_name!r})>"
+        return f"<{self.name}>"

--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -50,7 +50,10 @@ class BaseSyncMonitor(Greenlet):
         self.heartbeat_status = HeartbeatStatusProxy(
             self.account_id, folder_id, folder_name, email_address, provider_name
         )
+
         super().__init__()
+
+        self.name = f"{self.__class__.__name__}(account_id={account_id!r})"
 
     def _run(self):
         # Bind greenlet-local logging context.
@@ -92,4 +95,4 @@ class BaseSyncMonitor(Greenlet):
         raise NotImplementedError
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__}(account_id={self.account_id!r})>"
+        return f"<{self.name}>"


### PR DESCRIPTION
I'm in the process of hunting memory leaks in sync-engine. memray can split leaks by threads and having the names in the flamegraph speeds up the work of pinning the down and fixing them. Other profilers typically use this info as well.

![image](https://github.com/user-attachments/assets/5454c593-c6fd-4897-b032-02caebb00393)

