### PR TITLE
Fix the GitHub Actions workflow for branches with `/` in the name

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -2,8 +2,6 @@ name: Build and Release
 
 on:
   push:
-    branches:
-      - '*'
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Apparently using `*` breaks for branches with `/` in the name.