### PR TITLE
Replace CircleCI badge with a GH Actions badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sync Engine [![CircleCI](https://circleci.com/gh/closeio/sync-engine.svg?style=svg)](https://circleci.com/gh/closeio/sync-engine)
+# Sync Engine [![Build and release](https://github.com/closeio/sync-engine/actions/workflows/build-and-release.yaml/badge.svg)](https://github.com/closeio/sync-engine/actions/workflows/build-and-release.yaml)
 
 This is a fork of the Nylas [sync-engine project](https://github.com/nylas/sync-engine). 
 For those looking for a hosted email syncing service, check out 


### PR DESCRIPTION
This was missed in:
- https://github.com/closeio/sync-engine/pull/642
- https://github.com/closeio/sync-engine/pull/648

I randomly noticed it while visiting this repo for an unrelated reason:
<img width="965" height="231" alt="Screenshot 2026-04-10 at 12 14 36 PM" src="https://github.com/user-attachments/assets/9c9201b9-01e5-47b0-ad45-5380cd2fa278" />

Now it looks good:
<img width="1179" height="342" alt="Screenshot 2026-04-10 at 12 29 35 PM" src="https://github.com/user-attachments/assets/974f22d7-595e-4ca3-a8ee-89130d933e11" />

Not that the GHA link doesn't include a branch filter, but that's OK – the badge uses the "default" branch (which in our case is the "master" branch) by default.