### PR TITLE
Bump webob to 1.8.10

### DIFF
--- a/requirements/requirements-prod.in
+++ b/requirements/requirements-prod.in
@@ -52,7 +52,6 @@ structlog==23.1.0
 typing_extensions
 urllib3==2.7.0
 vobject==0.9.6.1
-WebOb==1.8.8
 Werkzeug==3.1.8
 zipp==3.20.2
 zstandard==0.23.0

--- a/requirements/requirements-prod.txt
+++ b/requirements/requirements-prod.txt
@@ -1225,12 +1225,10 @@ wcwidth==0.6.0 \
     --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
     --hash=sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159
     # via prompt-toolkit
-webob==1.8.8 \
-    --hash=sha256:2abc1555e118fc251e705fc6dc66c7f5353bb9fbfab6d20e22f1c02b4b71bcee \
-    --hash=sha256:b60ba63f05c0cf61e086a10c3781a41fcfe30027753a8ae6d819c77592ce83ea
-    # via
-    #   -r requirements-prod.in
-    #   flanker
+webob==1.8.10 \
+    --hash=sha256:1c963a11f307bc3f624fbab9dde737701eae255f32981b7a5486a88db1767c2b \
+    --hash=sha256:e68ad87fda378191081965ab02a185391c26e4e926adec855c3b0286a8369d49
+    # via flanker
 werkzeug==3.1.8 \
     --hash=sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50 \
     --hash=sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44


### PR DESCRIPTION
Remove it from requirements/requirements-prod.in, it's a transitive dependency via flanker.

Changelog is not great, see release history in pipy

- https://pypi.org/project/WebOb/#history

- [Tags in Github gives us](https://github.com/Pylons/webob/tags):

```
[1.8.10](https://github.com/Pylons/webob/releases/tag/1.8.10)
Merge commit from fork

Fix open redirect issue due to changes made in cPython >=3.10
 on Jun 2 [ b240857]


[1.8.9](https://github.com/Pylons/webob/releases/tag/1.8.9)
Add info for 1.8.9 fix for Python 3.13
```

1.8.10, released in june,  fixes: https://github.com/closeio/sync-engine/security/dependabot/130


