### PR TITLE
Bump Werkzeug to 3.1.5

### DIFF
--- a/inbox/mailsync/frontend.py
+++ b/inbox/mailsync/frontend.py
@@ -73,7 +73,7 @@ class SyncHTTPFrontend(ProfilingHTTPFrontend):
 
         @app.route("/unassign", methods=["POST"])
         def unassign_account():  # type: ignore[no-untyped-def]
-            account_id = request.json["account_id"]  # type: ignore[index]
+            account_id = request.json["account_id"]
             ret = self.sync_service.stop_sync(account_id)
             if ret:
                 return "OK"

--- a/requirements/requirements-prod.in
+++ b/requirements/requirements-prod.in
@@ -88,6 +88,6 @@ urllib3==2.6.3
 vobject==0.9.6.1
 wcwidth==0.2.6
 WebOb==1.8.8
-Werkzeug==3.0.6
+Werkzeug==3.1.5
 zipp==3.20.2
 zstandard==0.23.0

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -1148,9 +1148,9 @@ webob==1.8.8 \
     # via
     #   -r requirements-prod.in
     #   flanker
-werkzeug==3.0.6 \
-    --hash=sha256:1bc0c2310d2fbb07b1dd1105eba2f7af72f322e1e455f2f93c993bee8c8a5f17 \
-    --hash=sha256:a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d
+werkzeug==3.1.5 \
+    --hash=sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc \
+    --hash=sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67
     # via
     #   -r requirements-prod.in
     #   flask

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures don't go here; see util/base.py and friends."""
 
+import importlib
 import os
 
 import werkzeug
@@ -23,7 +24,7 @@ def make_api_client():
         # test_client uses werkzeug.__version__ attribute
         # which has been deprecated
         # To avoid a rushed flask upgrade we'll patch it here
-        werkzeug.__version__ = "1.0.0"
+        werkzeug.__version__ = importlib.metadata.version("werkzeug")
         with app.test_client() as c:
             return TestAPIClient(c, namespace.public_id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 import os
 
+import werkzeug
+
 os.environ["NYLAS_ENV"] = "test"
 
 from pytest import fixture  # noqa: PT013
@@ -18,6 +20,10 @@ def make_api_client():
         from inbox.api.srv import app
 
         app.config["TESTING"] = True
+        # test_client uses werkzeug.__version__ attribute
+        # which has been deprecated
+        # To avoid a rushed flask upgrade we'll patch it here
+        werkzeug.__version__ = "1.0.0"
         with app.test_client() as c:
             return TestAPIClient(c, namespace.public_id)
 


### PR DESCRIPTION
Fixes security alert.

I'm going to copy here the full [change log](https://werkzeug.palletsprojects.com/en/stable/changes/#version-3-1-5) from 3.0.6:

```
Version 3.1.5
Released 2026-01-08

safe_join on Windows does not allow more special device names, regardless of extension or surrounding spaces. [GHSA-87hc-h4r5-73f7](https://github.com/advisories/GHSA-87hc-h4r5-73f7)

The multipart form parser handles a \r\n sequence at a chunk boundary. This fixes the previous attempt, which caused incorrect content lengths. [#3065](https://github.com/pallets/werkzeug/issues/3065) [#3077](https://github.com/pallets/werkzeug/issues/3077)

Fix AttributeError when initializing DebuggedApplication with pin_security=False. [#3075](https://github.com/pallets/werkzeug/issues/3075)

Version 3.1.4
Released 2025-11-28

safe_join on Windows does not allow special device names. This prevents reading from these when using send_from_directory. secure_filename already prevented writing to these. [GHSA-hgf8-39gv-g3f2](https://github.com/advisories/GHSA-hgf8-39gv-g3f2)

The debugger pin fails after 10 attempts instead of 11. [#3020](https://github.com/pallets/werkzeug/pull/3020)

The multipart form parser handles a \r\n sequence at a chunk boundary. [#3065](https://github.com/pallets/werkzeug/issues/3065)

Improve CPU usage during Watchdog reloader. [#3054](https://github.com/pallets/werkzeug/issues/3054)

Request.json annotation is more accurate. [#3067](https://github.com/pallets/werkzeug/issues/3067)

Traceback rendering handles when the line number is beyond the available source lines. [#3044](https://github.com/pallets/werkzeug/issues/3044)

HTTPException.get_response annotation and doc better conveys the distinction between WSGI and sans-IO responses. [#3056](https://github.com/pallets/werkzeug/issues/3056)

Version 3.1.3
Released 2024-11-08

Initial data passed to MultiDict and similar interfaces only accepts list, tuple, or set when passing multiple values. It had been changed to accept any Collection, but this matched types that should be treated as single values, such as bytes. [#2994](https://github.com/pallets/werkzeug/issues/2994)

When the Host header is not set and Request.host falls back to the WSGI SERVER_NAME value, if that value is an IPv6 address it is wrapped in [] to match the Host header. [#2993](https://github.com/pallets/werkzeug/issues/2993)

Version 3.1.2
Released 2024-11-04

Improve type annotation for TypeConversionDict.get to allow the type parameter to be a callable. [#2988](https://github.com/pallets/werkzeug/issues/2988)

Headers does not inherit from MutableMapping, as it is does not exactly match that interface. [#2989](https://github.com/pallets/werkzeug/issues/2989)

Version 3.1.1
Released 2024-11-01

Fix an issue that caused str(Request.headers) to always appear empty. [#2985](https://github.com/pallets/werkzeug/issues/2985)

Version 3.1.0
Released 2024-10-31

Drop support for Python 3.8. [#2966](https://github.com/pallets/werkzeug/pull/2966)

Remove previously deprecated code. [#2967](https://github.com/pallets/werkzeug/pull/2967)

Request.max_form_memory_size defaults to 500kB instead of unlimited. Non-file form fields over this size will cause a RequestEntityTooLarge error. [#2964](https://github.com/pallets/werkzeug/issues/2964)

OrderedMultiDict and ImmutableOrderedMultiDict are deprecated. Use MultiDict and ImmutableMultiDict instead. [#2968](https://github.com/pallets/werkzeug/issues/2968)

Behavior of properties on request.cache_control and response.cache_control has been significantly adjusted.

Dict values are always str | None. Setting properties will convert the value to a string. Setting a property to False is equivalent to setting it to None. Getting typed properties will return None if conversion raises ValueError, rather than the string. [#2980](https://github.com/pallets/werkzeug/issues/2980)

max_age is None if present without a value, rather than -1. [#2980](https://github.com/pallets/werkzeug/issues/2980)

no_cache is a boolean for requests, it is True instead of "*" when present. It remains a string for responses. [#2980](https://github.com/pallets/werkzeug/issues/2980)

max_stale is True if present without a value, rather than "*". [#2980](https://github.com/pallets/werkzeug/issues/2980)

no_transform is a boolean. Previously it was mistakenly always None. [#2881](https://github.com/pallets/werkzeug/issues/2881)

min_fresh is None if present without a value, rather than "*". [#2881](https://github.com/pallets/werkzeug/issues/2881)

private is True if present without a value, rather than "*". [#2980](https://github.com/pallets/werkzeug/issues/2980)

Added the must_understand property. [#2881](https://github.com/pallets/werkzeug/issues/2881)

Added the stale_while_revalidate, and stale_if_error properties. [#2948](https://github.com/pallets/werkzeug/issues/2948)

Type annotations more accurately reflect the values. [#2881](https://github.com/pallets/werkzeug/issues/2881)

Support Cookie CHIPS (Partitioned Cookies). [#2797](https://github.com/pallets/werkzeug/issues/2797)

Add 421 MisdirectedRequest HTTP exception. [#2850](https://github.com/pallets/werkzeug/issues/2850)

Increase default work factor for PBKDF2 to 1,000,000 iterations. [#2969](https://github.com/pallets/werkzeug/issues/2969)

Inline annotations for datastructures, removing stub files. [#2970](https://github.com/pallets/werkzeug/issues/2970)

MultiDict.getlist catches TypeError in addition to ValueError when doing type conversion. [#2976](https://github.com/pallets/werkzeug/issues/2976)

Implement | and |= operators for MultiDict, Headers, and CallbackDict, and disallow |= on immutable types. [#2977](https://github.com/pallets/werkzeug/issues/2977)
