### PR TITLE
Migrate MS Events to use `iCalUId` for events created after cutoff date

### DIFF
--- a/inbox/config.py
+++ b/inbox/config.py
@@ -1,6 +1,7 @@
 import errno
 import os
 
+import ciso8601
 import urllib3
 import yaml
 
@@ -123,6 +124,17 @@ def _update_config_from_env_variables(  # type: ignore[no-untyped-def]
         or config.get("CALENDAR_POLL_FREQUENCY", 300)
     )
     config["CALENDAR_POLL_FREQUENCY"] = calendar_poll_frequencey
+
+    # MS Calendar events created before this cutoff will continue to use the legacy
+    # ID for all event association/deduplication. After the cutoff, the primary ID
+    # will be taken from iCalUId, to allow deduplication of events shared between
+    # calendars.
+    ms_graph_ical_uid_cutoff_str = os.environ.get(
+        "MS_GRAPH_ICAL_UID_CUTOFF", ""
+    ) or config.get("MS_GRAPH_ICAL_UID_CUTOFF", "2025-07-30T00:00:00Z")
+    config["MS_GRAPH_ICAL_UID_CUTOFF"] = ciso8601.parse_datetime(
+        ms_graph_ical_uid_cutoff_str
+    )
 
 
 def _get_process_name(config) -> None:  # type: ignore[no-untyped-def]

--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -46,6 +46,8 @@ MAX_RECURRING_EVENT_WINDOW = datetime.timedelta(days=365)
 
 EVENT_FIELDS = [
     "id",
+    "iCalUId",
+    "createdDateTime",
     "type",
     "subject",
     "start",

--- a/inbox/events/microsoft/events_provider.py
+++ b/inbox/events/microsoft/events_provider.py
@@ -23,6 +23,7 @@ from inbox.events.microsoft.parse import (
     validate_event,
 )
 from inbox.events.util import CalendarSyncResponse
+from inbox.logging import get_logger
 from inbox.models.account import Account
 from inbox.models.backends.outlook import MICROSOFT_CALENDAR_SCOPES
 from inbox.models.calendar import Calendar
@@ -156,27 +157,32 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
 
             if isinstance(event, RecurringEvent):
                 (exceptions, cancellations) = self._get_event_overrides(
-                    raw_event, event, read_only=read_only
+                    raw_event,
+                    event,
+                    ms_graph_event_id=raw_event["id"],
+                    read_only=read_only,
                 )
                 updates.extend(exceptions)  # type: ignore[arg-type]
                 updates.extend(cancellations)  # type: ignore[arg-type]
 
         return updates
 
-    def _get_event_overrides(  # type: ignore[no-untyped-def]
+    def _get_event_overrides(
         self,
         raw_master_event: MsGraphEvent,
         master_event: RecurringEvent,
         *,
-        read_only,
+        ms_graph_event_id: str,
+        read_only: bool,
     ) -> tuple[list[MsGraphEvent], list[MsGraphEvent]]:
         """
         Fetch recurring event instances and determine exceptions and cancellations.
 
         Arguments:
-            raw_master_event: Recurring master event as retruend by the API
-            master_event: Parsed recurring master event as ORM object
-            read_only: Does master event come from read-only calendar
+            raw_master_event: Recurring master event as returned by the API
+            master_event: Parsed recurring master event as an ORM object
+            ms_graph_event_id: Microsoft Graph event ID for use with Graph API
+            read_only: Does master event come from a read-only calendar
 
         Returns:
             Tuple of exceptions and cancellations
@@ -186,14 +192,27 @@ class MicrosoftEventsProvider(AbstractEventsProvider):
 
         start = master_event.start
         end = start + MAX_RECURRING_EVENT_WINDOW
-
+        log = get_logger()
+        log.info(
+            "Getting overrides for event",
+            event_uid=master_event.uid,
+            event_ms_graph_id=ms_graph_event_id,
+        )
         raw_occurrences = cast(
             list[MsGraphEvent],
             list(
                 self.client.iter_event_instances(
-                    master_event.uid, start=start, end=end, fields=EVENT_FIELDS
+                    ms_graph_event_id,
+                    start=start,
+                    end=end,
+                    fields=EVENT_FIELDS,
                 )
             ),
+        )
+        log.info(
+            "got overrides for event",
+            event_id=master_event.uid,
+            occurrence_count=len(raw_occurrences),
         )
         (raw_exceptions, raw_cancellations) = (
             calculate_exception_and_canceled_occurrences(

--- a/inbox/events/microsoft/graph_types.py
+++ b/inbox/events/microsoft/graph_types.py
@@ -200,7 +200,9 @@ class MsGraphEvent(TypedDict):
     """
 
     id: str
+    iCalUId: str
     type: MsGraphEventType
+    createdDateTime: str
     start: MsGraphDateTimeTimeZone
     originalStart: str
     end: MsGraphDateTimeTimeZone

--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -417,6 +417,11 @@ def synthesize_canceled_occurrence(
         + "-synthesizedCancellation-"
         + start_datetime.date().isoformat()
     )
+    cancellation_ical_uid = (
+        master_event["iCalUId"]
+        + "-synthesizedCancellation-"
+        + start_datetime.date().isoformat()
+    )
     cancellation_start = dump_datetime_as_msgraph_datetime_tz(start_datetime)
     assert start_datetime.tzinfo == pytz.UTC
     original_start = start_datetime.replace(tzinfo=None).isoformat() + "Z"
@@ -427,9 +432,13 @@ def synthesize_canceled_occurrence(
         start_datetime + duration
     )
 
+    # As this is still an MSGraphEvent, we need to maintain separate id and
+    # iCalUId. The decision for which to use will be made when parsing this into
+    # a sync engine internal Event model.
     result = {
         **master_event,
         "id": cancellation_id,
+        "iCalUId": cancellation_ical_uid,
         "type": "synthesizedCancellation",
         "isCancelled": True,
         "recurrence": None,

--- a/tests/events/microsoft/test_events_provider.py
+++ b/tests/events/microsoft/test_events_provider.py
@@ -64,6 +64,8 @@ def events_responses() -> None:
             "value": [
                 {
                     "id": "singular_id",
+                    "iCalUId": "singular_ical_id",
+                    "createdDateTime": "2025-07-07T08:41:36.5027961Z",
                     "lastModifiedDateTime": "2022-09-07T08:41:36.5027961Z",
                     "originalStartTimeZone": "Eastern Standard Time",
                     "originalEndTimeZone": "Eastern Standard Time",
@@ -106,6 +108,8 @@ def events_responses() -> None:
                 },
                 {
                     "id": "recurrence_id",
+                    "iCalUId": "recurrence_ical_id",
+                    "createdDateTime": "2022-09-07T08:41:36.5027961Z",
                     "lastModifiedDateTime": "2022-09-27T14:41:23.1042764Z",
                     "originalStartTimeZone": "Pacific Standard Time",
                     "originalEndTimeZone": "Pacific Standard Time",
@@ -352,6 +356,8 @@ def exception_override_response() -> None:
                 },
                 {
                     "id": "recurrence_id_exception",
+                    "iCalUId": "recurrence_ical_id_exception",
+                    "createdDateTime": "2022-09-27T14:41:23.1042764Z",
                     "lastModifiedDateTime": "2022-09-27T14:41:23.1042764Z",
                     "originalStartTimeZone": "Pacific Standard Time",
                     "originalEndTimeZone": "Pacific Standard Time",
@@ -474,8 +480,193 @@ def test_sync_events(provider) -> None:
 
     assert isinstance(events_by_title["Singular"], Event)
     assert events_by_title["Singular"].description == "Singular"
+    assert events_by_title["Singular"].uid == "singular_id"
     assert isinstance(events_by_title["Recurring"], RecurringEvent)
     assert events_by_title["Recurring"].description == "Hello world!"
+
+
+@pytest.fixture
+def events_with_cutoff_response() -> None:
+    responses.get(
+        BASE_URL + "/me/calendars/fake_calendar_id/events",
+        json={
+            "value": [
+                {
+                    "id": "before_cutoff_id",
+                    "iCalUId": "before_cutoff_ical_id",
+                    "createdDateTime": "2025-07-29T12:00:00.0000000Z",  # Before cutoff
+                    "lastModifiedDateTime": "2025-07-29T12:00:00.0000000Z",
+                    "originalStartTimeZone": "Eastern Standard Time",
+                    "originalEndTimeZone": "Eastern Standard Time",
+                    "subject": "Event Before Cutoff",
+                    "importance": "normal",
+                    "sensitivity": "normal",
+                    "isAllDay": False,
+                    "isCancelled": False,
+                    "isOrganizer": True,
+                    "showAs": "busy",
+                    "type": "singleInstance",
+                    "recurrence": None,
+                    "body": {
+                        "contentType": "html",
+                        "content": "Before cutoff",
+                    },
+                    "start": {
+                        "dateTime": "2025-08-01T12:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "end": {
+                        "dateTime": "2025-08-01T13:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "locations": [],
+                    "attendees": [],
+                    "organizer": None,
+                },
+                {
+                    "id": "after_cutoff_id",
+                    "iCalUId": "after_cutoff_ical_id",
+                    "createdDateTime": "2025-08-01T12:00:00.0000000Z",  # After cutoff
+                    "lastModifiedDateTime": "2025-08-01T12:00:00.0000000Z",
+                    "originalStartTimeZone": "Eastern Standard Time",
+                    "originalEndTimeZone": "Eastern Standard Time",
+                    "subject": "Event After Cutoff",
+                    "importance": "normal",
+                    "sensitivity": "normal",
+                    "isAllDay": False,
+                    "isCancelled": False,
+                    "isOrganizer": True,
+                    "showAs": "busy",
+                    "type": "singleInstance",
+                    "recurrence": None,
+                    "body": {"contentType": "html", "content": "After cutoff"},
+                    "start": {
+                        "dateTime": "2025-08-01T14:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "end": {
+                        "dateTime": "2025-08-01T15:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "locations": [],
+                    "attendees": [],
+                    "organizer": None,
+                },
+                {
+                    "id": "recurring_after_cutoff_id",
+                    "iCalUId": "recurring_after_cutoff_ical_id",
+                    "createdDateTime": "2025-08-05T10:00:00.0000000Z",  # After cutoff
+                    "lastModifiedDateTime": "2025-08-05T10:00:00.0000000Z",
+                    "originalStartTimeZone": "Pacific Standard Time",
+                    "originalEndTimeZone": "Pacific Standard Time",
+                    "subject": "Recurring After Cutoff",
+                    "importance": "normal",
+                    "sensitivity": "normal",
+                    "isAllDay": False,
+                    "isCancelled": False,
+                    "isOrganizer": True,
+                    "showAs": "busy",
+                    "type": "seriesMaster",
+                    "body": {
+                        "contentType": "html",
+                        "content": "Recurring after cutoff",
+                    },
+                    "start": {
+                        "dateTime": "2025-08-10T15:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "end": {
+                        "dateTime": "2025-08-10T15:30:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "locations": [],
+                    "recurrence": {
+                        "pattern": {
+                            "type": "daily",
+                            "interval": 1,
+                            "month": 0,
+                            "dayOfMonth": 0,
+                            "firstDayOfWeek": "sunday",
+                            "index": "first",
+                        },
+                        "range": {
+                            "type": "endDate",
+                            "startDate": "2025-08-10",
+                            "endDate": "2025-08-12",
+                            "recurrenceTimeZone": "Pacific Standard Time",
+                            "numberOfOccurrences": 0,
+                        },
+                    },
+                    "attendees": [],
+                    "organizer": {
+                        "emailAddress": {
+                            "name": "Test",
+                            "address": "test@example.com",
+                        }
+                    },
+                },
+            ]
+        },
+    )
+
+
+@pytest.fixture
+def recurring_instances_response() -> None:
+    responses.get(
+        BASE_URL + "/me/events/recurring_after_cutoff_id/instances",
+        json={
+            "value": [
+                {
+                    "type": "occurrence",
+                    "start": {
+                        "dateTime": "2025-08-10T15:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "originalStart": "2025-08-10T15:00:00Z",
+                },
+                {
+                    "type": "occurrence",
+                    "start": {
+                        "dateTime": "2025-08-11T15:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "originalStart": "2025-08-11T15:00:00Z",
+                },
+                {
+                    "type": "occurrence",
+                    "start": {
+                        "dateTime": "2025-08-12T15:00:00.0000000",
+                        "timeZone": "UTC",
+                    },
+                    "originalStart": "2025-08-12T15:00:00Z",
+                },
+            ]
+        },
+    )
+
+
+@responses.activate
+@pytest.mark.usefixtures(
+    "events_with_cutoff_response", "recurring_instances_response"
+)
+def test_sync_events_respects_ical_uid_cutoff(provider) -> None:
+    events = provider.sync_events("fake_calendar_id")
+    events_by_title = {event.title: event for event in events}
+
+    # Event created before cutoff should use MS Graph ID
+    assert events_by_title["Event Before Cutoff"].uid == "before_cutoff_id"
+
+    # Event created after cutoff should use iCalUID
+    assert events_by_title["Event After Cutoff"].uid == "after_cutoff_ical_id"
+
+    # Recurring event created after cutoff should use iCalUID
+    assert isinstance(
+        events_by_title["Recurring After Cutoff"], RecurringEvent
+    )
+    assert (
+        events_by_title["Recurring After Cutoff"].uid
+        == "recurring_after_cutoff_ical_id"
+    )
 
 
 @responses.activate

--- a/tests/events/microsoft/test_parse.py
+++ b/tests/events/microsoft/test_parse.py
@@ -735,6 +735,7 @@ def test_inflate_msgraph_patterned_recurrence(
 
 master_event = {
     "id": "AAMkADdiYzg5OGRlLTY1MjktNDc2Ni05YmVkLWMxMzFlNTQ0MzU3YQBGAAAAAACi9RQWB-SNTZBuALM6KIOsBwBtf4g8yY_zTZgZh6x0X-50AAIM02sjAABtf4g8yY_zTZgZh6x0X-50AAIM0_o4AAA=",
+    "iCalUId": "iCalUId:2",
     "subject": "Expansion",
     "importance": "normal",
     "sensitivity": "normal",
@@ -769,6 +770,7 @@ master_event = {
 event_occurrences = [
     {
         "id": "AAMkADdiYzg5OGRlLTY1MjktNDc2Ni05YmVkLWMxMzFlNTQ0MzU3YQFRAAgI2pnR5UQAAEYAAAAAovUUFgf0jU2QbgCzOiiDrAcAbX_IPMmPs02YGYesdF-_dAACDNNrIwAAbX_IPMmPs02YGYesdF-_dAACDNPqOAAAEA==",
+        "iCalUId": "iCalUId:3",
         "subject": "Expansion",
         "importance": "normal",
         "sensitivity": "normal",
@@ -789,6 +791,7 @@ event_occurrences = [
     },
     {
         "id": "AAMkADdiYzg5OGRlLTY1MjktNDc2Ni05YmVkLWMxMzFlNTQ0MzU3YQFRAAgI2pqbD63AAEYAAAAAovUUFgf0jU2QbgCzOiiDrAcAbX_IPMmPs02YGYesdF-_dAACDNNrIwAAbX_IPMmPs02YGYesdF-_dAACDNPqOAAAEA==",
+        "iCalUId": "iCalUId:4",
         "subject": "Expansion",
         "importance": "normal",
         "sensitivity": "normal",
@@ -809,6 +812,7 @@ event_occurrences = [
     },
     {
         "id": "AAMkADdiYzg5OGRlLTY1MjktNDc2Ni05YmVkLWMxMzFlNTQ0MzU3YQFRAAgI2ptkOheAAEYAAAAAovUUFgf0jU2QbgCzOiiDrAcAbX_IPMmPs02YGYesdF-_dAACDNNrIwAAbX_IPMmPs02YGYesdF-_dAACDNPqOAAAEA==",
+        "iCalUId": "iCalUId:5",
         "subject": "Expansion",
         "importance": "normal",
         "sensitivity": "normal",
@@ -860,6 +864,7 @@ def test_calculate_exception_and_canceled_occurrences_with_deletion() -> None:
 
 master_event_crossing_dst = {
     "id": "AAMkADdiYzg5OGRlLTY1MjktNDc2Ni05YmVkLWMxMzFlNTQ0MzU3YQBGAAAAAACi9RQWB-SNTZBuALM6KIOsBwBtf4g8yY_zTZgZh6x0X-50AAIzYW90AABtf4g8yY_zTZgZh6x0X-50AAI4iyJwAAA=",
+    "iCalUId": "iCalUId:6",
     "originalStartTimeZone": "Eastern Standard Time",
     "originalEndTimeZone": "Eastern Standard Time",
     "type": "seriesMaster",
@@ -1397,7 +1402,7 @@ single_instance_event = {
     "transactionId": "962593bf-9e1b-ef34-bff6-da63d058df7f",
     "originalStartTimeZone": "Eastern Standard Time",
     "originalEndTimeZone": "Eastern Standard Time",
-    "iCalUId": "040000008200E00074C5B7101A82E00800000000D0C4525C95C2D80100000000000000001000000007003FD5ECC09F42A0ACCA4299772507",
+    "iCalUId": "iCalUId:1",
     "reminderMinutesBeforeStart": 15,
     "isReminderOn": True,
     "hasAttachments": False,
@@ -1520,3 +1525,207 @@ def test_parse_calendar() -> None:
     assert calendar.name == "Calendar"
     assert calendar.read_only is False
     assert calendar.default is True
+
+
+def test_parse_event_uses_ical_uid_after_cutoff() -> None:
+    # Event created after cutoff date should use iCalUID
+    event_after_cutoff = {
+        "@odata.etag": 'W/"bX+IPMmPs02YGYesdF/+dAAB/52fpA=="',
+        "id": "ms_graph_id_after",
+        "iCalUId": "ical_uid_after",
+        "createdDateTime": "2025-08-01T10:00:00.0000000Z",  # After cutoff
+        "lastModifiedDateTime": "2025-08-01T10:00:00.0000000Z",
+        "originalStartTimeZone": "Eastern Standard Time",
+        "originalEndTimeZone": "Eastern Standard Time",
+        "subject": "Event after cutoff",
+        "importance": "normal",
+        "sensitivity": "normal",
+        "isAllDay": False,
+        "isCancelled": False,
+        "isOrganizer": True,
+        "showAs": "busy",
+        "type": "singleInstance",
+        "recurrence": None,
+        "body": {"contentType": "html", "content": "Test"},
+        "start": {
+            "dateTime": "2025-08-15T12:00:00.0000000",
+            "timeZone": "UTC",
+        },
+        "end": {"dateTime": "2025-08-15T13:00:00.0000000", "timeZone": "UTC"},
+        "locations": [],
+        "attendees": [],
+        "organizer": None,
+    }
+
+    event = parse_event(event_after_cutoff, read_only=False)
+    assert event.uid == "ical_uid_after"
+
+    # Event created before cutoff date should use MS Graph ID
+    event_before_cutoff = {
+        "@odata.etag": 'W/"bX+IPMmPs02YGYesdF/+dAAB/52fpA=="',
+        "id": "ms_graph_id_before",
+        "iCalUId": "ical_uid_before",
+        "createdDateTime": "2025-07-29T10:00:00.0000000Z",  # Before cutoff
+        "lastModifiedDateTime": "2025-07-29T10:00:00.0000000Z",
+        "originalStartTimeZone": "Eastern Standard Time",
+        "originalEndTimeZone": "Eastern Standard Time",
+        "subject": "Event before cutoff",
+        "importance": "normal",
+        "sensitivity": "normal",
+        "isAllDay": False,
+        "isCancelled": False,
+        "isOrganizer": True,
+        "showAs": "busy",
+        "type": "singleInstance",
+        "recurrence": None,
+        "body": {"contentType": "html", "content": "Test"},
+        "start": {
+            "dateTime": "2025-08-15T12:00:00.0000000",
+            "timeZone": "UTC",
+        },
+        "end": {"dateTime": "2025-08-15T13:00:00.0000000", "timeZone": "UTC"},
+        "locations": [],
+        "attendees": [],
+        "organizer": None,
+    }
+
+    event = parse_event(event_before_cutoff, read_only=False)
+    assert event.uid == "ms_graph_id_before"
+
+
+def test_parse_event_at_exact_cutoff_time() -> None:
+    # Event created exactly at cutoff should use MS Graph ID (not after)
+    event_at_cutoff = {
+        "@odata.etag": 'W/"bX+IPMmPs02YGYesdF/+dAAB/52fpA=="',
+        "id": "ms_graph_id_at_cutoff",
+        "iCalUId": "ical_uid_at_cutoff",
+        "createdDateTime": "2025-07-30T00:00:00.0000000Z",  # Exactly at cutoff
+        "lastModifiedDateTime": "2025-07-30T00:00:00.0000000Z",
+        "originalStartTimeZone": "UTC",
+        "originalEndTimeZone": "UTC",
+        "subject": "Event at cutoff",
+        "importance": "normal",
+        "sensitivity": "normal",
+        "isAllDay": False,
+        "isCancelled": False,
+        "isOrganizer": True,
+        "showAs": "busy",
+        "type": "singleInstance",
+        "recurrence": None,
+        "body": {"contentType": "html", "content": "Test"},
+        "start": {
+            "dateTime": "2025-08-15T12:00:00.0000000",
+            "timeZone": "UTC",
+        },
+        "end": {"dateTime": "2025-08-15T13:00:00.0000000", "timeZone": "UTC"},
+        "locations": [],
+        "attendees": [],
+        "organizer": None,
+    }
+
+    event = parse_event(event_at_cutoff, read_only=False)
+    assert event.uid == "ms_graph_id_at_cutoff"
+
+
+def test_parse_recurring_event_uses_ical_uid_after_cutoff() -> None:
+    # Recurring event created after cutoff should use iCalUID
+    recurring_after_cutoff = {
+        "@odata.etag": 'W/"bX+IPMmPs02YGYesdF/+dAACDYEM6g=="',
+        "id": "recurring_ms_graph_id_after",
+        "iCalUId": "recurring_ical_uid_after",
+        "createdDateTime": "2025-08-05T15:32:22.239054Z",  # After cutoff
+        "lastModifiedDateTime": "2025-08-05T15:32:22.239054Z",
+        "originalStartTimeZone": "Pacific Standard Time",
+        "originalEndTimeZone": "Pacific Standard Time",
+        "subject": "Recurring after cutoff",
+        "importance": "normal",
+        "sensitivity": "normal",
+        "isAllDay": False,
+        "isCancelled": False,
+        "isOrganizer": True,
+        "showAs": "busy",
+        "type": "seriesMaster",
+        "body": {"contentType": "html", "content": "Recurring test"},
+        "start": {
+            "dateTime": "2025-08-10T15:00:00.0000000",
+            "timeZone": "UTC",
+        },
+        "end": {"dateTime": "2025-08-10T15:30:00.0000000", "timeZone": "UTC"},
+        "locations": [],
+        "recurrence": {
+            "pattern": {
+                "type": "daily",
+                "interval": 1,
+                "month": 0,
+                "dayOfMonth": 0,
+                "firstDayOfWeek": "sunday",
+                "index": "first",
+            },
+            "range": {
+                "type": "endDate",
+                "startDate": "2025-08-10",
+                "endDate": "2025-08-20",
+                "recurrenceTimeZone": "Pacific Standard Time",
+                "numberOfOccurrences": 0,
+            },
+        },
+        "attendees": [],
+        "organizer": {
+            "emailAddress": {"name": "Test", "address": "test@example.com"}
+        },
+    }
+
+    event = parse_event(recurring_after_cutoff, read_only=False)
+    assert isinstance(event, RecurringEvent)
+    assert event.uid == "recurring_ical_uid_after"
+
+    # Recurring event created before cutoff should use MS Graph ID
+    recurring_before_cutoff = {
+        "@odata.etag": 'W/"bX+IPMmPs02YGYesdF/+dAACDYEM6g=="',
+        "id": "recurring_ms_graph_id_before",
+        "iCalUId": "recurring_ical_uid_before",
+        "createdDateTime": "2025-07-25T15:32:22.239054Z",  # Before cutoff
+        "lastModifiedDateTime": "2025-07-25T15:32:22.239054Z",
+        "originalStartTimeZone": "Pacific Standard Time",
+        "originalEndTimeZone": "Pacific Standard Time",
+        "subject": "Recurring before cutoff",
+        "importance": "normal",
+        "sensitivity": "normal",
+        "isAllDay": False,
+        "isCancelled": False,
+        "isOrganizer": True,
+        "showAs": "busy",
+        "type": "seriesMaster",
+        "body": {"contentType": "html", "content": "Recurring test"},
+        "start": {
+            "dateTime": "2025-08-10T15:00:00.0000000",
+            "timeZone": "UTC",
+        },
+        "end": {"dateTime": "2025-08-10T15:30:00.0000000", "timeZone": "UTC"},
+        "locations": [],
+        "recurrence": {
+            "pattern": {
+                "type": "daily",
+                "interval": 1,
+                "month": 0,
+                "dayOfMonth": 0,
+                "firstDayOfWeek": "sunday",
+                "index": "first",
+            },
+            "range": {
+                "type": "endDate",
+                "startDate": "2025-08-10",
+                "endDate": "2025-08-20",
+                "recurrenceTimeZone": "Pacific Standard Time",
+                "numberOfOccurrences": 0,
+            },
+        },
+        "attendees": [],
+        "organizer": {
+            "emailAddress": {"name": "Test", "address": "test@example.com"}
+        },
+    }
+
+    event = parse_event(recurring_before_cutoff, read_only=False)
+    assert isinstance(event, RecurringEvent)
+    assert event.uid == "recurring_ms_graph_id_before"


### PR DESCRIPTION
Migrating to `iCalUId` gives us immutable event IDs for calendar events synced from the MS Graph API. In the past, any event synced to multiple user's calendars would get unique event IDs from MS. This would make them look like distinct events to the consuming application, assigning users to the same meeting multiple times.

With `iCalUId`, we can avoid this issue and have behavior similar to gmail. To avoid creating duplicates with all events synced prior to this change, a cutoff date can be used.