### PR TITLE
Lock some CPU & RAM intesitve operations

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -247,57 +247,62 @@ class GmailFolderSyncEngine(FolderSyncEngine):
         assert isinstance(crispin_client, GmailCrispinClient)
 
         change_poller = None
+
         try:
-            remote_uids = set(crispin_client.all_uids())
-            with self.syncmanager_lock:
-                with session_scope(self.namespace_id) as db_session:
-                    local_uids = common.local_uids(
-                        self.account_id, db_session, self.folder_id
-                    )
-                common.remove_deleted_uids(
-                    self.account_id, self.folder_id, local_uids - remote_uids
-                )
-                unknown_uids = remote_uids - local_uids
-                with session_scope(self.namespace_id) as db_session:
-                    self.update_uid_counts(
-                        db_session,
-                        remote_uid_count=len(remote_uids),
-                        download_uid_count=len(unknown_uids),
-                    )
-
-            del local_uids  # free up memory as soon as possible
-            len_remote_uids = len(remote_uids)
-            del remote_uids  # free up memory as soon as possible
-
-            change_poller = ChangePoller(self)
-            change_poller.start()
-            bind_context(change_poller, "changepoller", self.account_id, self.folder_id)
-
-            if self.is_all_mail(crispin_client):
-                # Prioritize UIDs for messages in the inbox folder.
-                if len_remote_uids < 1e6:
-                    inbox_uids = set(
-                        crispin_client.search_uids(["X-GM-LABELS", "inbox"])
-                    )
-                else:
-                    # The search above is really slow (times out) on really
-                    # large mailboxes, so bound the search to messages within
-                    # the past month in order to get anywhere.
-                    since = datetime.utcnow() - timedelta(days=30)
-                    inbox_uids = set(
-                        crispin_client.search_uids(
-                            ["X-GM-LABELS", "inbox", "SINCE", since]
+            with self.global_lock:
+                remote_uids = set(crispin_client.all_uids())
+                with self.syncmanager_lock:
+                    with session_scope(self.namespace_id) as db_session:
+                        local_uids = common.local_uids(
+                            self.account_id, db_session, self.folder_id
                         )
+                    common.remove_deleted_uids(
+                        self.account_id, self.folder_id, local_uids - remote_uids
+                    )
+                    unknown_uids = remote_uids - local_uids
+                    with session_scope(self.namespace_id) as db_session:
+                        self.update_uid_counts(
+                            db_session,
+                            remote_uid_count=len(remote_uids),
+                            download_uid_count=len(unknown_uids),
+                        )
+
+                del local_uids  # free up memory as soon as possible
+                len_remote_uids = len(remote_uids)
+                del remote_uids  # free up memory as soon as possible
+
+                change_poller = ChangePoller(self)
+                change_poller.start()
+                bind_context(
+                    change_poller, "changepoller", self.account_id, self.folder_id
+                )
+
+                if self.is_all_mail(crispin_client):
+                    # Prioritize UIDs for messages in the inbox folder.
+                    if len_remote_uids < 1e6:
+                        inbox_uids = set(
+                            crispin_client.search_uids(["X-GM-LABELS", "inbox"])
+                        )
+                    else:
+                        # The search above is really slow (times out) on really
+                        # large mailboxes, so bound the search to messages within
+                        # the past month in order to get anywhere.
+                        since = datetime.utcnow() - timedelta(days=30)
+                        inbox_uids = set(
+                            crispin_client.search_uids(
+                                ["X-GM-LABELS", "inbox", "SINCE", since]
+                            )
+                        )
+
+                    uids_to_download = sorted(unknown_uids - inbox_uids) + sorted(
+                        unknown_uids & inbox_uids
                     )
 
-                uids_to_download = sorted(unknown_uids - inbox_uids) + sorted(
-                    unknown_uids & inbox_uids
-                )
-                del inbox_uids  # free up memory as soon as possible
-            else:
-                uids_to_download = sorted(unknown_uids)
+                    del inbox_uids  # free up memory as soon as possible
+                else:
+                    uids_to_download = sorted(unknown_uids)
 
-            del unknown_uids  # free up memory as soon as possible
+                del unknown_uids  # free up memory as soon as possible
 
             for uids in chunk(reversed(uids_to_download), 1024):
                 g_metadata = crispin_client.g_metadata(uids)
@@ -332,13 +337,17 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                     # away
                     log.debug("UIDVALIDITY unchanged")
                     return
-                msg_uids = crispin_client.all_uids()
-                mapping = {
-                    g_msgid: msg_uid
-                    for msg_uid, g_msgid in crispin_client.g_msgids(msg_uids).items()
-                }
 
-                del msg_uids  # free up memory as soon as possible
+                with self.global_lock:
+                    msg_uids = crispin_client.all_uids()
+                    mapping = {
+                        g_msgid: msg_uid
+                        for msg_uid, g_msgid in crispin_client.g_msgids(
+                            msg_uids
+                        ).items()
+                    }
+
+                    del msg_uids  # free up memory as soon as possible
             imap_uid_entries = (
                 db_session.query(ImapUid)
                 .options(


### PR DESCRIPTION
We are running on threads in production now. I observed CPU & RAM usage balloon on some of the pods where we run a lot of accounts. This is because with gevent CPU & RAM intensive sections are "naturally" locked - i.e. gevent will only switch between greenlets when you use gevent APIs or I/O - threads on the other hand can switch every N-th Python bytecode. This in turn makes it possible to allocate faster and have bigger spikes in CPU usage. I tried this branch already in production and it solves the problem without slowing down or negatively impacting syncs. It just brings back the "natural" gevent behavior.

This adds `with self.global_lock` sections around CPU & RAM intensive operations so threads don't switch between each other in those sections and don't inflate CPU & RAM usage. The diff is ugly because git can't understand indent - dedent.

We might need to lock more sections in the future, but this is enough for now not to trigger warnings/alarms.