### PR TITLE
Upgrade `structlog` from `21.4.0` to `23.1.0`

### DIFF
--- a/inbox/logging.py
+++ b/inbox/logging.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import colorlog
 import structlog
+
+# TODO: Stop using this, `structlog.threadlocal` is deprecated
 from structlog.threadlocal import wrap_dict
 
 MAX_EXCEPTION_LENGTH = 10000

--- a/requirements/requirements-prod.in
+++ b/requirements/requirements-prod.in
@@ -80,7 +80,7 @@ sqlalchemy==1.4.54
 statsd==3.3.0
 stack-data==0.6.2
 tldextract==3.1.2
-structlog==21.4.0
+structlog==23.1.0
 traitlets==5.9.0
 typing_extensions
 urllib3==1.26.20

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -1089,9 +1089,9 @@ statsd==3.3.0 \
     --hash=sha256:c610fb80347fca0ef62666d241bce64184bd7cc1efe582f9690e045c25535eaa \
     --hash=sha256:e3e6db4c246f7c59003e51c9720a51a7f39a396541cb9b147ff4b14d15b5dd1f
     # via -r requirements-prod.in
-structlog==21.4.0 \
-    --hash=sha256:305a66201f9605a2e8a2595271a446f258175901c09c01e4c2c2a8ac5b68edf1 \
-    --hash=sha256:6ed8fadb27cf8362be0e606f5e79ccdd3b1e879aac65f9dc0ac3033fd013a7be
+structlog==23.1.0 \
+    --hash=sha256:270d681dd7d163c11ba500bc914b2472d2b50a8ef00faa999ded5ff83a2f906b \
+    --hash=sha256:79b9e68e48b54e373441e130fa447944e6f87a05b35de23138e475c05d0f7e0e
     # via
     #   -r requirements-prod.in
     #   authalligator-client


### PR DESCRIPTION
Changelog: https://github.com/hynek/structlog/blob/main/CHANGELOG.md

The upgrade is needed to get this fix for `render_to_log_kwargs`: https://github.com/hynek/structlog/pull/427
I need it for the Sentry integration.

Not seeing anything too risky in the changelog.
That said, I wouldn't ship this before the end of the company holidays.