### PR TITLE
Allow ordering messages by received date ascending

### DIFF
--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -237,6 +237,7 @@ def messages_or_drafts(  # type: ignore[no-untyped-def]  # noqa: ANN201
     in_,
     unread,
     starred,
+    order_by,
     limit,
     offset,
     view,
@@ -476,7 +477,15 @@ def messages_or_drafts(  # type: ignore[no-untyped-def]  # noqa: ANN201
         res = query.params(**param_dict).one()[0]
         return {"count": res}
 
-    query = query.order_by(desc(Message.received_date))
+    if not order_by:
+        query = query.order_by(desc(Message.received_date))
+    elif order_by == "received_date":
+        query = query.order_by(asc(Message.received_date))
+    elif order_by == "-received_date":
+        query = query.order_by(desc(Message.received_date))
+    else:
+        raise ValueError(f"Unknown 'order_by' value: '{order_by}'")
+
     query = query.limit(bindparam("limit"))
     if offset:
         query = query.offset(bindparam("offset"))

--- a/inbox/api/ns_api.py
+++ b/inbox/api/ns_api.py
@@ -554,6 +554,7 @@ def message_query_api():  # type: ignore[no-untyped-def]  # noqa: ANN201
     g.parser.add_argument("thread_id", type=valid_public_id, location="args")
     g.parser.add_argument("unread", type=strict_bool, location="args")
     g.parser.add_argument("starred", type=strict_bool, location="args")
+    g.parser.add_argument("order_by", type=bounded_str, location="args")
     g.parser.add_argument("view", type=view, location="args")
 
     args = strict_parse_args(g.parser, request.args)
@@ -578,6 +579,7 @@ def message_query_api():  # type: ignore[no-untyped-def]  # noqa: ANN201
         in_=args["in"],
         unread=args["unread"],
         starred=args["starred"],
+        order_by=args["order_by"],
         limit=args["limit"],
         offset=args["offset"],
         view=args["view"],
@@ -1739,6 +1741,7 @@ def draft_query_api():  # type: ignore[no-untyped-def]  # noqa: ANN201
     g.parser.add_argument("thread_id", type=valid_public_id, location="args")
     g.parser.add_argument("unread", type=strict_bool, location="args")
     g.parser.add_argument("starred", type=strict_bool, location="args")
+    g.parser.add_argument("order_by", type=bounded_str, location="args")
     g.parser.add_argument("view", type=view, location="args")
 
     args = strict_parse_args(g.parser, request.args)
@@ -1763,6 +1766,7 @@ def draft_query_api():  # type: ignore[no-untyped-def]  # noqa: ANN201
         in_=args["in"],
         unread=args["unread"],
         starred=args["starred"],
+        order_by=args["order_by"],
         limit=args["limit"],
         offset=args["offset"],
         view=args["view"],


### PR DESCRIPTION
Allow ordering messages by received date ascending. (And leaves room for more configurable options in the future if desired.) This is useful when debugging things related to syncing emails into Close, and you want to see emails in the order they arrived to understand how the code on the Close side was run.