### PR TITLE
Interruptible threading

### DIFF
--- a/inbox/interruptible_threading.py
+++ b/inbox/interruptible_threading.py
@@ -70,7 +70,7 @@ class InterruptibleThread(threading.Thread):
         thread is started. Otherwise, the subclass must implement the `_run`
         method.
         """
-        self.__should_be_killed = False
+        self.__should_be_killed = threading.Event()
         self.__ready = False
         self.__run_target = (
             _InterruptibleThreadTarget(target, args, kwargs) if target else None
@@ -130,7 +130,7 @@ class InterruptibleThread(threading.Thread):
 
         If block is True, wait until the thread is ready.
         """
-        self.__should_be_killed = True
+        self.__should_be_killed.set()
         if block:
             self.join()
 
@@ -141,7 +141,7 @@ class InterruptibleThread(threading.Thread):
         Don't use this directly instead use the public
         `check_interrupted` function below.
         """
-        if self.__should_be_killed:
+        if self.__should_be_killed.wait(0.01):
             raise InterruptibleThreadExit()
 
         if (
@@ -259,3 +259,5 @@ def timeout(timeout: float):
         yield
     except InterruptibleThreadTimeout:
         pass
+    finally:
+        current_thread._timeout_deadline = None

--- a/inbox/interruptible_threading.py
+++ b/inbox/interruptible_threading.py
@@ -1,0 +1,261 @@
+"""
+Minimal interruptible version of stdlib threading.
+
+The API closely mimicks gevent's API for greenlets, it's almost a drop-in
+replacement. It was coined while porting this project from gevent to
+threading.
+
+The module provides an `InterruptibleThread` class that can be used to run
+interruptible code in a separate thread. The thread can be interrupted by
+calling the `kill` method. The thread must collaborate and periodically check
+if it is interrupted by calling the `check_interrupted` function unlike with
+gevent where the greenlet is interrupted automatically when using gevent-native
+APIs or monkey-patched version of stdlib.
+
+The module also provides a few utility functions that can be used to write
+interruptible code e.g. interruptible version of `time.sleep`, `queue.Queue.get`.
+
+For simple examples see tests in tests/test_interruptible_threading.py.
+"""
+
+import contextlib
+import dataclasses
+import queue
+import threading
+import time
+from typing import Any, Callable, Dict, Optional, Tuple, TypeVar
+
+from typing_extensions import Concatenate, ParamSpec
+
+
+class InterruptibleThreadExit(BaseException):
+    """
+    Exception raised when the thread is interrupted.
+
+    This exception is raised after the `kill` method is called on the
+    `InterruptibleThread` instance next time the thread checks if it's
+    interrupted. It is then caught in `InterruptibleThread.run` and ignored
+    since it means a successful interruption of the thread.
+
+    This mimicks exactly the behavior of gevent's `GreenletExit` exception.
+    Note that this exception is a subclass of `BaseException` and not
+    `Exception` because it's not suppoed to be caught by `except Exception` block,
+    just like https://greenlet.readthedocs.io/en/latest/api.html#greenlet.GreenletExit.
+    """
+
+
+@dataclasses.dataclass
+class _InterruptibleThreadTarget:
+    """
+    Convenience class to store target function and its positional and keyword
+    arguments.
+    """
+
+    target: Callable[..., Any]
+    args: Tuple[Any, ...]
+    kwargs: Dict[str, Any]
+
+    def __call__(self) -> Any:
+        return self.target(*self.args, **self.kwargs)
+
+
+class InterruptibleThread(threading.Thread):
+    def __init__(
+        self, target: Optional[Callable[..., Any]] = None, *args: Any, **kwargs: Any
+    ) -> None:
+        """
+        Initialize the thread.
+
+        If target is provided, it will be called with args and kwargs when the
+        thread is started. Otherwise, the subclass must implement the `_run`
+        method.
+        """
+        self.__should_be_killed = False
+        self.__ready = False
+        self.__run_target = (
+            _InterruptibleThreadTarget(target, args, kwargs) if target else None
+        )
+        self.__exception: Optional[Exception] = None
+
+        self._timeout_deadline: "float | None" = None
+
+        super().__init__()
+
+    def ready(self) -> bool:
+        """
+        Return True if the thread has finished.
+        """
+        return self.__ready
+
+    def successful(self) -> bool:
+        """
+        Return True if the thread has finished successfully
+        i.e. without rising an exception.
+        """
+        return self.__ready and self.__exception is None
+
+    @property
+    def exception(self) -> Optional[Exception]:
+        """
+        Stores an exception if one was raised during thread
+        execution.
+        """
+        return self.__exception
+
+    def run(self) -> None:
+        try:
+            self._run()
+        except InterruptibleThreadExit:
+            pass
+        except Exception as e:
+            self.__exception = e
+        finally:
+            self.__ready = True
+
+    def _run(self) -> None:
+        """
+        Run thread body.
+
+        Subclasses must implement this method unless the target
+        function is provided to the initializer.
+        """
+        if self.__run_target:
+            self.__run_target()
+        else:
+            raise NotImplementedError()
+
+    def kill(self, block: bool = True) -> None:
+        """
+        Kill the thread.
+
+        If block is True, wait until the thread is ready.
+        """
+        self.__should_be_killed = True
+        if block:
+            self.join()
+
+    def _check_interrupted(self) -> None:
+        """
+        Internally check if the thread should be interrupted.
+
+        Don't use this directly instead use the public
+        `check_interrupted` function below.
+        """
+        if self.__should_be_killed:
+            raise InterruptibleThreadExit()
+
+        if (
+            self._timeout_deadline is not None
+            and time.monotonic() >= self._timeout_deadline
+        ):
+            raise InterruptibleThreadTimeout()
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def _interruptible(
+    blocking_function: Callable[P, T]
+) -> Callable[[Callable[Concatenate[InterruptibleThread, P], T]], Callable[P, T]]:
+    """
+    If the current thread is interruptible run interruptible version of
+    the blocking function. Otherwise fallback to original implementation.
+    """
+
+    def decorator(
+        interruptible_function: Callable[Concatenate[InterruptibleThread, P], T]
+    ) -> Callable[P, T]:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            current_thread = threading.current_thread()
+            if not isinstance(current_thread, InterruptibleThread):
+                return blocking_function(*args)
+
+            return interruptible_function(current_thread, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+# Time to wait between checking if the thread should be interrupted
+# when using interruptible versions of blocking functions.
+CHECK_INTERRUPTED_TIMEOUT = 0.2
+
+
+@_interruptible(time.sleep)
+def sleep(current_thread: InterruptibleThread, /, seconds: float) -> None:
+    """
+    Interruptible version of time.sleep.
+    """
+    start = time.monotonic()
+    while time.monotonic() - start < seconds:
+        time.sleep(CHECK_INTERRUPTED_TIMEOUT)
+        current_thread._check_interrupted()
+
+
+@_interruptible(queue.Queue.get)
+def queue_get(
+    current_thread: InterruptibleThread,
+    /,
+    self: "queue.Queue[queue._T]",
+    block: bool = True,
+    timeout: "float | None" = None,
+) -> "queue._T":
+    """
+    Interruptible version of queue.Queue.get.
+    """
+    if not block:
+        return self.get(block=False)
+
+    if timeout is not None:
+        raise NotImplementedError("timeout is not supported.")
+
+    while True:
+        try:
+            return self.get(timeout=CHECK_INTERRUPTED_TIMEOUT)
+        except queue.Empty:
+            current_thread._check_interrupted()
+
+
+@_interruptible(lambda: None)
+def check_interrupted(current_thread: InterruptibleThread, /) -> None:
+    """
+    Check if the current thread is interrupted.
+    """
+    return current_thread._check_interrupted()
+
+
+class InterruptibleThreadTimeout(BaseException):
+    """
+    Exception raised when the the timeout set by `timeout` context manager
+    elapses.
+
+    This exception is raised after the deadline is reached and the thread
+    checks if it's interrupted. It is then caught in `timeout` context manager.
+
+    This exception is a subclass of `BaseException` and not `Exception` so it
+    won't be caught by a generic `except Exception` block.
+    """
+
+
+@contextlib.contextmanager
+def timeout(timeout: float):
+    """
+    Context manager to set a timeout for the interruptible
+    operations run by the current interruptible thread.
+    """
+    current_thread = threading.current_thread()
+    if not isinstance(current_thread, InterruptibleThread):
+        yield
+        return
+
+    if current_thread._timeout_deadline is not None:
+        raise RuntimeError("Nested timeout is not supported.")
+
+    current_thread._timeout_deadline = time.monotonic() + timeout
+
+    try:  # noqa: SIM105
+        yield
+    except InterruptibleThreadTimeout:
+        pass

--- a/tests/test_interruptible_threading.py
+++ b/tests/test_interruptible_threading.py
@@ -120,3 +120,30 @@ def test_timeout_interrupts_sleep():
     assert thread.ready() is True
     assert thread.successful() is True
     assert thread.exception is None
+
+
+class SeveralTimeoutsThread(InterruptibleThread):
+    def __init__(self):
+        self.executed_to_end = False
+
+        super().__init__()
+
+    def _run(self):
+        with interruptible_threading.timeout(1):
+            interruptible_threading.sleep(1000)
+
+        with interruptible_threading.timeout(1):
+            interruptible_threading.sleep(1000)
+
+        self.executed_to_end = True
+
+
+def test_several_timeouts_interrupts_sleep():
+    thread = SeveralTimeoutsThread()
+    thread.start()
+    thread.join()
+
+    assert thread.executed_to_end is True
+    assert thread.ready() is True
+    assert thread.successful() is True
+    assert thread.exception is None

--- a/tests/test_interruptible_threading.py
+++ b/tests/test_interruptible_threading.py
@@ -1,0 +1,122 @@
+import queue
+import time
+
+from inbox import interruptible_threading
+from inbox.interruptible_threading import InterruptibleThread
+
+
+class SuccessfulThread(InterruptibleThread):
+    def _run(self):
+        pass
+
+
+def test_successful_states():
+    thread = SuccessfulThread()
+
+    assert thread.ready() is False
+    assert thread.successful() is False
+    assert thread.exception is None
+
+    thread.start()
+    thread.join()
+
+    assert thread.ready() is True
+    assert thread.successful() is True
+    assert thread.exception is None
+
+
+class FailingThread(InterruptibleThread):
+    def _run(self):
+        raise ValueError("This is a test exception")
+
+
+def test_failing_states():
+    thread = FailingThread()
+
+    assert thread.ready() is False
+    assert thread.successful() is False
+    assert thread.exception is None
+
+    thread.start()
+    thread.join()
+
+    assert thread.ready() is True
+    assert thread.successful() is False
+    assert isinstance(thread.exception, ValueError)
+
+
+class SleepingThread(InterruptibleThread):
+    def _run(self):
+        while True:
+            interruptible_threading.sleep(1)
+
+
+def test_sleeping_can_be_interrupted():
+    thread = SleepingThread()
+    thread.start()
+    thread.kill()
+
+    assert thread.ready() is True
+    assert thread.successful() is True
+    assert thread.exception is None
+
+
+class WaitingOnEmptyQueue(InterruptibleThread):
+    def _run(self):
+        empty_queue = queue.Queue()
+        interruptible_threading.queue_get(empty_queue)
+
+
+def test_waiting_on_empty_queue_can_be_interrupted():
+    thread = WaitingOnEmptyQueue()
+    thread.start()
+    thread.kill()
+
+    assert thread.ready() is True
+    assert thread.successful() is True
+    assert thread.exception is None
+
+
+class CheckInterruptedThread(InterruptibleThread):
+    def _run(self):
+        while True:
+            interruptible_threading.check_interrupted()
+
+
+def test_check_interrupted_can_be_interrupted():
+    thread = CheckInterruptedThread()
+    thread.start()
+    thread.kill()
+
+    assert thread.ready() is True
+    assert thread.successful() is True
+    assert thread.exception is None
+
+
+class TimeoutThread(InterruptibleThread):
+    def __init__(self):
+        self.executed_to_end = False
+
+        super().__init__()
+
+    def _run(self):
+        with interruptible_threading.timeout(1):
+            interruptible_threading.sleep(1000)
+
+        self.executed_to_end = True
+
+
+def test_timeout_interrupts_sleep():
+    thread = TimeoutThread()
+
+    start = time.monotonic()
+    thread.start()
+    thread.join()
+    end = time.monotonic()
+
+    assert 1 < end - start < 2
+
+    assert thread.executed_to_end is True
+    assert thread.ready() is True
+    assert thread.successful() is True
+    assert thread.exception is None


### PR DESCRIPTION
This is a secret sauce that will let me convert syncback and sync pods to threading without doing a complete rewrite. Both sync and syncback processes are trees of greenlets and they need to become trees of threads.

Greenlets can be killed in any place you are calling gevent-native API or monkey patched stdlib. Internally this raises exceptions both in greenlets and on this branch but normally you don't see this because it happens behind the scenes. I provided a polyfill that lets me replace the Greenlet base classes with InterruptibleThread. This polyfill provides greenlet-like methods/properties and emulates greenlets as close as practically possible. The threads must call `check_interrupted` from time to time or use conveniently provided `interruptible_threading.sleep` and others utilities that will do that for you.

The polyfill is less than 100 lines of Python code if you remove docstrings and makes porting straghtforward.

For this in action please see: https://github.com/closeio/sync-engine/pull/911