### PR TITLE
Tune logging for s3transfer

### DIFF
--- a/inbox/util/logging_helper.py
+++ b/inbox/util/logging_helper.py
@@ -4,6 +4,6 @@ import logging
 
 
 def reconfigure_logging():
-    logging.getLogger("boto").setLevel(logging.ERROR)
     logging.getLogger("boto3").setLevel(logging.ERROR)
     logging.getLogger("botocore").setLevel(logging.ERROR)
+    logging.getLogger("s3transfer").setLevel(logging.ERROR)


### PR DESCRIPTION
After replacing boto with boto3 in [this PR](https://github.com/closeio/sync-engine/pull/961) I've seen in production that it started logging a lot.

```

2024-10-29 15:02:30.400	s3transfer.utils - DEBUG: Releasing acquire 0/None
2024-10-29 15:02:30.398	s3transfer.tasks - DEBUG: Executing task PutObjectTask(transfer_id=0, {'bucket': '...', 'key': '...', 'extra_args': {}}) with kwargs {'client': <botocore.client.S3 object at 0x73310037efe0>, 'fileobj': <s3transfer.utils.ReadFileChunk object at 0x733130fc3850>, 'bucket': '...', 'key': '...', 'extra_args': {}}

```

Every time it uploads something to S3, and it does it a lot taking a lot of logging space. Previously we had boto tweaked here already so we just need to tweak s3transfer similarly.