### PR TITLE
Use boto3

### DIFF
--- a/etc/secrets-test.yml
+++ b/etc/secrets-test.yml
@@ -8,9 +8,7 @@ AUTHALLIGATOR_AUTH_KEY: super-secret-authalligator-auth-key
 TEMP_MESSAGE_STORE_BUCKET_NAME: sync-engine
 AWS_ACCESS_KEY_ID: sync-engine
 AWS_SECRET_ACCESS_KEY: sync-engine
-AWS_S3_HOST: minio
-AWS_S3_PORT: 9000
-AWS_S3_IS_SECURE: false
+AWS_S3_ENDPOINT_URL: http://minio:9000
 
 
 # Hexl-encoded static keys used to encrypt blocks in S3, secrets in database:

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,9 +8,8 @@ git+https://github.com/closeio/authalligator-client.git@e7cc8e0bc5b1f2285ab5997e
 async_timeout==4.0.3
 backcall==0.2.0
 jedi==0.18.2
-boto==2.49.0
-boto3==1.19.4
-botocore==1.22.9
+boto3==1.35.50
+botocore==1.35.50
 certifi==2024.8.30
 cffi==1.15.1
 chardet==3.0.4
@@ -68,7 +67,7 @@ regex==2021.11.10
 requests==2.32.3
 requests-file==1.5.1
 rollbar==0.16.2
-s3transfer==0.5.0
+s3transfer==0.10.3
 setproctitle==1.2.2
 six==1.16.0
 sqlalchemy==1.4.54


### PR DESCRIPTION
The code that is uploading/downloading things from S3 still used outdated [boto](https://pypi.org/project/boto/) library (last released in 2018 💀). That library is no longer maintained and does not work on newer Python versions. I dropped that old library and ported it to boto3 (which we had in requirements but were not using at all 🤡). I updated boto3 at the same time.

Note that we are using minio locally to do real requests to S3 test double, so this is fairly well tested but I'll canary as well.