### PR TITLE
Use generators to save memory

### DIFF
--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -362,7 +362,7 @@ uid_format = re.compile(b"[0-9]+")
 original_parse_message_list = imapclient.response_parser.parse_message_list
 
 
-def fixed_parse_message_list(data: List[bytes]) -> List[int]:
+def fixed_parse_message_list(data: List[bytes]) -> Iterable[int]:
     """Fixed version of imapclient.response_parser.parse_message_list
 
     We observed in real world that some IMAP servers send many
@@ -395,10 +395,10 @@ def fixed_parse_message_list(data: List[bytes]) -> List[int]:
     # Optimize most common textual format for low memory footprint
     with contextlib.suppress(TypeError):
         if len(data) == 1 and common_uid_list_format.match(data[0]):
-            return [
+            return (
                 int(uid_match.group(0))
                 for uid_match in re.finditer(uid_format, data[0])
-            ]
+            )
 
     return original_parse_message_list(data)
 
@@ -882,9 +882,7 @@ class CrispinClient:
                 raise
 
         elapsed = time.time() - t
-        log.debug(
-            "Requested all UIDs", search_time=elapsed, total_uids=len(fetch_result)
-        )
+        log.debug("Requested all UIDs", search_time=elapsed)
         return (int(uid) if not isinstance(uid, int) else uid for uid in fetch_result)
 
     def uids(self, uids: List[int]) -> List[RawMessage]:

--- a/inbox/crispin.py
+++ b/inbox/crispin.py
@@ -6,6 +6,7 @@ import imaplib
 import re
 import ssl
 import time
+from collections.abc import Iterable
 from typing import (
     Any,
     Callable,
@@ -825,19 +826,19 @@ class CrispinClient:
     def idle_supported(self) -> bool:
         return b"IDLE" in self.conn.capabilities()
 
-    def search_uids(self, criteria: List[str]) -> List[int]:
+    def search_uids(self, criteria: List[str]) -> Iterable[int]:
         """
         Find UIDs in this folder matching the criteria. See
         http://tools.ietf.org/html/rfc3501.html#section-6.4.4 for valid
         criteria.
 
         """
-        return sorted(
+        return (
             int(uid) if not isinstance(uid, int) else uid
             for uid in self.conn.search(criteria)
         )
 
-    def all_uids(self) -> List[int]:
+    def all_uids(self) -> Iterable[int]:
         """Fetch all UIDs associated with the currently selected folder.
 
         Returns
@@ -884,9 +885,7 @@ class CrispinClient:
         log.debug(
             "Requested all UIDs", search_time=elapsed, total_uids=len(fetch_result)
         )
-        return sorted(
-            int(uid) if not isinstance(uid, int) else uid for uid in fetch_result
-        )
+        return (int(uid) if not isinstance(uid, int) else uid for uid in fetch_result)
 
     def uids(self, uids: List[int]) -> List[RawMessage]:
         uid_set = set(uids)
@@ -1025,7 +1024,7 @@ class CrispinClient:
 
         return self.conn.append(self.selected_folder_name, message, ["\\Seen"], date)
 
-    def fetch_headers(self, uids: List[int]) -> Dict[int, Dict[bytes, Any]]:
+    def fetch_headers(self, uids: Iterable[int]) -> Dict[int, Dict[bytes, Any]]:
         """
         Fetch headers for the given uids. Chunked because certain providers
         fail with 'Command line too large' if you feed them too many uids at
@@ -1524,7 +1523,7 @@ class GmailCrispinClient(CrispinClient):
         self._delete_message(message_id_header, delete_multiple)
         return True
 
-    def search_uids(self, criteria: List[str]) -> List[int]:
+    def search_uids(self, criteria: List[str]) -> Iterable[int]:
         """
         Handle Gmail label search oddities.
         https://developers.google.com/gmail/imap/imap-extensions#access_to_gmail_labels_x-gm-labels.
@@ -1585,4 +1584,4 @@ class GmailCrispinClient(CrispinClient):
             raise
 
         response = imapclient.response_parser.parse_message_list(data)
-        return sorted(int(uid) if not isinstance(uid, int) else uid for uid in response)
+        return (int(uid) if not isinstance(uid, int) else uid for uid in response)

--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -247,16 +247,16 @@ class GmailFolderSyncEngine(FolderSyncEngine):
 
         change_poller = None
         try:
-            remote_uids = crispin_client.all_uids()
+            remote_uids = set(crispin_client.all_uids())
             with self.syncmanager_lock:
                 with session_scope(self.namespace_id) as db_session:
                     local_uids = common.local_uids(
                         self.account_id, db_session, self.folder_id
                     )
                 common.remove_deleted_uids(
-                    self.account_id, self.folder_id, local_uids - set(remote_uids)
+                    self.account_id, self.folder_id, local_uids - remote_uids
                 )
-                unknown_uids = set(remote_uids) - local_uids
+                unknown_uids = remote_uids - local_uids
                 with session_scope(self.namespace_id) as db_session:
                     self.update_uid_counts(
                         db_session,

--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -451,7 +451,7 @@ class FolderSyncEngine(Greenlet):
         change_poller = None
         try:
             assert crispin_client.selected_folder_name == self.folder_name
-            remote_uids = crispin_client.all_uids()
+            remote_uids = set(crispin_client.all_uids())
             with self.syncmanager_lock:
                 with session_scope(self.namespace_id) as db_session:
                     local_uids = common.local_uids(
@@ -461,7 +461,7 @@ class FolderSyncEngine(Greenlet):
                     self.account_id, self.folder_id, local_uids.difference(remote_uids)
                 )
 
-            new_uids = sorted(set(remote_uids).difference(local_uids), reverse=True)
+            new_uids = sorted(remote_uids.difference(local_uids), reverse=True)
 
             len_remote_uids = len(remote_uids)
             del remote_uids  # free up memory as soon as possible
@@ -854,7 +854,7 @@ class FolderSyncEngine(Greenlet):
 
         del changed_flags  # free memory as soon as possible
 
-        remote_uids = crispin_client.all_uids()
+        remote_uids = set(crispin_client.all_uids())
 
         with session_scope(self.namespace_id) as db_session:
             local_uids = common.local_uids(self.account_id, db_session, self.folder_id)

--- a/tests/imap/test_actions.py
+++ b/tests/imap/test_actions.py
@@ -54,12 +54,12 @@ def test_draft_updates(db, default_account, mock_imapclient):
     with pool.get() as conn:
         save_draft(conn, default_account.id, draft.id, {"version": 0})
         conn.select_folder("Drafts", lambda *args: True)
-        assert len(conn.all_uids()) == 1
+        assert len(list(conn.all_uids())) == 1
 
         # Check that draft is not resaved if already synced.
         update_draft(conn, default_account.id, draft.id, {"version": 0})
         conn.select_folder("Drafts", lambda *args: True)
-        assert len(conn.all_uids()) == 1
+        assert len(list(conn.all_uids())) == 1
 
         # Check that an older version is deleted
         draft.version = 4
@@ -76,7 +76,7 @@ def test_draft_updates(db, default_account, mock_imapclient):
         update_draft(conn, default_account.id, draft.id, {"version": 5})
 
         conn.select_folder("Drafts", lambda *args: True)
-        all_uids = conn.all_uids()
+        all_uids = list(conn.all_uids())
         assert len(all_uids) == 1
         data = conn.uids(all_uids)[0]
         parsed = mime.from_string(data.body)
@@ -102,7 +102,7 @@ def test_draft_updates(db, default_account, mock_imapclient):
         )
 
         conn.select_folder("Drafts", lambda *args: True)
-        all_uids = conn.all_uids()
+        all_uids = list(conn.all_uids())
         assert len(all_uids) == 0
 
 

--- a/tests/imap/test_crispin_client.py
+++ b/tests/imap/test_crispin_client.py
@@ -813,7 +813,7 @@ def test_german_outlook(monkeypatch):
     "callee", [fixed_parse_message_list, original_parse_message_list]
 )
 def test_parse_message_list(callee):
-    assert callee([b"1 123 124 1024"]) == [1, 123, 124, 1024]
+    assert list(callee([b"1 123 124 1024"])) == [1, 123, 124, 1024]
 
 
 @pytest.mark.parametrize(
@@ -822,7 +822,7 @@ def test_parse_message_list(callee):
 def test_parse_message_list_large_list(callee):
     large_list = [" ".join(str(uid) for uid in range(1, 6_000_000)).encode()]
 
-    assert callee(large_list) == list(range(1, 6_000_000))
+    assert list(callee(large_list)) == list(range(1, 6_000_000))
 
 
 def test_fixed_parse_message_list_multiple_elements():


### PR DESCRIPTION
As stated before a single folder can have millions of messages, and millions of IMAP uid integers. We were buffering to lists in intermediate functions while we can just generate one int at a time using generators and buffer to set when we really need to (because we need to calculate differences between what we have in the database and what's remotely on IMAP server to decide what to delete locally and what to create locally).
