### PR TITLE
`subqueryload` -> `selectinload`

### DIFF
--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -8,7 +8,7 @@ from sqlalchemy import (  # type: ignore[import-untyped]
 )
 from sqlalchemy.orm import (  # type: ignore[import-untyped]
     contains_eager,
-    subqueryload,
+    selectinload,
 )
 
 from inbox.api.err import InputError
@@ -500,13 +500,13 @@ def messages_or_drafts(  # type: ignore[no-untyped-def]  # noqa: ANN201
     # thread table. We should eventually try to simplify this.
     query = query.options(
         contains_eager(Message.thread),
-        subqueryload(
+        selectinload(
             Message.messagecategories  # type: ignore[attr-defined]
         ).joinedload("category", "created_at"),
-        subqueryload(Message.parts).joinedload(  # type: ignore[attr-defined]
+        selectinload(Message.parts).joinedload(  # type: ignore[attr-defined]
             Part.block
         ),
-        subqueryload(Message.events),  # type: ignore[attr-defined]
+        selectinload(Message.events),  # type: ignore[attr-defined]
     )
 
     prepared = query.params(**param_dict)

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm import (  # type: ignore[import-untyped]
     joinedload,
     load_only,
     relationship,
-    subqueryload,
+    selectinload,
     synonym,
     validates,
     with_polymorphic,
@@ -882,14 +882,14 @@ class Message(
 
         return (
             load_only(*columns),
-            subqueryload("parts").joinedload("block"),
-            subqueryload("thread").load_only("public_id", "discriminator"),
-            subqueryload(
+            selectinload("parts").joinedload("block"),
+            selectinload("thread").load_only("public_id", "discriminator"),
+            selectinload(
                 Message.events.of_type(  # type: ignore[attr-defined]
                     all_event_subclasses
                 )
             ),
-            subqueryload("messagecategories").joinedload("category"),
+            selectinload("messagecategories").joinedload("category"),
         )
 
 

--- a/inbox/models/thread.py
+++ b/inbox/models/thread.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import (  # type: ignore[import-untyped]
     backref,
     object_session,
     relationship,
-    subqueryload,
+    selectinload,
     validates,
 )
 
@@ -257,11 +257,11 @@ class Thread(
                 "reply_to",
             ]
         return (
-            subqueryload(Thread.messages)  # type: ignore[attr-defined]
+            selectinload(Thread.messages)  # type: ignore[attr-defined]
             .load_only(*message_columns)
             .joinedload("messagecategories")
             .joinedload("category"),
-            subqueryload(Thread.messages)  # type: ignore[attr-defined]
+            selectinload(Thread.messages)  # type: ignore[attr-defined]
             .joinedload("parts")
             .joinedload("block"),
         )


### PR DESCRIPTION
Replace all usage of `subqueryload` with `selectinload`. It appears that `selectinload` performs better and is more reliable than `subqueryload`. The results are the same in all possible scenarios and the interface is the same such that it's just a matter of replacing one name for the other.

- [ ] Deploy this to one cluster.
- [ ] Watch it for a while.