### PR TITLE
Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # --- Stage 0 --- #
 # This first stage is responsible for installing any dependencies the app needs
 # to run, and updating any base dependencies.
-FROM ubuntu:22.04 AS stage_0
+FROM ubuntu:24.04 AS stage_0
 
 RUN groupadd -g 5000 sync-engine \
   && useradd -d /home/sync-engine -m -u 5000 -g 5000 sync-engine
@@ -24,7 +24,7 @@ RUN echo $BUILD_WEEK && apt-get update \
     gpg \
     gpg-agent \
     dirmngr \
-    python3.10 \
+    python3.12 \
     gettext-base \
     libmysqlclient21 \
     mysql-client \
@@ -54,16 +54,16 @@ RUN apt-get update \
     gcc \
     git \
     pkg-config \
-    python3.10-dev \
+    python3.12-dev \
+    python3.12-venv \
     python3-pip \
     libmysqlclient-dev \
   && rm -rf /var/lib/apt/lists/*
 
 COPY /requirements/ /requirements/
-RUN python3.10 -m pip install pip==24.3.1 virtualenv==20.27.0 && \
-  python3.10 -m virtualenv /opt/venv && \
-  /opt/venv/bin/python3.10 -m pip install --no-cache --no-deps -r /requirements/prod.txt -r /requirements/test.txt && \
-  /opt/venv/bin/python3.10 -m pip check
+RUN python3.12 -m venv /opt/venv && \
+  /opt/venv/bin/python3.12 -m pip install --no-cache --no-deps -r /requirements/prod.txt -r /requirements/test.txt && \
+  /opt/venv/bin/python3.12 -m pip check
 
 
 # --- Stage 2 --- #

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -69,6 +69,7 @@ requests-file==1.5.1
 rollbar==0.16.2
 s3transfer==0.10.3
 setproctitle==1.2.2
+setuptools==75.2.0
 six==1.16.0
 sqlalchemy==1.4.54
 statsd==3.3.0


### PR DESCRIPTION
I've already started testing this end to end on single pods where my email is synced, will of course do a canary.

<!-- start git-machete generated -->

# Based on PR #959

TODO:

* [x] Replace boto with boto3
* [x] Open [issue](https://github.com/closeio/limitlion/issues/37) on limitlion about setuptools dependency on Python 3.12

## Full chain of PRs as of 2024-10-28

* PR #960:
  `python-312` ➔ `python-310`
* PR #959:
  `python-310` ➔ `master`

<!-- end git-machete generated -->
