### PR TITLE
Allow busting cache in docker builds and fix `DOCKER_WEEK`

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -97,6 +97,8 @@ jobs:
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#nobuildcache')" ]; then
             echo 'BUILD_CACHE_BUST=${{ github.sha }}' >> $GITHUB_ENV
           fi
+          BUILD_WEEK=$(date +%Y-%V)
+          echo "BUILD_WEEK=${BUILD_WEEK}" >> $GITHUB_ENV
           DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG}-arm64"
@@ -134,6 +136,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILD_CACHE_BUST=${{ env.BUILD_CACHE_BUST }}
+            BUILD_WEEK=${{ env.BUILD_WEEK }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -94,6 +94,9 @@ jobs:
           if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#notests')" ]; then
             echo 'SKIP_TESTS="1"' >> $GITHUB_ENV
           fi
+          if [ "$(git log -1 --pretty=%B | head -n 1 | grep '#nobuildcache')" ]; then
+            echo 'BUILD_CACHE_BUST=${{ github.sha }}' >> $GITHUB_ENV
+          fi
           DOCKER_IMAGE_TAG=${{ env.DOCKERHUB_NAMESPACE }}/${{ env.PROJECT }}:${{ github.sha }}
           if [ "${{ matrix.arch }}" = "arm64" ]; then
             DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG}-arm64"
@@ -129,6 +132,8 @@ jobs:
             ${{ env.DOCKER_IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_CACHE_BUST=${{ env.BUILD_CACHE_BUST }}
 
       - name: Run tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV \
   DEBIAN_FRONTEND=noninteractive \
   PATH="/opt/venv/bin:$PATH"
 
-ARG BUILD_WEEK=0
+ARG BUILD_WEEK
 ARG BUILD_CACHE_BUST
 RUN echo $BUILD_WEEK $BUILD_CACHE_BUST && apt-get update \
   && apt-get dist-upgrade -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ ENV \
   PATH="/opt/venv/bin:$PATH"
 
 ARG BUILD_WEEK=0
-RUN echo $BUILD_WEEK && apt-get update \
+ARG BUILD_CACHE_BUST
+RUN echo $BUILD_WEEK $BUILD_CACHE_BUST && apt-get update \
   && apt-get dist-upgrade -y \
   && apt-get install --no-install-recommends -y \
     tzdata \


### PR DESCRIPTION
Normally, steps in a Docker build are cached to save time.

This change will let us trigger an almost full rebuild of the Docker image via an empty commit containing `#nobuildcache` in the message.

Such a rebuild may be necessary if we want to get upgraded versions of packages that we'd otherwise get from the cache.

Also, this PR fixes the `DOCKER_WEEK` Dockerfile argument that's supposed to bust the cache every week.