### PR TITLE
Introduce jitter

### DIFF
--- a/inbox/sync/base_sync.py
+++ b/inbox/sync/base_sync.py
@@ -7,7 +7,7 @@ from inbox.interruptible_threading import InterruptibleThread
 from inbox.logging import get_logger
 from inbox.models import Account
 from inbox.models.session import session_scope
-from inbox.util.concurrency import retry_with_logging
+from inbox.util.concurrency import introduce_jitter, retry_with_logging
 
 logger = get_logger()
 
@@ -87,8 +87,8 @@ class BaseSyncMonitor(InterruptibleThread):
         # 2x poll frequency.
         except ConnectionError:
             self.log.error("Error while polling", exc_info=True)
-            interruptible_threading.sleep(self.poll_frequency)
-        interruptible_threading.sleep(self.poll_frequency)
+            interruptible_threading.sleep(introduce_jitter(self.poll_frequency))
+        interruptible_threading.sleep(introduce_jitter(self.poll_frequency))
 
     def sync(self):
         """Subclasses should override this to do work"""

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -203,3 +203,7 @@ def run_in_parallel(functions: "list[Callable[[], Any]]") -> None:
     with concurrent.futures.ThreadPoolExecutor(len(functions)) as executor:
         for function in functions:
             executor.submit(function)
+
+
+def introduce_jitter(value: float, ratio: float = 0.3) -> float:
+    return value + value * ratio * random.uniform(-1, 1)


### PR DESCRIPTION
This address two problems I realized after starring for too much time at our metrics:

First, sync engine sync pods are essentially doing concurrently:
- wait for something or sleep some period of time
- fetch remote state (IMAP or Calendar), fetch local state (MySQL) - compare - update local state to reflect remote state

There are around 400 concurrent of those checks happening per sync pod (every single IMAP folder in every single account, every calendar etc.). They all use the same poll intervals meaning that they wake all up at the same time more or less and create momentary CPU and RAM spikes in metrics. It's better to jitter that a little bit to smooth-en metrics and load out.

Second, for servers that support it (Gmail does for example) we use IMAP IDLE - this basically tells the server that we are waiting for the folder changes instead of blindly polling from time to time. The server will keep  the connection in open state and then return back to us from IDLE command as soon as something is available. Then we fetch remote state fetch local state and compare etc. We were IDLEing up to 30 seconds before, and then saying we are gonna check everything anyway. This is source of significant load on the server. As the comment says it's because IDLE might not return if there were flag changes on emails (think Starred, Seen etc) but we do not care about those anyway in CRM, we just want new emails. I increased IDLE max time from 30 seconds to 60 seconds, as servers can be trusted to return when new emails arrive or old emails are deleted. I tested this in production and it did not have any negative latency effects (again servers will return as soon as new emails appear or old emails disappear). Previously we were often doing useless work every 30 seconds, now every 60 seconds. This in turn head positive effect on k8s CFS throttling (i.e. how much k8s has to throttle a pod to keep it at its assigned CPU limits). I might later increase IDLE even more, I just want to make conservative changes.

Anyway here's what happened in k8s (left before, right after) in production on sync pods (just 3 examples but this affected the whole cluster):

<img width="1315" alt="Screenshot 2024-10-24 at 12 52 47" src="https://github.com/user-attachments/assets/b4b8d7c1-7e38-4494-a3aa-a4aaa2d5ee5a">

<img width="1318" alt="Screenshot 2024-10-24 at 12 54 29" src="https://github.com/user-attachments/assets/747616aa-64da-4318-a0b3-e3c6631ccc37">

<img width="1325" alt="Screenshot 2024-10-24 at 12 57 01" src="https://github.com/user-attachments/assets/c441ffee-1b76-4811-9901-3c7366c1b8e3">








