### PR TITLE
Optimize MAX msg_uid query

### DIFF
--- a/inbox/mailsync/backends/imap/common.py
+++ b/inbox/mailsync/backends/imap/common.py
@@ -63,15 +63,21 @@ def local_uids(  # type: ignore[no-untyped-def]
 def lastseenuid(  # type: ignore[no-untyped-def]  # noqa: ANN201
     account_id, session, folder_id
 ):
-    q = session.query(func.max(ImapUid.msg_uid)).with_hint(
-        ImapUid, "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)"
+    q = (
+        session.query(ImapUid.msg_uid)
+        .with_hint(
+            ImapUid,
+            "FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)",
+        )
+        .filter(
+            ImapUid.account_id == bindparam("account_id"),
+            ImapUid.folder_id == bindparam("folder_id"),
+        )
+        .order_by(ImapUid.msg_uid.desc())
+        .limit(1)
     )
-    q = q.filter(
-        ImapUid.account_id == bindparam("account_id"),
-        ImapUid.folder_id == bindparam("folder_id"),
-    )
-    res = q.params(account_id=account_id, folder_id=folder_id).one()[0]
-    return res or 0
+    res = q.params(account_id=account_id, folder_id=folder_id).first()
+    return res[0] if res else 0
 
 
 def update_message_metadata(


### PR DESCRIPTION
```
EXPLAIN ANALYZE SELECT max(imapuid.msg_uid) AS max_1 
FROM imapuid FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc) 
WHERE imapuid.account_id = 42791 AND imapuid.folder_id = 464285;

-> Aggregate: max(imapuid.msg_uid)  (cost=921858 rows=1) (actual time=999..999 rows=1 loops=1)↵    -> Covering index lookup on imapuid using ix_imapuid_account_id_folder_id_msg_uid_desc (account_id=42791, folder_id=464285)  (cost=464365 rows=4.57e+6) (actual time=0.664..830 rows=2.03e+6 loops=1)↵


EXPLAIN ANALYZE SELECT msg_uid
FROM imapuid FORCE INDEX (ix_imapuid_account_id_folder_id_msg_uid_desc)
WHERE account_id = 42791 AND folder_id = 464285
ORDER BY msg_uid DESC LIMIT 1;

-> Limit: 1 row(s)  (cost=33 rows=1) (actual time=0.0359..0.036 rows=1 loops=1)↵    -> Covering index lookup on imapuid using ix_imapuid_account_id_folder_id_msg_uid_desc (account_id=42791, folder_id=464285)  (cost=33 rows=321) (actual time=0.0354..0.0354 rows=1 loops=1)↵
```