### PR TITLE
Optimize DB query, move `order by` to client side

### DIFF
--- a/inbox/api/kellogs.py
+++ b/inbox/api/kellogs.py
@@ -207,7 +207,11 @@ def _encode(  # type: ignore[no-untyped-def]  # noqa: D417
             "starred": obj.is_starred,
             "files": obj.api_attachment_metadata,
             "events": [
-                encode(e) for e in obj.events  # type: ignore[attr-defined]
+                encode(e)
+                for e in sorted(
+                    obj.events,  # type: ignore[attr-defined]
+                    key=lambda e: e.last_modified,
+                )
             ],
         }
 

--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -186,11 +186,7 @@ class Event(
     )
 
     message = relationship(
-        Message,
-        backref=backref(
-            "events",
-            cascade="all, delete-orphan",
-        ),
+        Message, backref=backref("events", cascade="all, delete-orphan")
     )
 
     __table_args__ = (

--- a/inbox/models/event.py
+++ b/inbox/models/event.py
@@ -189,7 +189,6 @@ class Event(
         Message,
         backref=backref(
             "events",
-            order_by="Event.last_modified",
             cascade="all, delete-orphan",
         ),
     )


### PR DESCRIPTION
The `order by` clause was making the planner choose not to use an index that is actually helpful for the query, so let's remove it and order client-side since the list of events returned here is very small (most often 0-1 elements).