### PR TITLE
Skip SQLAlchemy when fetching millions of UIDs

### DIFF
--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -28,6 +28,7 @@ from inbox.models.backends.imap import ImapFolderInfo, ImapUid
 from inbox.models.category import Category
 from inbox.models.session import session_scope
 from inbox.models.util import reconcile_message
+from inbox.sqlalchemy_ext.util import get_db_api_cursor_with_query
 
 log = get_logger()
 
@@ -45,10 +46,11 @@ def local_uids(
     if limit:
         q = q.order_by(desc(ImapUid.msg_uid))
         q = q.limit(bindparam("limit"))
-    q = q.params(account_id=account_id, folder_id=folder_id, limit=limit).yield_per(
-        1000
-    )
-    return {uid for uid, in q}
+    q = q.params(account_id=account_id, folder_id=folder_id, limit=limit)
+
+    db_api_cursor = get_db_api_cursor_with_query(session, q)
+
+    return {uid for uid, in db_api_cursor.fetchall()}
 
 
 def lastseenuid(account_id, session, folder_id):

--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -36,6 +36,13 @@ log = get_logger()
 def local_uids(
     account_id: int, session, folder_id: int, limit: "int | None" = None
 ) -> "set[int]":
+    """
+    Get the local UIDs of all messages in a folder.
+
+    Note that these days a lot email inboxes can have millions of messages in it,
+    and we prefer to skip SQLAlchemy's ORM layer when fetching these UIDs
+    from the database as it's a lot faster.
+    """
     q = session.query(ImapUid.msg_uid).with_hint(
         ImapUid, "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)"
     )
@@ -48,6 +55,7 @@ def local_uids(
         q = q.limit(bindparam("limit"))
     q = q.params(account_id=account_id, folder_id=folder_id, limit=limit)
 
+    # We're using a raw DB-API cursor here to avoid the overhead of the ORM.
     db_api_cursor = get_db_api_cursor_with_query(session, q)
 
     return {uid for uid, in db_api_cursor.fetchall()}

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -7,7 +7,6 @@ import weakref
 from typing import Any, MutableMapping, Optional, Tuple
 
 from sqlalchemy import String, Text, event
-from sqlalchemy.dialects import mysql
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.pool import QueuePool
@@ -364,9 +363,6 @@ def safer_yield_per(query, id_field, start_id, count):
         cur_id = results[-1].id + 1
 
 
-mysql_dialect = mysql.dialect()
-
-
 def get_db_api_cursor_with_query(session, query):
     """
     Return a DB-API cursor with the given SQLAlchemy query executed.
@@ -377,7 +373,8 @@ def get_db_api_cursor_with_query(session, query):
     SQLAlchemy ORM has to instantiate several Python objects for each row
     returned by the query, which can be a performance bottleneck.
     """
-    compiled_query = query.statement.compile(dialect=mysql_dialect)
+    dialect = session.get_bind().dialect
+    compiled_query = query.statement.compile(dialect=dialect)
 
     db_api_cursor = session.connection().connection.cursor()
     db_api_cursor.execute(compiled_query.string, compiled_query.params.values())

--- a/inbox/sqlalchemy_ext/util.py
+++ b/inbox/sqlalchemy_ext/util.py
@@ -368,6 +368,15 @@ mysql_dialect = mysql.dialect()
 
 
 def get_db_api_cursor_with_query(session, query):
+    """
+    Return a DB-API cursor with the given SQLAlchemy query executed.
+
+    This is useful when you want to optimize and skip the machinery of
+    SQLAlchemy ORM, particularly when you want to execute
+    a query that returns a large number of rows with a couple of columns.
+    SQLAlchemy ORM has to instantiate several Python objects for each row
+    returned by the query, which can be a performance bottleneck.
+    """
     compiled_query = query.statement.compile(dialect=mysql_dialect)
 
     db_api_cursor = session.connection().connection.cursor()


### PR DESCRIPTION
This function is called a lot and it shows in the profiles as the busiest function. I've used [py-spy](https://github.com/benfred/py-spy) to obtain those profiles in production.

I discovered that the SQLAlchemy "post-processing" which just creates intermediate objects to handle all the possible shapes that SQLAlchemy supports takes significant portion of this function runtime. You can see a lot of SQLAlchemy fiddling below the call to it, the actual execution in MySQL is 50% of time.

<img width="1192" alt="Screenshot 2024-10-24 at 19 13 42" src="https://github.com/user-attachments/assets/a4c57cee-e0ef-471a-8a37-b7461eb6dcb0">

Since this is a trivial query that returns a single column we can easily rewrite it to use driver's DB-API which is still portable between different databases ([PEP](https://peps.python.org/pep-0249/)) which means that it's 2 times faster now as it only spends time executing.

<img width="1206" alt="Screenshot 2024-10-24 at 19 11 06" src="https://github.com/user-attachments/assets/b1f2e83e-71f2-48a2-aa6d-22cb73156413">


Just the other day I was dealing with a case when this function can return 24 million rows for a single folder, so performance here is critical.