### PR TITLE
Only free inbox_uids if defined

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -293,11 +293,11 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 uids_to_download = sorted(unknown_uids - inbox_uids) + sorted(
                     unknown_uids & inbox_uids
                 )
+                del inbox_uids  # free up memory as soon as possible
             else:
                 uids_to_download = sorted(unknown_uids)
 
             del unknown_uids  # free up memory as soon as possible
-            del inbox_uids  # free up memory as soon as possible
 
             for uids in chunk(reversed(uids_to_download), 1024):
                 g_metadata = crispin_client.g_metadata(uids)


### PR DESCRIPTION
Testing email syncing, I encountered an error.

When the `if self.is_all_mail(crispin_client):` path isn't taken (because email can't sync?) then there is no `inbox_uids` defined.
```
Traceback (most recent call last):
  File "/opt/app/inbox/util/concurrency.py", line 75, in wrapped
    return func(*args, **kwargs)
  File "/opt/app/inbox/mailsync/backends/imap/generic.py", line 291, in _run_impl
    self.state = self.state_handlers[old_state]()
  File "/opt/app/inbox/util/concurrency.py", line 75, in wrapped
    return func(*args, **kwargs)
  File "/opt/app/inbox/mailsync/backends/imap/generic.py", line 421, in initial_sync
    self.initial_sync_impl(crispin_client)
  File "/opt/app/inbox/mailsync/backends/gmail.py", line 300, in initial_sync_impl
    del inbox_uids  # free up memory as soon as possible
UnboundLocalError: local variable 'inbox_uids' referenced before assignment
```


