### PR TITLE
Batch and optimize large deletions

### DIFF
--- a/inbox/mailsync/backends/gmail.py
+++ b/inbox/mailsync/backends/gmail.py
@@ -281,7 +281,11 @@ class GmailFolderSyncEngine(FolderSyncEngine):
                 uid.update_flags(raw_message.flags)
                 uid.update_labels(raw_message.g_labels)
                 common.update_message_metadata(
-                    db_session, account, message_obj, uid.is_draft
+                    db_session,
+                    account.id,
+                    account.category_type,
+                    message_obj,
+                    uid.is_draft,
                 )
                 db_session.commit()
 

--- a/tests/imap/test_delete_handling.py
+++ b/tests/imap/test_delete_handling.py
@@ -37,7 +37,7 @@ def test_messages_deleted_asynchronously(
         db.session,
     )
     assert "label" in [cat.display_name for cat in message.categories]
-    remove_deleted_uids(default_account.id, folder.id, [msg_uid])
+    remove_deleted_uids(default_account.id, folder.id, {msg_uid})
     db.session.expire_all()
     assert abs((message.deleted_at - datetime.utcnow()).total_seconds()) < 2
     # Check that message categories do get updated synchronously.
@@ -50,7 +50,7 @@ def test_drafts_deleted_synchronously(
     message.is_draft = True
     db.session.commit()
     msg_uid = imapuid.msg_uid
-    remove_deleted_uids(default_account.id, folder.id, [msg_uid])
+    remove_deleted_uids(default_account.id, folder.id, {msg_uid})
     db.session.expire_all()
     with pytest.raises(ObjectDeletedError):
         message.id
@@ -72,7 +72,7 @@ def test_deleting_from_a_message_with_multiple_uids(
 
     assert len(message.imapuids) == 2
 
-    remove_deleted_uids(default_account.id, inbox_folder.id, [2222])
+    remove_deleted_uids(default_account.id, inbox_folder.id, {2222})
     db.session.expire_all()
 
     assert (

--- a/tests/imap/test_labels.py
+++ b/tests/imap/test_labels.py
@@ -32,7 +32,13 @@ def folder_and_message_maps(db, default_account):
         # Create a message in the folder
         message = add_fake_message(db.session, default_account.namespace.id, thread)
         add_fake_imapuid(db.session, default_account.id, message, folder, 13)
-        update_message_metadata(db.session, default_account, message, False)
+        update_message_metadata(
+            db.session,
+            default_account.id,
+            default_account.category_type,
+            message,
+            False,
+        )
         db.session.commit()
         folder_map[name] = folder
         message_map[name] = message
@@ -42,11 +48,18 @@ def folder_and_message_maps(db, default_account):
 def add_inbox_label(db, default_account, message):
     assert len(message.imapuids) == 1
     imapuid = message.imapuids[0]
-    assert {c.name for c in imapuid.categories} == {"all"}
+    assert {c.name for c in imapuid.get_categories(default_account.category_type)} == {
+        "all"
+    }
     imapuid.update_labels(["\\Inbox"])
     db.session.commit()
-    assert {c.name for c in imapuid.categories} == {"all", "inbox"}
-    update_message_metadata(db.session, default_account, message, False)
+    assert {c.name for c in imapuid.get_categories(default_account.category_type)} == {
+        "all",
+        "inbox",
+    }
+    update_message_metadata(
+        db.session, default_account.id, default_account.category_type, message, False
+    )
     db.session.commit()
     return message
 
@@ -54,11 +67,18 @@ def add_inbox_label(db, default_account, message):
 def add_custom_label(db, default_account, message):
     assert len(message.imapuids) == 1
     imapuid = message.imapuids[0]
-    existing = [c.name for c in imapuid.categories][0]
+    existing = [c.name for c in imapuid.get_categories(default_account.category_type)][
+        0
+    ]
     imapuid.update_labels(["<3"])
     db.session.commit()
-    assert {c.name for c in imapuid.categories} == {existing, ""}
-    update_message_metadata(db.session, default_account, message, False)
+    assert {c.name for c in imapuid.get_categories(default_account.category_type)} == {
+        existing,
+        "",
+    }
+    update_message_metadata(
+        db.session, default_account.id, default_account.category_type, message, False
+    )
     db.session.commit()
     return message
 

--- a/tests/imap/test_update_metadata.py
+++ b/tests/imap/test_update_metadata.py
@@ -68,7 +68,9 @@ def test_update_categories_when_actionlog_entry_missing(
 ):
     message.categories_changes = True
     db.session.commit()
-    update_message_metadata(db.session, imapuid.account, message, False)
+    update_message_metadata(
+        db.session, imapuid.account.id, imapuid.account.category_type, message, False
+    )
     assert message.categories == {imapuid.folder.category}
 
 
@@ -112,7 +114,9 @@ def test_categories_from_multiple_imap_folders(
         imapuid.updated_at = imapuid.updated_at + datetime.timedelta(seconds=delay)
         db.session.commit()
 
-    update_message_metadata(db.session, generic_account, message, False)
+    update_message_metadata(
+        db.session, generic_account.id, generic_account.category_type, message, False
+    )
     assert {category.name for category in message.categories} == categories
 
     delete_imapuids(db.session)


### PR DESCRIPTION
After https://github.com/closeio/sync-engine/pull/969 we got RAM and CPU usage under control.

The other problem with this code is that it can be painfully slow, especially with large deletions.

I know we have at least on escalation because of the slowness of this code where customer is using automation to move large amounts of emails between folders.

There are two problems here:
- For non conforming IMAP servers that can list one message under many uids we were deleting uids one by one and then updating a message, for such cases it's thousand of times much faster to delete all the uids in one go and then update message.
- We had N+1 queries when recalculating email categories
