### PR TITLE
Upgrade Werkzeug to 3.0.6

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -82,6 +82,6 @@ urllib3==1.26.20
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.8
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 zipp==3.20.2
 zstandard==0.23.0


### PR DESCRIPTION
Addresses [CVE-2024-49767](https://nvd.nist.gov/vuln/detail/CVE-2024-49767)

Dependencies before upgrade (from `pipdeptree -p werkzeug`):
```
Werkzeug==3.0.3
└── MarkupSafe [required: >=2.1.1, installed: 2.1.2]
```

Dependencies after upgrade (from `pipdeptree -p werkzeug`):
```
Werkzeug==3.0.6
└── MarkupSafe [required: >=2.1.1, installed: 2.1.2]
```

Changelog:
```
Version 3.0.6
-------------

Released 2024-10-25

-   Fix how ``max_form_memory_size`` is applied when parsing large non-file
    fields. :ghsa:`q34m-jh98-gwm2`
-   ``safe_join`` catches certain paths on Windows that were not caught by
    ``ntpath.isabs`` on Python < 3.11. :ghsa:`f9vj-2wh5-fj8j`


Version 3.0.5
-------------

Released 2024-10-24

-   The Watchdog reloader ignores file closed no write events. :issue:`2945`
-   Logging works with client addresses containing an IPv6 scope :issue:`2952`
-   Ignore invalid authorization parameters. :issue:`2955`
-   Improve type annotation fore ``SharedDataMiddleware``. :issue:`2958`
-   Compatibility with Python 3.13 when generating debugger pin and the current
    UID does not have an associated name. :issue:`2957`


Version 3.0.4
-------------

Released 2024-08-21

-   Restore behavior where parsing `multipart/x-www-form-urlencoded` data with
    invalid UTF-8 bytes in the body results in no form data parsed rather than a
    413 error. :issue:`2930`
-   Improve ``parse_options_header`` performance when parsing unterminated
    quoted string values. :issue:`2904`
-   Debugger pin auth is synchronized across threads/processes when tracking
    failed entries. :issue:`2916`
-   Dev server handles unexpected `SSLEOFError` due to issue in Python < 3.13.
    :issue:`2926`
-   Debugger pin auth works when the URL already contains a query string.
    :issue:`2918`
```