### PR TITLE
Bump mysqlclient version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update \
     make \
     gcc \
     git \
+    pkg-config \
     python3.9-dev \
     python3-pip \
     libmysqlclient-dev \

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Callable
 from typing import Any, Iterable, TypeVar
 
-import _mysql_exceptions
+from MySQLdb import _mysql_exceptions
 from redis import TimeoutError
 from sqlalchemy.exc import StatementError
 

--- a/inbox/util/concurrency.py
+++ b/inbox/util/concurrency.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Callable
 from typing import Any, Iterable, TypeVar
 
-from MySQLdb import _mysql_exceptions
+from MySQLdb import _exceptions as _mysql_exceptions
 from redis import TimeoutError
 from sqlalchemy.exc import StatementError
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -47,7 +47,7 @@ lxml==5.1.0
 Mako==1.2.2
 MarkupSafe==2.1.2
 matplotlib-inline==0.1.6
-mysqlclient==1.3.14
+mysqlclient==2.2.5
 parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5

--- a/tests/general/test_concurrency.py
+++ b/tests/general/test_concurrency.py
@@ -2,7 +2,7 @@ import socket
 import time
 
 import pytest
-from MySQLdb import _mysql_exceptions
+from MySQLdb import _exceptions as _mysql_exceptions
 from sqlalchemy.exc import StatementError
 
 from inbox.interruptible_threading import InterruptibleThreadExit

--- a/tests/general/test_concurrency.py
+++ b/tests/general/test_concurrency.py
@@ -1,8 +1,8 @@
 import socket
 import time
 
-import _mysql_exceptions
 import pytest
+from MySQLdb import _mysql_exceptions
 from sqlalchemy.exc import StatementError
 
 from inbox.interruptible_threading import InterruptibleThreadExit


### PR DESCRIPTION
So we are running very outdated version of mysql database driver (from 2019)... because they removed support for gevent long time ago. This also prevented us from updating to newer  Python versions (Past 3.9) because that old version of the driver no longer compiles on newer Pythons. Now that gevent is gone it's time to rectify this... Thank heavens there was not a single CVE against this in all those years, otherwise we would be screwed.

I tried this end to end locally but will also do canaries.

[Changelog](https://github.com/PyMySQL/mysqlclient/blob/main/HISTORY.rst):

```
What's new in 2.2.5

Release: 2024-10-20

    (Windows wheel) Update MariaDB Connector/C to 3.4.1. #726
    (Windows wheel) Build wheels for Python 3.13. #726

What's new in 2.2.4

Release: 2024-02-09

    Support ssl=True in connect(). (#700) This makes better compatibility with PyMySQL and mysqlclient==2.2.1 with libmariadb. See #698 for detail.

What's new in 2.2.3

Release: 2024-02-04

    Fix Connection.kill() method that broken in 2.2.2. (#689)

What's new in 2.2.2

Release: 2024-02-04

    Support building with MySQL 8.3 (#688).
    Deprecate db.shutdown() and db.kill() methods in docstring. This is because mysql_shutdown() and mysql_kill() were removed in MySQL 8.3. They will emit DeprecationWarning in the future but not for now.

What's new in 2.2.1

Release: 2023-12-13

    Connection.ping() avoid using MYSQL_OPT_RECONNECT option until reconnect=True is specified. MySQL 8.0.33 start showing warning when the option is used. (#664)
    Windows: Update MariaDB Connector/C to 3.3.8. (#665)
    Windows: Build wheels for Python 3.12 (#644)

What's new in 2.2.0

Release: 2023-06-22

    Use pkg-config instead of mysql_config (#586)
    Raise ProgrammingError on -inf (#557)
    Raise IntegrityError for ER_BAD_NULL. (#579)
    Windows: Use MariaDB Connector/C 3.3.4 (#585)
    Use pkg-config instead of mysql_config (#586)
    Add collation option (#564)
    Drop Python 3.7 support (#593)
    Use pyproject.toml for build (#598)
    Add Cursor.mogrify (#477)
    Partial support of ssl_mode option with mariadbclient (#475)
    Discard remaining results without creating Python objects (#601)
    Fix executemany with binary prefix (#605)

What's new in 2.1.1

Release: 2022-06-22

    Fix qualname of exception classes. (#522)
    Fix range check in MySQLdb._mysql.result.fetch_row(). Invalid how argument caused SEGV. (#538)
    Fix docstring of _mysql.connect. (#540)

    Windows: Binary wheels are updated. (#541)
            Use MariaDB Connector/C 3.3.1.
            Use cibuildwheel to build wheels.
            Python 3.8-3.11

What's new in 2.1.0

Release: 2021-11-17

    Add multistatement=True option. You can disable multi statement. (#500).
    Remove unnecessary bytes encoder which is remained for Django 1.11 compatibility (#490).
    Deprecate passwd and db keyword. Use password and database instead. (#488).
    Windows: Binary wheels are built with MariaDB Connector/C 3.2.4. (#508)
    set_character_set() sends SET NAMES query always. This means all new connections send it too. This solves compatibility issues when server and client library are different version. (#509)
    Remove escape() and escape_string() from MySQLdb package. (#511)
    Add Python 3.10 support and drop Python 3.5 support.

What's new in 2.0.3

Release: 2021-01-01

    Add -std=c99 option to cflags by default for ancient compilers that doesn't accept C99 by default.
    You can customize cflags and ldflags by setting MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS. It overrides mysql_config.

What's new in 2.0.2

Release: 2020-12-10

    Windows: Update MariaDB Connector/C to 3.1.11.
    Optimize fetching many rows with DictCursor.

What's new in 2.0.1

Release: 2020-07-03

    Fixed multithread safety issue in fetching row.
    Removed obsolete members from Cursor. (e.g. messages, _warnings, _last_executed)

What's new in 2.0.0

Release: 2020-07-02

    Dropped Python 2 support
    Dropped Django 1.11 support
    Add context manager interface to Connection which closes the connection on __exit__.
    Add ssl_mode option.

What's new in 1.4.6

Release: 2019-11-21

    The cp1252 encoding is used when charset is "latin1". (#390)

What's new in 1.4.5

Release: 2019-11-06

    The auth_plugin option is added. (#389)

What's new in 1.4.4

Release: 2019-08-12

    charset option is passed to mysql_options(mysql, MYSQL_SET_CHARSET_NAME, charset) before mysql_real_connect is called. This avoid extra SET NAMES <charset> query when creating connection.

What's new in 1.4.3

Release: 2019-08-09

    --static build supports libmariadbclient.a
    Try mariadb_config when mysql_config is not found
    Fixed warning happened in Python 3.8 (#359)
    Fixed from MySQLdb import *, while I don't recommend it. (#369)
    Fixed SEGV MySQLdb.escape_string("1") when libmariadb is used and no connection is created. (#367)
    Fixed many circular references are created in Cursor.executemany(). (#375)

What's new in 1.4.2

Release: 2019-02-08

    Fix Django 1.11 compatibility. (#327) mysqlclient 1.5 will not support Django 1.11. It is not because mysqlclient will break backward compatibility, but Django used unsupported APIs and Django 1.11 don't fix bugs including compatibility issues.

What's new in 1.4.1

Release: 2019-01-19

    Fix dict parameter support (#323, regression of 1.4.0)

What's new in 1.4.0

Release: 2019-01-18

    Dropped Python 3.4 support.
    Removed threadsafe and embedded build options.
    Remove some deprecated cursor classes and methods.
    _mysql and _mysql_exceptions modules are moved under MySQLdb package. (#293)
    Remove errorhandler from Connection and Cursor classes.
    Remove context manager API from Connection. It was for transaction. New context manager API for closing connection will be added in future version.
    Remove waiter option from Connection.
    Remove escape_sequence, and escape_dict methods from Connection class.
    Remove automatic MySQL warning checking.
    Drop support for MySQL Connector/C with MySQL<5.1.12.
    Remove _mysql.NULL constant.
    Remove _mysql.thread_safe() function.
    Support non-ASCII field name with non-UTF-8 connection encoding. (#210)
    Optimize decoding speed of string and integer types.
    Remove MySQLdb.constants.REFRESH module.
    Remove support for old datetime format for MySQL < 4.1.
    Fix wrong errno is raised when mysql_real_connect is failed. (#316)

```
