### PR TITLE
Load events for messages manually

### DIFF
--- a/inbox/api/filtering.py
+++ b/inbox/api/filtering.py
@@ -8,6 +8,7 @@ from sqlalchemy import (  # type: ignore[import-untyped]
 )
 from sqlalchemy.orm import (  # type: ignore[import-untyped]
     contains_eager,
+    noload,
     subqueryload,
 )
 
@@ -27,6 +28,7 @@ from inbox.models import (
     Thread,
 )
 from inbox.models.event import RecurringEvent
+from inbox.models.message import load_events_for_messages
 
 
 def contact_subquery(  # type: ignore[no-untyped-def]  # noqa: ANN201
@@ -506,11 +508,15 @@ def messages_or_drafts(  # type: ignore[no-untyped-def]  # noqa: ANN201
         subqueryload(Message.parts).joinedload(  # type: ignore[attr-defined]
             Part.block
         ),
-        subqueryload(Message.events),  # type: ignore[attr-defined]
+        noload(Message.events),  # type: ignore[attr-defined]
     )
 
     prepared = query.params(**param_dict)
-    return prepared.all()
+    messages = prepared.all()
+
+    load_events_for_messages(db_session, messages)
+
+    return messages
 
 
 def files(  # type: ignore[no-untyped-def]  # noqa: ANN201

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -31,11 +31,15 @@ from sqlalchemy.orm import (  # type: ignore[import-untyped]
     backref,
     joinedload,
     load_only,
+    noload,
     relationship,
     subqueryload,
     synonym,
     validates,
     with_polymorphic,
+)
+from sqlalchemy.orm.attributes import (  # type: ignore[import-untyped]
+    set_committed_value,
 )
 from sqlalchemy.sql.expression import false  # type: ignore[import-untyped]
 
@@ -45,6 +49,7 @@ from inbox.logging import get_logger
 from inbox.models.account import Account
 from inbox.models.base import MailSyncBase
 from inbox.models.category import Category
+from inbox.models.event import Event, RecurringEvent, RecurringEventOverride
 from inbox.models.mixins import (
     DeletedAtMixin,
     HasPublicID,
@@ -540,7 +545,7 @@ class Message(
     ) -> None:
         disposition, _ = mimepart.content_disposition
         content_id: str | None = mimepart.headers.get("Content-Id")
-        content_type, params = mimepart.content_type  # noqa: F841
+        content_type, params = mimepart.content_type
 
         filename: str | None = mimepart.detected_file_name
         if filename == "":
@@ -870,26 +875,44 @@ class Message(
         if expand:
             columns += ["message_id_header", "in_reply_to", "references"]
 
-        from inbox.models.event import (
-            Event,
-            RecurringEvent,
-            RecurringEventOverride,
-        )
-
-        all_event_subclasses = with_polymorphic(
-            Event, [RecurringEvent, RecurringEventOverride], flat=True
-        )
-
         return (
             load_only(*columns),
             subqueryload("parts").joinedload("block"),
             subqueryload("thread").load_only("public_id", "discriminator"),
-            subqueryload(
-                Message.events.of_type(  # type: ignore[attr-defined]
-                    all_event_subclasses
-                )
-            ),
+            noload(Message.events),  # type: ignore[attr-defined]
             subqueryload("messagecategories").joinedload("category"),
+        )
+
+
+def load_events_for_messages(db_session, messages):  # type: ignore[no-untyped-def]  # noqa: ANN201
+    """
+    Manually load events for a list of messages using FORCE INDEX to ensure
+    MySQL uses the message_id index. This replaces the automatic eager
+    loading (subqueryload/selectinload) which generates queries that the
+    MySQL query planner handles poorly on large tables.
+    """
+    if not messages:
+        return
+
+    message_ids = [msg.id for msg in messages]
+
+    all_event_subclasses = with_polymorphic(
+        Event, [RecurringEvent, RecurringEventOverride]
+    )
+    events = (
+        db_session.query(all_event_subclasses)
+        .with_hint(Event, "FORCE INDEX (message_id)", "mysql")
+        .filter(Event.message_id.in_(message_ids))
+        .all()
+    )
+
+    events_by_message_id = defaultdict(list)
+    for event in events:
+        events_by_message_id[event.message_id].append(event)
+
+    for msg in messages:
+        set_committed_value(
+            msg, "events", events_by_message_id.get(msg.id, [])
         )
 
 

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -544,7 +544,7 @@ class Message(
     ) -> None:
         disposition, _ = mimepart.content_disposition
         content_id: str | None = mimepart.headers.get("Content-Id")
-        content_type, params = mimepart.content_type
+        content_type, params = mimepart.content_type  # noqa: F841
 
         filename: str | None = mimepart.detected_file_name
         if filename == "":

--- a/inbox/models/message.py
+++ b/inbox/models/message.py
@@ -49,7 +49,6 @@ from inbox.logging import get_logger
 from inbox.models.account import Account
 from inbox.models.base import MailSyncBase
 from inbox.models.category import Category
-from inbox.models.event import Event, RecurringEvent, RecurringEventOverride
 from inbox.models.mixins import (
     DeletedAtMixin,
     HasPublicID,
@@ -891,6 +890,13 @@ def load_events_for_messages(db_session, messages):  # type: ignore[no-untyped-d
     loading (subqueryload/selectinload) which generates queries that the
     MySQL query planner handles poorly on large tables.
     """
+    # Importing this here to avoid circular imports.
+    from inbox.models.event import (
+        Event,
+        RecurringEvent,
+        RecurringEventOverride,
+    )
+
     if not messages:
         return
 

--- a/inbox/transactions/delta_sync.py
+++ b/inbox/transactions/delta_sync.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm.exc import NoResultFound  # type: ignore[import-untyped]
 
 from inbox.api.kellogs import APIEncoder, encode
 from inbox.models import Account, Message, Namespace, Thread, Transaction
+from inbox.models.message import load_events_for_messages
 from inbox.models.session import session_scope
 from inbox.models.util import transaction_objects
 
@@ -245,9 +246,9 @@ def format_transactions_after_pointer(  # type: ignore[no-untyped-def]  # noqa: 
                 if object_cls == Message:
                     query = query.options(*Message.api_loading_options(expand))
                     # T7045: Workaround for some SQLAlchemy bugs.
-                    objects = {
-                        obj.id: obj for obj in query if obj.thread is not None
-                    }
+                    messages = [obj for obj in query if obj.thread is not None]
+                    load_events_for_messages(db_session, messages)
+                    objects = {obj.id: obj for obj in messages}
                 else:
                     objects = {obj.id: obj for obj in query}
 


### PR DESCRIPTION
The `order by` clause is making the planner choose not to use an index that is actually helpful for the query to find events for messages, so let's remove find the events and insert them into the `Message` objects on the client side. Building the query manually opens up the possibility of using the `with_hint` API to request a `FORCE INDEX`.