### PR TITLE
Log IMAP disabled status as a warning

### DIFF
--- a/inbox/mailsync/backends/imap/generic.py
+++ b/inbox/mailsync/backends/imap/generic.py
@@ -356,11 +356,12 @@ class FolderSyncEngine(InterruptibleThread):
                 account.update_sync_error(exc)
             raise MailsyncDone()  # noqa: B904
         except IMAPDisabledError as exc:
-            log.exception(
+            log.warning(
                 "Error syncing, IMAP disabled; stopping sync",
                 account_id=self.account_id,
                 folder_id=self.folder_id,
                 logstash_tag="mark_invalid",
+                exc_info=True,
             )
             with session_scope(self.namespace_id) as db_session:
                 account = db_session.query(Account).get(self.account_id)

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -198,10 +198,11 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
                 account.mark_invalid()
                 account.update_sync_error(exc)
         except IMAPDisabledError as exc:
-            log.exception(
+            log.warning(
                 "Error syncing, IMAP disabled; stopping sync",
                 account_id=self.account_id,
                 logstash_tag="mark_invalid",
+                exc_info=True,
             )
             with session_scope(self.namespace_id) as db_session:
                 account = db_session.query(Account).get(self.account_id)


### PR DESCRIPTION
This is an "expected" error state for an account that needs to be fixed by the user, it's not a problem with our system. Let's downgrade the log message to a warning only.