### PR TITLE
Truncate long `Block.content_type`

### DIFF
--- a/inbox/models/block.py
+++ b/inbox/models/block.py
@@ -251,6 +251,13 @@ def serialize_before_insert(  # type: ignore[no-untyped-def]
         target._content_type_common = target.content_type
         target._content_type_other = None
     else:
+        if target.content_type and len(target.content_type) > 255:
+            target.content_type = target.content_type[:255]
+            log.warning(
+                "Block content_type is longer than 255 characters - truncating.",
+                truncated_content_type=target.content_type,
+            )
+
         target._content_type_common = None
         target._content_type_other = target.content_type
 


### PR DESCRIPTION
Fixes an issue where long attachment content types can cause database errors.
We've been getting the following error, because for one of the emails, an attachment's `Content-Type` header contained the base64-encoded attachment body for some reason (probably a bug on the side of one of the email providers):
```
DataError: (MySQLdb.DataError) (1406, "Data too long for column '_content_type_other' at row 1")
[SQL: INSERT INTO block (public_id, updated_at, deleted_at, data_sha256, size, _content_type_common, _content_type_other, filename, namespace_id) VALUES (...)
```