### PR TITLE
Fix noqa comments breaking shebangs

### DIFF
--- a/bin/backfix-duplicate-categories.py
+++ b/bin/backfix-duplicate-categories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 # Duplicate categories were created because of an inadequate unique constraint
 # in MySQL. This script deletes duplicate categories with no messages
 # associated. If two or more duplicate categories exist with associated

--- a/bin/backfix-generic-imap-separators.py
+++ b/bin/backfix-generic-imap-separators.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 # We previously didn't store IMAP path separators for generic imap accounts.
 # This script backfixes the accounts.
 

--- a/bin/check-attachments.py
+++ b/bin/check-attachments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 # Check that we can fetch attachments for 99.9% of our syncing accounts.
 import concurrent.futures
 import datetime

--- a/bin/clear-all-heartbeats.py
+++ b/bin/clear-all-heartbeats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 from sys import exit

--- a/bin/clear-db.py
+++ b/bin/clear-db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 import argparse
 import sys
 

--- a/bin/clear-heartbeat-status.py
+++ b/bin/clear-heartbeat-status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 from sys import exit

--- a/bin/clear-kv.py
+++ b/bin/clear-kv.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 from sys import exit
 

--- a/bin/correct-autoincrements.py
+++ b/bin/correct-autoincrements.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import click

--- a/bin/create-db.py
+++ b/bin/create-db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import os

--- a/bin/create-encryption-keys.py
+++ b/bin/create-encryption-keys.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import binascii

--- a/bin/create-event-contact-associations.py
+++ b/bin/create-event-contact-associations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 """
 Create event contact associations for events that don't have any.
 """

--- a/bin/delete-account-data.py
+++ b/bin/delete-account-data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 """
 Deletes an account's data permanently.
 

--- a/bin/delete-marked-accounts.py
+++ b/bin/delete-marked-accounts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 """
 Searches for accounts that are marked for deletion and deletes
 all of their data

--- a/bin/detect-missing-sync-host.py
+++ b/bin/detect-missing-sync-host.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import click

--- a/bin/get-accounts-for-host.py
+++ b/bin/get-accounts-for-host.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import click

--- a/bin/get-accounts-for-host.py
+++ b/bin/get-accounts-for-host.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: EXE001, N999
+#!/usr/bin/env python  # noqa: N999
 
 
 import click

--- a/bin/get-id.py
+++ b/bin/get-id.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 # Query the id corresponding to a public id and vice-versa.
 
 

--- a/bin/get-object.py
+++ b/bin/get-object.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 # Query the id corresponding to a public id and vice-versa.
 
 

--- a/bin/inbox-api.py
+++ b/bin/inbox-api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 import os
 import sys

--- a/bin/inbox-auth.py
+++ b/bin/inbox-auth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import sys

--- a/bin/inbox-console.py
+++ b/bin/inbox-console.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 from setproctitle import setproctitle

--- a/bin/inbox-start.py
+++ b/bin/inbox-start.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import os

--- a/bin/migrate-db.py
+++ b/bin/migrate-db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import os

--- a/bin/mysql-prompt.py
+++ b/bin/mysql-prompt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import subprocess

--- a/bin/purge-transaction-log.py
+++ b/bin/purge-transaction-log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 """
 Deletes entries in the transaction older than `days_ago` days( as measured by
 the created_at column)

--- a/bin/remove-message-attachments.py
+++ b/bin/remove-message-attachments.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 import datetime
 import enum
 import logging

--- a/bin/restart-forgotten-accounts.py
+++ b/bin/restart-forgotten-accounts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: EXE001, N999
+#!/usr/bin/env python  # noqa: N999
 
 import time
 

--- a/bin/restart-forgotten-accounts.py
+++ b/bin/restart-forgotten-accounts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 import time
 

--- a/bin/set-desired-host.py
+++ b/bin/set-desired-host.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import click

--- a/bin/set-desired-host.py
+++ b/bin/set-desired-host.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: EXE001, N999
+#!/usr/bin/env python  # noqa: N999
 
 
 import click

--- a/bin/set-throttled.py
+++ b/bin/set-throttled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: EXE001, N999
+#!/usr/bin/env python  # noqa: N999
 # throttle or unthrottle an account
 
 

--- a/bin/set-throttled.py
+++ b/bin/set-throttled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 # throttle or unthrottle an account
 
 

--- a/bin/stamp-db.py
+++ b/bin/stamp-db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import os

--- a/bin/sync-single-account.py
+++ b/bin/sync-single-account.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 import logging
 from threading import BoundedSemaphore

--- a/bin/syncback-service.py
+++ b/bin/syncback-service.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 """
 Run the syncback service separately. You should run this if you run the
 API under something like gunicorn. (For convenience, the bin/inbox-api script

--- a/bin/syncback-stats.py
+++ b/bin/syncback-stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 import click
 from sqlalchemy import func

--- a/bin/unschedule-account-syncs.py
+++ b/bin/unschedule-account-syncs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import click

--- a/bin/update-categories.py
+++ b/bin/update-categories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 import click

--- a/bin/verify-db.py
+++ b/bin/verify-db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python  # noqa: N999
+#!/usr/bin/env python
 
 
 from inbox.config import config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,6 @@ unfixable = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"bin/**.py" = ["T201", "E402"]
+"bin/**.py" = ["T201", "E402", "N999"]
 "migrations/**.py" = ["T201", "E402"]
 "tests/**.py" = ["ANN"]


### PR DESCRIPTION
Broken here: https://github.com/closeio/sync-engine/pull/985

[EXE001](https://docs.astral.sh/ruff/rules/shebang-not-executable/) and [N999](https://docs.astral.sh/ruff/rules/invalid-module-name/) are ruff rules. I added `# noqa` comments to ignore them in certain files [here](https://github.com/closeio/sync-engine/pull/985), which broke some scripts - they will no longer run properly when `# noqa` comments are present on the same line as a shebang.

Review commits separately.