### PR TITLE
Map "INBOX.Archiv" to "archive" in folder settings

### DIFF
--- a/inbox/providers.py
+++ b/inbox/providers.py
@@ -443,6 +443,7 @@ providers: dict[str, dict[str, Any]] = {
         "auth": "password",
         "folder_map": {
             "INBOX.Archive": "archive",
+            "INBOX.Archiv": "archive",
             "INBOX.Drafts": "drafts",
             "INBOX.Junk Mail": "spam",
             "INBOX.Trash": "trash",

--- a/inbox/providers.py
+++ b/inbox/providers.py
@@ -443,6 +443,7 @@ providers: dict[str, dict[str, Any]] = {
         "auth": "password",
         "folder_map": {
             "INBOX.Archive": "archive",
+            # Support German naming for Archive folder
             "INBOX.Archiv": "archive",
             "INBOX.Drafts": "drafts",
             "INBOX.Junk Mail": "spam",


### PR DESCRIPTION
Add support for the alternate folder name "INBOX.Archiv" to properly map it to the "archive" folder. This enhances compatibility with email providers using this naming convention.

We previously [added support for German "archiv"](https://github.com/closeio/sync-engine/pull/468) to the default folders. Custom providers use the `INBOX.Archive` format, and we now have a German custom email provider that uses `INBOX.Archiv`.