### PR TITLE
Set Sentry sample rate to `0.1`

### DIFF
--- a/inbox/error_handling.py
+++ b/inbox/error_handling.py
@@ -103,6 +103,9 @@ def maybe_enable_sentry() -> None:
         dsn=SENTRY_DSN,
         environment=application_environment,
         release=os.environ.get("DEPLOYMENT_GIT_SHA", "unknown"),
+        # TODO: Remove `sample_rate` once we've reduced the number
+        # of errors sync-engine is reporting.
+        sample_rate=0.1,
         integrations=[
             sentry_sdk.integrations.logging.LoggingIntegration(
                 level=logging.INFO,  # Capture INFO+


### PR DESCRIPTION
Sync-engine is currently capable generating a huge volume of errors, so it's a good idea to limit what we send to Sentry for now.