### PR TITLE
Update `HIGHESTMODSEQ` cache when decremented by server

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -810,12 +810,17 @@ class FolderSyncEngine(Greenlet):
             # changed.
             return
         elif new_highestmodseq < self.highestmodseq:
-            # This should really never happen, but if it does, handle it.
+            # This should never happen in theory, but unfortunately some
+            # servers do decrement the HIGHESTMODSEQ without changing
+            # UIDVALIDITY. We need to adjust the HIGHESTMODSEQ counterpart
+            # stored on our end, or else refreshing the flags will stop
+            # working.
             log.warning(
                 "got server highestmodseq less than saved highestmodseq",
                 new_highestmodseq=new_highestmodseq,
                 saved_highestmodseq=self.highestmodseq,
             )
+            self.highestmodseq = new_highestmodseq
             return
 
         log.debug(


### PR DESCRIPTION
Fixes #

Summary: Some servers can decrement the `HIGHESTMODSEQ` value while the `UIDVALIDITY` remains unchanged, which is against the spec. This results in syncing issues.

Test Plan:

Reviewers:
Please add the reviewer as an assignee to this PR on the right
