### PR TITLE
Update urllib3 from `2.5.0` -> `2.6.3`

### DIFF
--- a/requirements/requirements-prod.in
+++ b/requirements/requirements-prod.in
@@ -84,7 +84,7 @@ tldextract==3.1.2
 structlog==23.1.0
 traitlets==5.9.0
 typing_extensions
-urllib3==2.5.0
+urllib3==2.6.3
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.8

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -1125,9 +1125,9 @@ typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8
     # via -r requirements-prod.in
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.3 \
+    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
+    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
     # via
     #   -r requirements-prod.in
     #   botocore

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -372,9 +372,9 @@ types-toml==0.10.8.20240310 \
     --hash=sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331 \
     --hash=sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d
     # via -r requirements-test.in
-urllib3==2.5.0 \
-    --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
-    --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
+urllib3==2.6.3 \
+    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
+    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
     # via
     #   -c requirements-prod.txt
     #   requests


### PR DESCRIPTION
Resolves security alert -> https://github.com/closeio/sync-engine/security/dependabot/82

Changelog show changes to custom decrompressors and brotli, but this shouldn't break anything for us: https://github.com/closeio/sync-engine/security/dependabot/82



