### PR TITLE
Remove `filelock` from top-level dependencies

### DIFF
--- a/requirements/requirements-prod.in
+++ b/requirements/requirements-prod.in
@@ -26,7 +26,6 @@ cryptography==46.0.5
 decorator==5.1.1
 dnspython==2.6.1
 executing==1.2.0
-filelock==3.20.3
 flanker @ https://github.com/closeio/flanker-new/archive/fa272d95345d45e8bb1f9bc32bc2c074bf52a484.zip
 tld==0.12.6
 Flask==2.3.2

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -332,9 +332,7 @@ executing==1.2.0 \
 filelock==3.20.3 \
     --hash=sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1 \
     --hash=sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1
-    # via
-    #   -r requirements-prod.in
-    #   tldextract
+    # via tldextract
 flanker @ https://github.com/closeio/flanker-new/archive/fa272d95345d45e8bb1f9bc32bc2c074bf52a484.zip \
     --hash=sha256:a197ba8c42aa6ee69c126b001de56ccbc5c3c24bdaba683359668820d2229de7
     # via -r requirements-prod.in


### PR DESCRIPTION
It's only a transitive dependency of `tldextract`.

Proof:
```
wojcikstefan@stefans-mbp sync-engine % rg filelock -A 5
requirements/requirements-prod.txt
332:filelock==3.20.3 \
333-    --hash=sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1 \
334-    --hash=sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1
335-    # via
336-    #   -r requirements-prod.in
337-    #   tldextract
```

It doesn't show up in any actual application code imports. I checked [the docs](https://py-filelock.readthedocs.io/en/latest/index.html) to ensure it's not one of those packages that has a different PyPI name and a different import path :)