### PR TITLE
Bump Werkzeug from 3.1.5 to 3.1.8

### DIFF
--- a/requirements/requirements-prod.in
+++ b/requirements/requirements-prod.in
@@ -53,6 +53,6 @@ typing_extensions
 urllib3==2.7.0
 vobject==0.9.6.1
 WebOb==1.8.8
-Werkzeug==3.1.5
+Werkzeug==3.1.8
 zipp==3.20.2
 zstandard==0.23.0

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -1231,9 +1231,9 @@ webob==1.8.8 \
     # via
     #   -r requirements-prod.in
     #   flanker
-werkzeug==3.1.5 \
-    --hash=sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc \
-    --hash=sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67
+werkzeug==3.1.8 \
+    --hash=sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50 \
+    --hash=sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44
     # via
     #   -r requirements-prod.in
     #   flask


### PR DESCRIPTION
Upgrades `werkzeug` to 3.1.8. 

Fixes security alert

3.1.6 was a security fix release.
3.1.7 and 3.1.8 are bugfix releases. 

<details>
<summary>
Expand for [Changelog since 3.1.5]
</summary>

[Changelog since 3.1.5](https://werkzeug.palletsprojects.com/en/stable/changes/#version-3-1-8)

Version 3.1.8
Released 2026-04-02

Request.host and get_host return the empty string if the header is missing or has invalid characters. [#3142](https://github.com/pallets/werkzeug/issues/3142)

Version 3.1.7
Released 2026-03-23

parse_list_header preserves partially quoted items, discards empty items, and returns empty for unclosed quoted values. [#3128](https://github.com/pallets/werkzeug/pull/3128)

WWWAuthenticate.to_header does not produce a trailing space when there are no parameters. [#3127](https://github.com/pallets/werkzeug/issues/3127)

Transfer-Encoding is parsed as a set. [#3134](https://github.com/pallets/werkzeug/pull/3134)

Request.host, get_host, and host_is_trusted validate the characters of the value. An empty value is no longer allowed. A Unix socket server address is ignored. The trusted_list argument to host_is_trusted is optional. [#3113](https://github.com/pallets/werkzeug/pull/3113)

Fix multipart form parser handling of newline at boundary. [#3088](https://github.com/pallets/werkzeug/issues/3088)

Response.make_conditional sets the Accept-Ranges header even if it is not a satisfiable range request. [#3108](https://github.com/pallets/werkzeug/issues/3108)

merge_slashes merges any number of consecutive slashes. [#3121](https://github.com/pallets/werkzeug/issues/3121)

Version 3.1.6
Released 2026-02-19

safe_join on Windows does not allow special devices names in multi-segment paths. [GHSA-29vq-49wr-vm6x](https://github.com/advisories/GHSA-29vq-49wr-vm6x)

Response.make_conditional sets the Accept-Ranges header even if it is not a satisfiable range request. [#3108](https://github.com/pallets/werkzeug/issues/3108)

</details>
