### PR TITLE
Update cffi version

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -12,7 +12,7 @@ boto==2.49.0
 boto3==1.19.4
 botocore==1.22.9
 certifi==2024.8.30
-cffi==1.15.1
+cffi==1.17.1
 chardet==3.0.4
 charset-normalizer==3.1.0
 ciso8601==2.2.0


### PR DESCRIPTION
Needed for later versions of Python.

[Changelog](https://cffi.readthedocs.io/en/latest/whatsnew.html)

```
v1.17.1[¶](https://cffi.readthedocs.io/en/latest/whatsnew.html#v1-17-1)

    Fix failing distutils.msvc9compiler imports under Windows ([#118](https://github.com/python-cffi/cffi/pull/118)).

    ffibuilder.emit_python_code() and ffibuiler.emit_c_code() accept file-like objects ([#115](https://github.com/python-cffi/cffi/pull/115)).

    ffiplatform calls are bypassed by ffibuilder.emit_python_code() and ffibuilder.emit_c_code() ([#81](https://github.com/python-cffi/cffi/pull/81)).

v1.17.0

    In API mode, when you get a function from a C library by writing fn = lib.myfunc, you get an object of a special type for performance reasons, instead of a <cdata ‘C-function-type’>. Before version 1.17 you could only call such objects. You could write ffi.addressof(lib, “myfunc”) in order to get a real <cdata> object, based on the idea that in these cases in C you’d usually write &myfunc instead of myfunc. In version 1.17, the special object lib.myfunc can now be passed in many places where CFFI expects a regular <cdata> object. For example, you can now pass it as a callback to a C function call, or write it inside a C structure field of the correct pointer-to-function type, or use ffi.cast() or ffi.typeof() on it.

v1.16.0

    Add support for Python 3.12. With the removal of distutils from Python 3.12, projects using CFFI features that depend on distutils at runtime must add a dependency on setuptools to function under Python 3.12+. CFFI does not declare a runtime setuptools requirement to avoid an unnecessary dependency for projects that do not require it.

    Drop support for end-of-life Python versions (2.7, 3.6, 3.7).

    Add support for PEP517 builds; setuptools is now a required build dependency.

    Declare python_requires metadata for Python 3.8+. This allows unsupported Pythons to continue using previously released sdists and wheels.

    Upstream project hosting moved from Heptapod to [GitHub](https://github.com/python-cffi/cffi).
```

Reverse dependencies

```
root@078a440d3ac8:/# /opt/venv/bin/pipdeptree -r -p cffi
cffi==1.17.1
├── cryptography==43.0.1 [requires: cffi>=1.12]
│   └── flanker==0.9.11 [requires: cryptography>=0.5]
└── PyNaCl==1.5.0 [requires: cffi>=1.4.1]
```