### PR TITLE
More runaway greenlets

### DIFF
--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -17,6 +17,7 @@ from inbox.events.remote_sync import EventSync, WebhookEventSync
 from inbox.heartbeat.status import clear_heartbeat_status
 from inbox.logging import get_logger
 from inbox.mailsync.backends import module_registry
+from inbox.mailsync.backends.gmail import GmailSyncMonitor
 from inbox.models import Account
 from inbox.models.session import global_session_scope, session_scope
 from inbox.providers import providers
@@ -130,6 +131,8 @@ class SyncService:
             if email_sync_monitor.delete_handler:
                 email_sync_monitor.delete_handler.kill()
             kill_all(email_sync_monitor.folder_monitors, block=False)
+            if isinstance(email_sync_monitor, GmailSyncMonitor):
+                kill_all(email_sync_monitor.label_rename_handlers.values(), block=False)
             email_sync_monitor.sync_greenlet.kill(block=False)
             email_sync_monitor.join()
         self.log.info(

--- a/tests/imap/test_save_folder_names.py
+++ b/tests/imap/test_save_folder_names.py
@@ -3,6 +3,7 @@ from inbox.mailsync.backends.gmail import GmailSyncMonitor
 from inbox.mailsync.backends.imap.monitor import ImapSyncMonitor
 from inbox.models import Category, Folder, Label
 from inbox.models.category import EPOCH
+from inbox.util.concurrency import kill_all
 
 
 def test_imap_save_generic_folder_names(db, default_account):
@@ -264,3 +265,5 @@ def test_not_deleting_canonical_folders(empty_db, default_account):
     label = empty_db.session.query(Label).get(label.id)
     assert label.deleted_at is None
     assert label.category.deleted_at == EPOCH
+
+    kill_all(monitor.label_rename_handlers.values())


### PR DESCRIPTION
Sometimes I can't believe how sloppy this codebase is, and it works very well nonetheless.

There were more run-away greenlets - e.g. greenlets that were spawned but were not correctly killed. This is bad since this can slow down the process shutdown. Also we were leaking them in tests in one place which could lead to polluting another test results.

I spotted this since these kinds of problems are actually worse with run-away threads.