### PR TITLE
One more del

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -465,6 +465,7 @@ class FolderSyncEngine(Greenlet):
 
             len_remote_uids = len(remote_uids)
             del remote_uids  # free up memory as soon as possible
+            del local_uids  # free up memory as soon as possible
 
             with session_scope(self.namespace_id) as db_session:
                 account = db_session.query(Account).get(self.account_id)


### PR DESCRIPTION
This reduces memory pressure because otherwise the reference is held until the end of the function. In particular this variable can hold millions of ints for a single email folder and it's not uncommon these days. It's not used later in this function.