### PR TITLE
Lock email parsing

### DIFF
--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -388,8 +388,14 @@ class Message(MailSyncBase, HasRevisions, HasPublicID, UpdatedAtMixin, DeletedAt
                             imap_uid=imap_uid,
                         )
                         message._mark_error()
+
+                del parsed  # free up memory as soon as possible
+
                 store_body: bool = config.get("STORE_MESSAGE_BODIES", True)
                 message.calculate_body(html_parts, plain_parts, store_body=store_body)
+
+                del html_parts  # free up memory as soon as possible
+                del plain_parts  # free up memory as soon as possible
 
             # Occasionally people try to send messages to way too many
             # recipients. In such cases, empty the field and treat as a parsing


### PR DESCRIPTION
Related to https://github.com/closeio/sync-engine/pull/948

> We are running on threads in production now. I observed CPU & RAM usage balloon on some of the pods where we run a lot of accounts. This is because with gevent CPU & RAM intensive sections are "naturally" locked - i.e. gevent will only switch between greenlets when you use gevent APIs or I/O - threads on the other hand can switch every N-th Python bytecode. This in turn makes it possible to allocate faster and have bigger spikes in CPU usage. I tried this branch already in production and it solves the problem without slowing down or negatively impacting syncs. It just brings back the "natural" gevent behavior.

Another CPU/RAM intensive part is email parsing. I've locked this and tried in production and CPU usage alarms went away as only one thread can end up in this "critical section" at the time. I've also added some dels to drop the references to potentially large blocks of memory as soon as possible. I might bump the semaphore value to 2 (2 threads parsing emails in parallel) if we can tolerate that in production but I have to measure that first.

The Git diff is of course useless with indents/dedents.