### PR TITLE
Detect IMAP disabled and stop syncing immediately

### DIFF
--- a/inbox/auth/google.py
+++ b/inbox/auth/google.py
@@ -2,7 +2,7 @@ import attr
 
 from inbox.config import config
 from inbox.crispin import GmailCrispinClient
-from inbox.exceptions import GMailDisabledError, IMAPDisabledError, OAuthError
+from inbox.exceptions import GmailDisabledError, IMAPDisabledError, OAuthError
 from inbox.logging import get_logger
 from inbox.models import Namespace
 from inbox.models.backends.gmail import GmailAccount
@@ -145,7 +145,7 @@ class GoogleAuthHandler(OAuthAuthHandler):
             )
             client.sync_folders()
             conn.logout()
-        except (GMailDisabledError, IMAPDisabledError):
+        except (GmailDisabledError, IMAPDisabledError):
             if account.sync_email:
                 raise
 

--- a/inbox/auth/google.py
+++ b/inbox/auth/google.py
@@ -2,7 +2,7 @@ import attr
 
 from inbox.config import config
 from inbox.crispin import GmailCrispinClient
-from inbox.exceptions import ImapSupportDisabledError, OAuthError
+from inbox.exceptions import GMailDisabledError, IMAPDisabledError, OAuthError
 from inbox.logging import get_logger
 from inbox.models import Namespace
 from inbox.models.backends.gmail import GmailAccount
@@ -145,7 +145,7 @@ class GoogleAuthHandler(OAuthAuthHandler):
             )
             client.sync_folders()
             conn.logout()
-        except ImapSupportDisabledError:
+        except (GMailDisabledError, IMAPDisabledError):
             if account.sync_email:
                 raise
 

--- a/inbox/auth/oauth.py
+++ b/inbox/auth/oauth.py
@@ -22,7 +22,7 @@ from imapclient import IMAPClient  # type: ignore[import-untyped]
 from inbox.config import config
 from inbox.exceptions import (
     ConnectionError,
-    GMailDisabledError,
+    GmailDisabledError,
     IMAPDisabledError,
     OAuthError,
     ValidationError,
@@ -248,7 +248,7 @@ class OAuthAuthHandler(AuthHandler):
 
             # Raise all IMAP disabled errors except authentication_failed
             # error, which we handle differently.
-            if isinstance(exc, GMailDisabledError | IMAPDisabledError):
+            if isinstance(exc, GmailDisabledError | IMAPDisabledError):
                 raise exc from original_exc
 
             log.warning(
@@ -350,7 +350,7 @@ def _process_imap_exception(exc):  # type: ignore[no-untyped-def]
     message = exc.args[0] if exc.args else ""
     if "Lookup failed" in message:
         # Gmail is disabled for this apps account
-        return GMailDisabledError(exc)
+        return GmailDisabledError(exc)
     elif "IMAP access is disabled for your domain." in message:
         # IMAP is disabled for this domain
         return IMAPDisabledError(exc)

--- a/inbox/auth/utils.py
+++ b/inbox/auth/utils.py
@@ -71,6 +71,10 @@ def is_error_message_invalid_auth(error_message: str) -> bool:
     )
 
 
+def is_error_message_disabled_imap(error_message: str) -> bool:
+    return "you are yet to enable imap" in error_message.lower()
+
+
 def create_imap_connection(  # type: ignore[no-untyped-def]  # noqa: ANN201
     host, port, use_timeout: bool = True
 ):

--- a/inbox/exceptions.py
+++ b/inbox/exceptions.py
@@ -30,10 +30,12 @@ class GmailSettingError(ValidationError):
     pass
 
 
-class ImapSupportDisabledError(ValidationError):
-    def __init__(self, reason=None) -> None:  # type: ignore[no-untyped-def]
-        super().__init__(reason)
-        self.reason = reason
+class GMailDisabledError(Exception):
+    pass
+
+
+class IMAPDisabledError(Exception):
+    pass
 
 
 class AccessNotEnabledError(Exception):

--- a/inbox/exceptions.py
+++ b/inbox/exceptions.py
@@ -30,7 +30,7 @@ class GmailSettingError(ValidationError):
     pass
 
 
-class GMailDisabledError(Exception):
+class GmailDisabledError(Exception):
     pass
 
 

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -188,9 +188,8 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
                 interruptible_threading.sleep(self.refresh_frequency)
                 self.start_new_folder_sync_engines()
         except ValidationError as exc:
-            log.error(  # noqa: G201
+            log.exception(
                 "Error authenticating; stopping sync",
-                exc_info=True,
                 account_id=self.account_id,
                 logstash_tag="mark_invalid",
             )
@@ -199,9 +198,8 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
                 account.mark_invalid()
                 account.update_sync_error(exc)
         except IMAPDisabledError as exc:
-            log.error(  # noqa: G201
+            log.exception(
                 "Error syncing, IMAP disabled; stopping sync",
-                exc_info=True,
                 account_id=self.account_id,
                 logstash_tag="mark_invalid",
             )

--- a/inbox/search/backends/imap.py
+++ b/inbox/search/backends/imap.py
@@ -35,17 +35,17 @@ class IMAPSearchClient:
             conn = account.auth_handler.get_authenticated_imap_connection(
                 account
             )
-        except (IMAPClient.Error, OSError, IMAP4.error):
-            raise SearchBackendException(  # noqa: B904
+        except (IMAPClient.Error, OSError, IMAP4.error) as exc:
+            raise SearchBackendException(
                 (
                     "Unable to connect to the IMAP "
                     "server. Please retry in a "
                     "couple minutes."
                 ),
                 503,
-            )
-        except ValidationError:
-            raise SearchBackendException(  # noqa: B904
+            ) from exc
+        except ValidationError as exc:
+            raise SearchBackendException(
                 (
                     "This search can't be performed "
                     "because the account's credentials "
@@ -53,16 +53,16 @@ class IMAPSearchClient:
                     "reauthenticate and try again."
                 ),
                 403,
-            )
-        except IMAPDisabledError:
-            raise SearchBackendException(  # noqa: B904
+            ) from exc
+        except IMAPDisabledError as exc:
+            raise SearchBackendException(
                 (
                     "This search can't be performed "
                     "because the account doesn't have IMAP enabled. "
                     "Enable IMAP and try again."
                 ),
                 403,
-            )
+            ) from exc
 
         try:
             acct_provider_info = provider_info(account.provider)

--- a/inbox/search/backends/imap.py
+++ b/inbox/search/backends/imap.py
@@ -5,7 +5,11 @@ from sqlalchemy import desc  # type: ignore[import-untyped]
 
 from inbox.api.kellogs import APIEncoder
 from inbox.crispin import CrispinClient, FolderMissingError
-from inbox.exceptions import NotSupportedError, ValidationError
+from inbox.exceptions import (
+    IMAPDisabledError,
+    NotSupportedError,
+    ValidationError,
+)
 from inbox.logging import get_logger
 from inbox.mailsync.backends.imap.generic import UidInvalid, uidvalidity_cb
 from inbox.models import Account, Folder, Message, Thread
@@ -47,6 +51,15 @@ class IMAPSearchClient:
                     "because the account's credentials "
                     "are out of date. Please "
                     "reauthenticate and try again."
+                ),
+                403,
+            )
+        except IMAPDisabledError:
+            raise SearchBackendException(  # noqa: B904
+                (
+                    "This search can't be performed "
+                    "because the account doesn't have IMAP enabled. "
+                    "Enable IMAP and try again."
                 ),
                 403,
             )

--- a/inbox/util/testutils.py
+++ b/inbox/util/testutils.py
@@ -139,8 +139,8 @@ class MockIMAPClient:
 
     def login(self, email, password) -> None:  # type: ignore[no-untyped-def]
         # Check if this login should raise a specific error
-        if (email, password) in self.login_errors:
-            raise IMAPClient.Error(self.login_errors[(email, password)])
+        if error := self.login_errors.get((email, password)):
+            raise IMAPClient.Error(error)
 
         # Check if this is a valid login
         if email not in self.logins or self.logins[email] != password:

--- a/tests/auth/test_gmail_auth.py
+++ b/tests/auth/test_gmail_auth.py
@@ -2,7 +2,7 @@ import attr
 import pytest
 
 from inbox.auth.google import GoogleAccountData, GoogleAuthHandler
-from inbox.exceptions import GMailDisabledError
+from inbox.exceptions import GmailDisabledError
 from inbox.models.account import Account
 from inbox.models.secret import SecretType
 
@@ -21,7 +21,7 @@ account_data = GoogleAccountData(
 @pytest.fixture
 def patched_gmail_client(monkeypatch) -> None:
     def raise_exc(*args, **kwargs):
-        raise GMailDisabledError()
+        raise GmailDisabledError()
 
     monkeypatch.setattr("inbox.crispin.GmailCrispinClient.__init__", raise_exc)
 
@@ -73,7 +73,7 @@ def test_verify_account(db, patched_gmail_client) -> None:
     db.session.commit()
     assert account.sync_email is True
     # Verify an exception is raised if there is an email settings error.
-    with pytest.raises(GMailDisabledError):
+    with pytest.raises(GmailDisabledError):
         handler.verify_account(account)
 
     # Create an account with sync_email=False

--- a/tests/auth/test_gmail_auth.py
+++ b/tests/auth/test_gmail_auth.py
@@ -2,7 +2,7 @@ import attr
 import pytest
 
 from inbox.auth.google import GoogleAccountData, GoogleAuthHandler
-from inbox.exceptions import ImapSupportDisabledError
+from inbox.exceptions import GMailDisabledError
 from inbox.models.account import Account
 from inbox.models.secret import SecretType
 
@@ -21,7 +21,7 @@ account_data = GoogleAccountData(
 @pytest.fixture
 def patched_gmail_client(monkeypatch) -> None:
     def raise_exc(*args, **kwargs):
-        raise ImapSupportDisabledError()
+        raise GMailDisabledError()
 
     monkeypatch.setattr("inbox.crispin.GmailCrispinClient.__init__", raise_exc)
 
@@ -73,7 +73,7 @@ def test_verify_account(db, patched_gmail_client) -> None:
     db.session.commit()
     assert account.sync_email is True
     # Verify an exception is raised if there is an email settings error.
-    with pytest.raises(ImapSupportDisabledError):
+    with pytest.raises(GMailDisabledError):
         handler.verify_account(account)
 
     # Create an account with sync_email=False

--- a/tests/auth/test_utils.py
+++ b/tests/auth/test_utils.py
@@ -1,6 +1,9 @@
 import pytest
 
-from inbox.auth.utils import is_error_message_invalid_auth
+from inbox.auth.utils import (
+    is_error_message_disabled_imap,
+    is_error_message_invalid_auth,
+)
 
 
 @pytest.mark.parametrize(
@@ -28,3 +31,13 @@ from inbox.auth.utils import is_error_message_invalid_auth
 )
 def test_auth_is_invalid(error_message):
     assert is_error_message_invalid_auth(error_message) is True
+
+
+def test_imap_disabled_detection():
+    assert (
+        is_error_message_disabled_imap(
+            "[ALERT] You are yet to enable IMAP for your account. Please"
+            " contact your administrator (Failure)"
+        )
+        is True
+    )


### PR DESCRIPTION
Immediately detect IMAP disabled and stop trying to sync the account, marking it as errored.