### PR TITLE
Kill greenlets faster

### DIFF
--- a/bin/inbox-start.py
+++ b/bin/inbox-start.py
@@ -142,8 +142,8 @@ def main(prod, enable_tracer, enable_profiler, config, process_num, exit_after):
 
     sync_service = SyncService(process_identifier, process_num)
 
-    signal.signal(signal.SIGTERM, sync_service.stop)
-    signal.signal(signal.SIGINT, sync_service.stop)
+    signal.signal(signal.SIGTERM, lambda *_: sync_service.stop())
+    signal.signal(signal.SIGINT, lambda *_: sync_service.stop())
     prepare_exit_after(log, sync_service, exit_after)
 
     http_frontend = SyncHTTPFrontend(

--- a/inbox/mailsync/backends/base.py
+++ b/inbox/mailsync/backends/base.py
@@ -5,7 +5,7 @@ from gevent import Greenlet, GreenletExit
 from inbox.config import config
 from inbox.logging import get_logger
 from inbox.models.session import session_scope
-from inbox.util.concurrency import retry_with_logging
+from inbox.util.concurrency import kill_all, retry_with_logging
 from inbox.util.debug import bind_context
 
 log = get_logger()
@@ -98,8 +98,7 @@ class BaseMailSyncMonitor(Greenlet):
         with session_scope(self.namespace_id) as mailsync_db_session:
             for x in self.folder_monitors:
                 x.set_stopped(mailsync_db_session)
-        for monitor in self.folder_monitors:
-            monitor.kill()
+        kill_all(self.folder_monitors)
 
     def __repr__(self) -> str:
         return f"<{self.name}>"

--- a/inbox/transactions/actions.py
+++ b/inbox/transactions/actions.py
@@ -45,7 +45,7 @@ from inbox.ignition import engine_manager
 from inbox.logging import get_logger
 from inbox.models import ActionLog, Event
 from inbox.models.session import session_scope, session_scope_by_shard_id
-from inbox.util.concurrency import retry_with_logging
+from inbox.util.concurrency import kill_all, retry_with_logging
 from inbox.util.misc import DummyContextManager
 from inbox.util.stats import statsd_client
 
@@ -497,8 +497,7 @@ class SyncbackService(gevent.Greenlet):
 
     def stop(self):
         self.keep_running = False
-        for worker in self.workers:
-            worker.kill()
+        kill_all(self.workers)
 
     def _run(self):
         self.log.info(

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -180,3 +180,14 @@ def iterate_and_periodically_switch_to_gevent(
             last_sleep_time = time.monotonic()
 
         yield item
+
+
+def kill_all(greenlets, *, block: bool = True) -> None:
+    if not greenlets:
+        return
+
+    for greenlet in greenlets:
+        greenlet.kill(block=False)
+
+    while block and not all(greenlet.ready() for greenlet in greenlets):
+        time.sleep(0.2)


### PR DESCRIPTION
This is a bugfix for https://github.com/closeio/sync-engine/pull/921.

When the original PR was deployed I noticed that the sync shutdown has become much slower in production i.e. minutes instead of seconds. This made the whole deploy process much slower. This is because I was now correctly waiting for all the greenlets but I was killing them one by one mostly and waiting for them to finish one by one at the same time. I know tweaked this to kill them one by one without waiting and then waiting for all of them to finish.

There's also a bug that crept in again because of too many branches/too much rebasing.