### PR TITLE
 Do not create an extra thread to run sync

### DIFF
--- a/inbox/mailsync/backends/base.py
+++ b/inbox/mailsync/backends/base.py
@@ -98,6 +98,9 @@ class BaseMailSyncMonitor(InterruptibleThread):
     def sync(self) -> Never:
         raise NotImplementedError
 
+    def stop(self) -> None:
+        raise NotImplementedError
+
     def _cleanup(self) -> None:
         with session_scope(self.namespace_id) as mailsync_db_session:
             for x in self.folder_monitors:  # type: ignore[attr-defined]

--- a/inbox/mailsync/backends/imap/monitor.py
+++ b/inbox/mailsync/backends/imap/monitor.py
@@ -217,5 +217,4 @@ class ImapSyncMonitor(BaseMailSyncMonitor):
         kill_all(self.folder_monitors, block=False)
         if isinstance(self, GmailSyncMonitor):
             kill_all(self.label_rename_handlers.values(), block=False)
-        self.sync_thread.kill(block=False)
-        self.join()
+        self.kill()

--- a/inbox/mailsync/service.py
+++ b/inbox/mailsync/service.py
@@ -104,7 +104,7 @@ class SyncService:
         )
 
         self.syncing_accounts = set()  # type: ignore[var-annotated]
-        self.email_sync_monitors = {}  # type: ignore[var-annotated]
+        self.email_sync_monitors: dict[int, BaseMailSyncMonitor] = {}
         self.contact_sync_monitors = {}  # type: ignore[var-annotated]
         self.event_sync_monitors = {}  # type: ignore[var-annotated]
         # Randomize the poll_interval so we maintain at least a little fairness


### PR DESCRIPTION
`BaseMailSyncMonitor` is a thread that does nothing other than create, start, and join another thread. It might as well just run the code synchronously itself.