### PR TITLE
[GitHub Actions] Update action versions

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12.3'
           architecture: 'x64'
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ !contains(github.event.head_commit.message, '#notests') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12.3'
 
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare environment
         run: |
@@ -110,20 +110,20 @@ jobs:
           docker context create container-builder
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           version: latest
           endpoint: container-builder
 
       - name: Login to DockerHub
         # if: ${{ github.ref == 'master' && github.event.pull_request.merged == true }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push sync-engine images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/${{ matrix.arch }}
           push: false

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -123,7 +123,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push sync-engine images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/${{ matrix.arch }}
           push: false


### PR DESCRIPTION
Beginning on June 16th, 2026, GH action runners will begin using Node24 by default. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

That means that we have to update the actions you use to support that node24 version. The most common ones should be updated to at least those versions:

```
actions/checkout@v6
hashicorp/vault-action@v4.0.0
actions/setup-python@6
docker/login-action@v4
docker/setup-qemu-action@v4
docker/setup-buildx-action@v4
docker/build-push-action@v7
closeio/ssh-agent@v0.10.0
aws-actions/configure-aws-credentials@v6
actions/github-script@v8
closeio/create-pull-request@v8
aws-actions/amazon-ecr-login@v2
actions/download-artifact@v8
actions/upload-artifact@v7
```
