### PR TITLE
Fallback to uid when ical uid is none

### DIFF
--- a/inbox/events/microsoft/parse.py
+++ b/inbox/events/microsoft/parse.py
@@ -417,11 +417,13 @@ def synthesize_canceled_occurrence(
         + "-synthesizedCancellation-"
         + start_datetime.date().isoformat()
     )
-    cancellation_ical_uid = (
-        master_event["iCalUId"]
-        + "-synthesizedCancellation-"
-        + start_datetime.date().isoformat()
-    )
+    cancellation_ical_uid = None
+    if master_event["iCalUId"] is not None:
+        cancellation_ical_uid = (
+            master_event["iCalUId"]
+            + "-synthesizedCancellation-"
+            + start_datetime.date().isoformat()
+        )
     cancellation_start = dump_datetime_as_msgraph_datetime_tz(start_datetime)
     assert start_datetime.tzinfo == pytz.UTC
     original_start = start_datetime.replace(tzinfo=None).isoformat() + "Z"
@@ -769,6 +771,7 @@ def parse_event(
         uid=(
             ical_uid
             if created_date_time > config["MS_GRAPH_ICAL_UID_CUTOFF"]
+            and ical_uid is not None
             else event_id
         ),
         raw_data=raw_data,


### PR DESCRIPTION
Fixes https://github.com/closeio/sync-engine/issues/1071
Summary:
For some events, the `iCalUId` may be `None`. This causes a type error when synthesizing a cancellation event. It would also preclude events created after the cutoff date from being inserted into the events table.

We can fall back to the `uid`, accepting that this will allow duplicate event creation again, and cancellation events may have a different ID than their master event, if the `iCalUId` is not provided.

In my testing, cancellation events did include the `iCalUId`, but internet lore suggests it is possible that either of these scenarios may lead to missing ids:
* Hybrid exchange environments
* Cancellation events from the events delta api
